### PR TITLE
Feature/43/add react testing library and refactor .skipped tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "postinstall": "if [ \"$ON_HEROKU\" ]; then npm install -g serve; fi"
   },
   "devDependencies": {
+    "@testing-library/react": "^9.1.4",
     "enzyme": "^3.3.0",
     "enzyme-to-json": "^3.3.4",
     "prettier": "^1.16.4",

--- a/src/components/OrgFile/OrgFile.test.js
+++ b/src/components/OrgFile/OrgFile.test.js
@@ -21,6 +21,7 @@ import { Map, fromJS } from 'immutable';
 import toJSON from 'enzyme-to-json';
 
 import readFixture from '../../../test_helpers/index';
+import { render, fireEvent } from '@testing-library/react';
 /**
  * This is a convenience wrapper around paring an org file using
  * `parseOrg` and then export it using `exportOrg`.
@@ -158,8 +159,23 @@ Some description content
     );
   });
 
-  test.skip('<OrgFile /> renders an org file', () => {
-    expect(toJSON(component)).toMatchSnapshot();
+  test('<OrgFile /> renders an org file', () => {
+    const { container, getByText, debug } = render(
+      <MemoryRouter keyLength={0}>
+        <Provider store={store}>
+          <OrgFile path="/some/test/file" />
+        </Provider>
+      </MemoryRouter>
+    );
+
+    expect(container).toMatchSnapshot();
+
+    const title = getByText('Top level header');
+    expect(title).toMatchInlineSnapshot(`
+<span>
+  Top level header
+</span>
+`);
   });
 
   test.skip('Can select a header in an org file', () => {

--- a/src/components/OrgFile/OrgFile.test.js
+++ b/src/components/OrgFile/OrgFile.test.js
@@ -21,7 +21,7 @@ import { Map, fromJS } from 'immutable';
 import toJSON from 'enzyme-to-json';
 
 import readFixture from '../../../test_helpers/index';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, cleanup } from '@testing-library/react';
 /**
  * This is a convenience wrapper around paring an org file using
  * `parseOrg` and then export it using `exportOrg`.
@@ -34,6 +34,8 @@ function parseAndExportOrgFile(testOrgFile) {
   const exportedFile = exportOrg(headers, todoKeywordSets);
   return exportedFile;
 }
+
+afterEach(cleanup);
 
 describe('Unit Tests for org file', () => {
   describe('Parsing', () => {
@@ -160,7 +162,7 @@ Some description content
   });
 
   test('<OrgFile /> renders an org file', () => {
-    const { container, getByText, debug } = render(
+    const { container, getAllByText, getByText } = render(
       <MemoryRouter keyLength={0}>
         <Provider store={store}>
           <OrgFile path="/some/test/file" />
@@ -170,11 +172,253 @@ Some description content
 
     expect(container).toMatchSnapshot();
 
-    const title = getByText('Top level header');
-    expect(title).toMatchInlineSnapshot(`
+    // 1) It is possible to query on container like on real dom node
+    const firstItem = container.querySelector('.title-line');
+    expect(firstItem).toMatchInlineSnapshot(`
+<div
+  class="title-line"
+  style="width: 0px;"
+>
+  
+  <div>
+    <span
+      style="word-break: break-word;"
+    >
+      <span>
+        Top level header
+      </span>
+      ...
+    </span>
+  </div>
+</div>
+`);
+    // but considered bad practice, because it often tests implementation details.
+    // Better to use one of the provided getBy... or queryBy... functions the render
+    // function returns, e.g. getAllByText:
+    const titles = getAllByText(/top level header/i);
+    expect(titles.length).toBe(2);
+
+    expect(titles[0]).toMatchInlineSnapshot(`
 <span>
   Top level header
 </span>
+`);
+
+    expect(titles[0].parentElement.parentElement).toMatchInlineSnapshot(`
+<div>
+  <span
+    style="word-break: break-word;"
+  >
+    <span>
+      Top level header
+    </span>
+    ...
+  </span>
+</div>
+`);
+    expect(titles[0].parentElement.parentElement.parentElement).toEqual(firstItem);
+
+    expect(firstItem.parentElement).toMatchInlineSnapshot(`
+<div
+  class="header"
+  style="padding-left: 20px; margin-left: 0px;"
+>
+  <div
+    class="left-swipe-action-container"
+    style="width: 0px; background-color: rgb(211, 211, 211);"
+  >
+    <i
+      class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
+      style="display: none;"
+    />
+  </div>
+  <div
+    class="right-swipe-action-container"
+    style="width: 0px; background-color: rgb(211, 211, 211);"
+  >
+    <i
+      class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
+      style="display: none;"
+    />
+  </div>
+  <div
+    class="header__bullet"
+    style="margin-left: -16px;"
+  >
+    *
+  </div>
+  <div
+    class="title-line"
+    style="width: 0px;"
+  >
+    
+    <div>
+      <span
+        style="word-break: break-word;"
+      >
+        <span>
+          Top level header
+        </span>
+        ...
+      </span>
+    </div>
+  </div>
+  <div />
+</div>
+`);
+
+    // Because it is the real dom we can fire real events
+    fireEvent.click(titles[0]);
+
+    // that change the real dom:
+    expect(firstItem.parentElement).toMatchInlineSnapshot(`
+<div
+  class="header header--selected"
+  style="padding-left: 20px; margin-left: 0px;"
+>
+  <div
+    class="left-swipe-action-container"
+    style="width: 0px; background-color: rgb(211, 211, 211);"
+  >
+    <i
+      class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
+      style="display: none;"
+    />
+  </div>
+  <div
+    class="right-swipe-action-container"
+    style="width: 0px; background-color: rgb(211, 211, 211);"
+  >
+    <i
+      class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
+      style="display: none;"
+    />
+  </div>
+  <div
+    class="header__bullet"
+    style="margin-left: -16px;"
+  >
+    *
+  </div>
+  <div
+    class="title-line"
+    style="width: 0px;"
+  >
+    
+    <div>
+      <span
+        style="word-break: break-word;"
+      >
+        <span>
+          Top level header
+        </span>
+        
+      </span>
+    </div>
+  </div>
+  <div
+    class="ReactCollapse--collapse"
+    style="overflow: hidden; height: 0px; margin-right: 0px;"
+  >
+    <div
+      class="ReactCollapse--content"
+    >
+      <div
+        class="header-action-drawer-container"
+      >
+        <div
+          class="header-action-drawer__row"
+        >
+          <div
+            class="header-action-drawer__ff-click-catcher-container"
+          >
+            <div
+              class="header-action-drawer__ff-click-catcher"
+            />
+            <i
+              class="fas fa-pencil-alt fa-lg"
+            />
+          </div>
+          <span
+            class="header-action-drawer__separator"
+          />
+          <div
+            class="header-action-drawer__ff-click-catcher-container"
+          >
+            <div
+              class="header-action-drawer__ff-click-catcher"
+            />
+            <i
+              class="fas fa-edit fa-lg"
+            />
+          </div>
+          <span
+            class="header-action-drawer__separator"
+          />
+          <div
+            class="header-action-drawer__ff-click-catcher-container"
+          >
+            <div
+              class="header-action-drawer__ff-click-catcher"
+            />
+            <i
+              class="fas fa-tags fa-lg"
+            />
+          </div>
+          <span
+            class="header-action-drawer__separator"
+          />
+          <div
+            class="header-action-drawer__ff-click-catcher-container"
+          >
+            <div
+              class="header-action-drawer__ff-click-catcher"
+            />
+            <i
+              class="fas fa-compress fa-lg"
+            />
+          </div>
+          <span
+            class="header-action-drawer__separator"
+          />
+          <div
+            class="header-action-drawer__ff-click-catcher-container"
+          >
+            <div
+              class="header-action-drawer__ff-click-catcher"
+            />
+            <i
+              class="fas fa-plus fa-lg"
+            />
+          </div>
+        </div>
+        <div
+          class="header-action-drawer__row"
+        >
+          <div
+            class="header-action-drawer__deadline-scheduled-button"
+          >
+            Deadline
+          </div>
+          <span
+            class="header-action-drawer__separator"
+          />
+          <div
+            class="header-action-drawer__deadline-scheduled-button"
+          >
+            Scheduled
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="header-content-container nice-scroll"
+    style="width: 0px;"
+  >
+    <span />
+  </div>
+</div>
 `);
   });
 

--- a/src/components/OrgFile/__snapshots__/OrgFile.test.js.snap
+++ b/src/components/OrgFile/__snapshots__/OrgFile.test.js.snap
@@ -1,3535 +1,291 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Rendering an org file <OrgFile /> renders an org file 1`] = `
-<MemoryRouter
-  keyLength={0}
->
-  <Router
-    history={
-      Object {
-        "action": "POP",
-        "block": [Function],
-        "canGo": [Function],
-        "createHref": [Function],
-        "entries": Array [
-          Object {
-            "hash": "",
-            "pathname": "/",
-            "search": "",
-            "state": undefined,
-          },
-        ],
-        "go": [Function],
-        "goBack": [Function],
-        "goForward": [Function],
-        "index": 0,
-        "length": 1,
-        "listen": [Function],
-        "location": Object {
-          "hash": "",
-          "pathname": "/",
-          "search": "",
-          "state": undefined,
-        },
-        "push": [Function],
-        "replace": [Function],
-      }
-    }
+<div>
+  <div
+    tabindex="-1"
   >
-    <Provider
-      store={
-        Object {
-          "dispatch": [Function],
-          "getState": [Function],
-          "replaceReducer": [Function],
-          "subscribe": [Function],
-          Symbol(observable): [Function],
-        }
-      }
+    <div
+      class="org-file-container"
+      tabindex="-1"
     >
-      <Connect(OrgFile)
-        path="/some/test/file"
+      <div
+        class="header-list-container"
       >
-        <OrgFile
-          activePopupData={null}
-          activePopupType={null}
-          base={
-            Object {
-              "activatePopup": [Function],
-              "clearModalStack": [Function],
-              "closePopup": [Function],
-              "hideLoadingMessage": [Function],
-              "loadStaticFile": [Function],
-              "popModalPage": [Function],
-              "pushModalPage": [Function],
-              "restoreBaseSettings": [Function],
-              "setAgendaDefaultDeadlineDelayUnit": [Function],
-              "setAgendaDefaultDeadlineDelayValue": [Function],
-              "setBulletStyle": [Function],
-              "setCustomKeybinding": [Function],
-              "setDisappearingLoadingMessage": [Function],
-              "setFontSize": [Function],
-              "setHasUnseenChangelog": [Function],
-              "setIsLoading": [Function],
-              "setLastSeenChangelogHeader": [Function],
-              "setLastViewedFile": [Function],
-              "setLoadingMessage": [Function],
-              "setShouldLiveSync": [Function],
-              "setShouldStoreSettingsInSyncBackend": [Function],
-              "setShouldTapTodoToAdvance": [Function],
-              "unloadStaticFile": [Function],
-            }
-          }
-          capture={
-            Object {
-              "addNewEmptyCaptureTemplate": [Function],
-              "addNewTemplateHeaderPath": [Function],
-              "addNewTemplateOrgFileAvailability": [Function],
-              "deleteTemplate": [Function],
-              "removeTemplateHeaderPath": [Function],
-              "removeTemplateOrgFileAvailability": [Function],
-              "reorderCaptureTemplate": [Function],
-              "restoreCaptureSettings": [Function],
-              "updateTemplateFieldPathValue": [Function],
-            }
-          }
-          captureTemplates={
-            Array [
-              Immutable.List [
-                Immutable.Map {
-                  "headerPaths": Immutable.List [
-                    "Capture",
-                    "Groceries",
-                  ],
-                  "iconName": "lemon",
-                  "letter": "",
-                  "isAvailableInAllOrgFiles": false,
-                  "isSample": true,
-                  "orgFilesWhereAvailable": Immutable.List [],
-                  "template": "* TODO %?",
-                  "id": 1,
-                  "shouldPrepend": false,
-                  "description": "Groceries",
-                },
-                Immutable.Map {
-                  "headerPaths": Immutable.List [
-                    "Capture",
-                    "Deeply",
-                    "Nested",
-                    "Headers",
-                    "Work",
-                    "Too!",
-                  ],
-                  "iconName": "fighter-jet",
-                  "letter": "",
-                  "isAvailableInAllOrgFiles": false,
-                  "isSample": true,
-                  "orgFilesWhereAvailable": Immutable.List [],
-                  "template": "* You can insert timestamps too! %T %?",
-                  "id": 2,
-                  "shouldPrepend": true,
-                  "description": "Deeply nested header",
-                },
-              ],
-            ]
-          }
-          customKeybindings={Immutable.Map {}}
-          headers={
-            Immutable.List [
-              Immutable.Map {
-                "titleLine": Immutable.Map {
-                  "title": Immutable.List [
-                    Immutable.Map {
-                      "type": "text",
-                      "contents": "Top level header",
-                    },
-                  ],
-                  "rawTitle": "Top level header",
-                  "todoKeyword": undefined,
-                  "tags": Immutable.List [],
-                },
-                "rawDescription": "",
-                "description": Immutable.List [],
-                "opened": false,
-                "id": 19,
-                "nestingLevel": 1,
-                "planningItems": Immutable.List [],
-                "propertyListItems": Immutable.List [],
-              },
-              Immutable.Map {
-                "titleLine": Immutable.Map {
-                  "title": Immutable.List [
-                    Immutable.Map {
-                      "type": "text",
-                      "contents": "A nested header",
-                    },
-                  ],
-                  "rawTitle": "A nested header",
-                  "todoKeyword": undefined,
-                  "tags": Immutable.List [],
-                },
-                "rawDescription": "",
-                "description": Immutable.List [],
-                "opened": false,
-                "id": 20,
-                "nestingLevel": 2,
-                "planningItems": Immutable.List [],
-                "propertyListItems": Immutable.List [],
-              },
-              Immutable.Map {
-                "titleLine": Immutable.Map {
-                  "title": Immutable.List [
-                    Immutable.Map {
-                      "type": "text",
-                      "contents": "A todo item",
-                    },
-                  ],
-                  "rawTitle": "A todo item",
-                  "todoKeyword": "TODO",
-                  "tags": Immutable.List [],
-                },
-                "rawDescription": "",
-                "description": Immutable.List [],
-                "opened": false,
-                "id": 21,
-                "nestingLevel": 2,
-                "planningItems": Immutable.List [],
-                "propertyListItems": Immutable.List [],
-              },
-              Immutable.Map {
-                "titleLine": Immutable.Map {
-                  "title": Immutable.List [
-                    Immutable.Map {
-                      "type": "text",
-                      "contents": "A finished todo item",
-                    },
-                  ],
-                  "rawTitle": "A finished todo item",
-                  "todoKeyword": "DONE",
-                  "tags": Immutable.List [],
-                },
-                "rawDescription": "",
-                "description": Immutable.List [],
-                "opened": false,
-                "id": 22,
-                "nestingLevel": 2,
-                "planningItems": Immutable.List [],
-                "propertyListItems": Immutable.List [],
-              },
-              Immutable.Map {
-                "titleLine": Immutable.Map {
-                  "title": Immutable.List [
-                    Immutable.Map {
-                      "type": "text",
-                      "contents": "Another top level header",
-                    },
-                  ],
-                  "rawTitle": "Another top level header",
-                  "todoKeyword": undefined,
-                  "tags": Immutable.List [],
-                },
-                "rawDescription": "Some description content",
-                "description": Immutable.List [
-                  Immutable.Map {
-                    "type": "text",
-                    "contents": "Some description content",
-                  },
-                ],
-                "opened": false,
-                "id": 23,
-                "nestingLevel": 1,
-                "planningItems": Immutable.List [],
-                "propertyListItems": Immutable.List [],
-              },
-              Immutable.Map {
-                "titleLine": Immutable.Map {
-                  "title": Immutable.List [
-                    Immutable.Map {
-                      "type": "text",
-                      "contents": "A header with tags                                              ",
-                    },
-                  ],
-                  "rawTitle": "A header with tags                                              ",
-                  "todoKeyword": undefined,
-                  "tags": Immutable.List [
-                    "tag1",
-                    "tag2",
-                  ],
-                },
-                "rawDescription": "",
-                "description": Immutable.List [],
-                "opened": false,
-                "id": 24,
-                "nestingLevel": 1,
-                "planningItems": Immutable.List [],
-                "propertyListItems": Immutable.List [],
-              },
-              Immutable.Map {
-                "titleLine": Immutable.Map {
-                  "title": Immutable.List [
-                    Immutable.Map {
-                      "type": "text",
-                      "contents": "A header with ",
-                    },
-                    Immutable.Map {
-                      "id": 25,
-                      "type": "link",
-                      "contents": Immutable.Map {
-                        "uri": "https://google.com",
-                        "title": "a link",
-                      },
-                    },
-                  ],
-                  "rawTitle": "A header with [[https://google.com][a link]]",
-                  "todoKeyword": undefined,
-                  "tags": Immutable.List [],
-                },
-                "rawDescription": "",
-                "description": Immutable.List [],
-                "opened": false,
-                "id": 26,
-                "nestingLevel": 1,
-                "planningItems": Immutable.List [],
-                "propertyListItems": Immutable.List [],
-              },
-            ]
-          }
-          inEditMode={false}
-          loadedPath="/some/test/file"
-          org={
-            Object {
-              "addHeader": [Function],
-              "addHeaderAndEdit": [Function],
-              "addNewPlanningItem": [Function],
-              "addNewTableColumn": [Function],
-              "addNewTableRow": [Function],
-              "advanceCheckboxState": [Function],
-              "advanceTodoState": [Function],
-              "applyOpennessState": [Function],
-              "clearPendingCapture": [Function],
-              "displayFile": [Function],
-              "enterEditMode": [Function],
-              "exitEditMode": [Function],
-              "focusHeader": [Function],
-              "insertCapture": [Function],
-              "insertPendingCapture": [Function],
-              "moveHeaderDown": [Function],
-              "moveHeaderLeft": [Function],
-              "moveHeaderRight": [Function],
-              "moveHeaderUp": [Function],
-              "moveSubtreeLeft": [Function],
-              "moveSubtreeRight": [Function],
-              "moveTableColumnLeft": [Function],
-              "moveTableColumnRight": [Function],
-              "moveTableRowDown": [Function],
-              "moveTableRowUp": [Function],
-              "noOp": [Function],
-              "openHeader": [Function],
-              "removeHeader": [Function],
-              "removeTableColumn": [Function],
-              "removeTableRow": [Function],
-              "reorderPropertyList": [Function],
-              "reorderTags": [Function],
-              "selectHeader": [Function],
-              "selectHeaderAndOpenParents": [Function],
-              "selectNextSiblingHeader": [Function],
-              "selectNextVisibleHeader": [Function],
-              "selectPreviousVisibleHeader": [Function],
-              "setDirty": [Function],
-              "setHeaderTags": [Function],
-              "setLastSyncAt": [Function],
-              "setOrgFileErrorMessage": [Function],
-              "setSelectedTableCellId": [Function],
-              "stopDisplayingFile": [Function],
-              "sync": [Function],
-              "toggleHeaderOpened": [Function],
-              "unfocusHeader": [Function],
-              "updateHeaderDescription": [Function],
-              "updateHeaderTitle": [Function],
-              "updatePlanningItemTimestamp": [Function],
-              "updatePropertyListItems": [Function],
-              "updateTableCellValue": [Function],
-              "updateTimestampWithId": [Function],
-            }
-          }
-          path="/some/test/file"
-          syncBackend={
-            Object {
-              "downloadFile": [Function],
-              "getDirectoryListing": [Function],
-              "loadMoreDirectoryListing": [Function],
-              "pushBackup": [Function],
-              "setCurrentFileBrowserDirectoryListing": [Function],
-              "setIsLoadingMoreDirectoryListing": [Function],
-              "signOut": [Function],
-            }
-          }
-          undo={
-            Object {
-              "clearHistory": [Function],
-              "jump": [Function],
-              "jumpToFuture": [Function],
-              "jumpToPast": [Function],
-              "redo": [Function],
-              "undo": [Function],
-            }
-          }
+        <div
+          class="header"
+          style="padding-left: 20px; margin-left: 0px;"
         >
-          <HotKeys
-            handlers={
-              Object {
-                "addHeader": [Function],
-                "advanceTodo": [Function],
-                "editDescription": [Function],
-                "editTitle": [Function],
-                "exitEditMode": [Function],
-                "moveHeaderDown": [Function],
-                "moveHeaderLeft": [Function],
-                "moveHeaderRight": [Function],
-                "moveHeaderUp": [Function],
-                "removeHeader": [Function],
-                "selectNextVisibleHeader": [Function],
-                "selectPreviousVisibleHeader": [Function],
-                "toggleHeaderOpened": [Function],
-                "undo": [Function],
-              }
-            }
-            keyMap={
-              Object {
-                "addHeader": "ctrl+enter",
-                "advanceTodo": "ctrl+t",
-                "editDescription": "ctrl+d",
-                "editTitle": "ctrl+h",
-                "exitEditMode": "command+enter",
-                "moveHeaderDown": "ctrl+command+n",
-                "moveHeaderLeft": "ctrl+command+b",
-                "moveHeaderRight": "ctrl+command+f",
-                "moveHeaderUp": "ctrl+command+p",
-                "removeHeader": "backspace",
-                "selectNextVisibleHeader": "ctrl+n",
-                "selectPreviousVisibleHeader": "ctrl+p",
-                "toggleHeaderOpened": "tab",
-                "undo": "ctrl+shift+-",
-              }
-            }
+          <div
+            class="left-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
           >
-            <FocusTrap
-              component="div"
-              onBlur={[Function]}
-              onFocus={[Function]}
-            >
-              <div
-                onBlur={[Function]}
-                onFocus={[Function]}
-                tabIndex="-1"
+            <i
+              class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="right-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="header__bullet"
+            style="margin-left: -16px;"
+          >
+            *
+          </div>
+          <div
+            class="title-line"
+            style="width: 0px;"
+          >
+            
+            <div>
+              <span
+                style="word-break: break-word;"
               >
+                <span>
+                  Top level header
+                </span>
+                ...
+              </span>
+            </div>
+          </div>
+          <div />
+        </div>
+        <div
+          class="header"
+          style="padding-left: 20px; margin-left: 0px;"
+        >
+          <div
+            class="left-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="right-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="header__bullet"
+            style="margin-left: -16px;"
+          >
+            *
+          </div>
+          <div
+            class="title-line"
+            style="width: 0px;"
+          >
+            
+            <div>
+              <span
+                style="word-break: break-word;"
+              >
+                <span>
+                  Another top level header
+                </span>
+                ...
+              </span>
+            </div>
+          </div>
+          <div />
+        </div>
+        <div
+          class="header"
+          style="padding-left: 20px; margin-left: 0px;"
+        >
+          <div
+            class="left-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="right-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="header__bullet"
+            style="margin-left: -16px;"
+          >
+            *
+          </div>
+          <div
+            class="title-line"
+            style="width: 0px;"
+          >
+            
+            <div>
+              <span
+                style="word-break: break-word;"
+              >
+                <span>
+                  A header with tags                                              
+                </span>
+                
+              </span>
+              <div>
                 <div
-                  className="org-file-container"
-                  tabIndex="-1"
+                  class="header-tag"
                 >
-                  <Connect(HeaderList)>
-                    <HeaderList
-                      headers={
-                        Immutable.List [
-                          Immutable.Map {
-                            "titleLine": Immutable.Map {
-                              "title": Immutable.List [
-                                Immutable.Map {
-                                  "type": "text",
-                                  "contents": "Top level header",
-                                },
-                              ],
-                              "rawTitle": "Top level header",
-                              "todoKeyword": undefined,
-                              "tags": Immutable.List [],
-                            },
-                            "rawDescription": "",
-                            "description": Immutable.List [],
-                            "opened": false,
-                            "id": 19,
-                            "nestingLevel": 1,
-                            "planningItems": Immutable.List [],
-                            "propertyListItems": Immutable.List [],
-                          },
-                          Immutable.Map {
-                            "titleLine": Immutable.Map {
-                              "title": Immutable.List [
-                                Immutable.Map {
-                                  "type": "text",
-                                  "contents": "A nested header",
-                                },
-                              ],
-                              "rawTitle": "A nested header",
-                              "todoKeyword": undefined,
-                              "tags": Immutable.List [],
-                            },
-                            "rawDescription": "",
-                            "description": Immutable.List [],
-                            "opened": false,
-                            "id": 20,
-                            "nestingLevel": 2,
-                            "planningItems": Immutable.List [],
-                            "propertyListItems": Immutable.List [],
-                          },
-                          Immutable.Map {
-                            "titleLine": Immutable.Map {
-                              "title": Immutable.List [
-                                Immutable.Map {
-                                  "type": "text",
-                                  "contents": "A todo item",
-                                },
-                              ],
-                              "rawTitle": "A todo item",
-                              "todoKeyword": "TODO",
-                              "tags": Immutable.List [],
-                            },
-                            "rawDescription": "",
-                            "description": Immutable.List [],
-                            "opened": false,
-                            "id": 21,
-                            "nestingLevel": 2,
-                            "planningItems": Immutable.List [],
-                            "propertyListItems": Immutable.List [],
-                          },
-                          Immutable.Map {
-                            "titleLine": Immutable.Map {
-                              "title": Immutable.List [
-                                Immutable.Map {
-                                  "type": "text",
-                                  "contents": "A finished todo item",
-                                },
-                              ],
-                              "rawTitle": "A finished todo item",
-                              "todoKeyword": "DONE",
-                              "tags": Immutable.List [],
-                            },
-                            "rawDescription": "",
-                            "description": Immutable.List [],
-                            "opened": false,
-                            "id": 22,
-                            "nestingLevel": 2,
-                            "planningItems": Immutable.List [],
-                            "propertyListItems": Immutable.List [],
-                          },
-                          Immutable.Map {
-                            "titleLine": Immutable.Map {
-                              "title": Immutable.List [
-                                Immutable.Map {
-                                  "type": "text",
-                                  "contents": "Another top level header",
-                                },
-                              ],
-                              "rawTitle": "Another top level header",
-                              "todoKeyword": undefined,
-                              "tags": Immutable.List [],
-                            },
-                            "rawDescription": "Some description content",
-                            "description": Immutable.List [
-                              Immutable.Map {
-                                "type": "text",
-                                "contents": "Some description content",
-                              },
-                            ],
-                            "opened": false,
-                            "id": 23,
-                            "nestingLevel": 1,
-                            "planningItems": Immutable.List [],
-                            "propertyListItems": Immutable.List [],
-                          },
-                          Immutable.Map {
-                            "titleLine": Immutable.Map {
-                              "title": Immutable.List [
-                                Immutable.Map {
-                                  "type": "text",
-                                  "contents": "A header with tags                                              ",
-                                },
-                              ],
-                              "rawTitle": "A header with tags                                              ",
-                              "todoKeyword": undefined,
-                              "tags": Immutable.List [
-                                "tag1",
-                                "tag2",
-                              ],
-                            },
-                            "rawDescription": "",
-                            "description": Immutable.List [],
-                            "opened": false,
-                            "id": 24,
-                            "nestingLevel": 1,
-                            "planningItems": Immutable.List [],
-                            "propertyListItems": Immutable.List [],
-                          },
-                          Immutable.Map {
-                            "titleLine": Immutable.Map {
-                              "title": Immutable.List [
-                                Immutable.Map {
-                                  "type": "text",
-                                  "contents": "A header with ",
-                                },
-                                Immutable.Map {
-                                  "id": 25,
-                                  "type": "link",
-                                  "contents": Immutable.Map {
-                                    "uri": "https://google.com",
-                                    "title": "a link",
-                                  },
-                                },
-                              ],
-                              "rawTitle": "A header with [[https://google.com][a link]]",
-                              "todoKeyword": undefined,
-                              "tags": Immutable.List [],
-                            },
-                            "rawDescription": "",
-                            "description": Immutable.List [],
-                            "opened": false,
-                            "id": 26,
-                            "nestingLevel": 1,
-                            "planningItems": Immutable.List [],
-                            "propertyListItems": Immutable.List [],
-                          },
-                        ]
-                      }
-                    >
-                      <div
-                        className="header-list-container"
-                      >
-                        <Connect(Header)
-                          color="rgba(38, 143, 214, 1)"
-                          hasContent={true}
-                          header={
-                            Immutable.Map {
-                              "titleLine": Immutable.Map {
-                                "title": Immutable.List [
-                                  Immutable.Map {
-                                    "type": "text",
-                                    "contents": "Top level header",
-                                  },
-                                ],
-                                "rawTitle": "Top level header",
-                                "todoKeyword": undefined,
-                                "tags": Immutable.List [],
-                              },
-                              "rawDescription": "",
-                              "description": Immutable.List [],
-                              "opened": false,
-                              "id": 19,
-                              "nestingLevel": 1,
-                              "planningItems": Immutable.List [],
-                              "propertyListItems": Immutable.List [],
-                            }
-                          }
-                          isSelected={false}
-                          key="19"
-                          onRef={[Function]}
-                        >
-                          <Header
-                            base={
-                              Object {
-                                "activatePopup": [Function],
-                                "clearModalStack": [Function],
-                                "closePopup": [Function],
-                                "hideLoadingMessage": [Function],
-                                "loadStaticFile": [Function],
-                                "popModalPage": [Function],
-                                "pushModalPage": [Function],
-                                "restoreBaseSettings": [Function],
-                                "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                "setAgendaDefaultDeadlineDelayValue": [Function],
-                                "setBulletStyle": [Function],
-                                "setCustomKeybinding": [Function],
-                                "setDisappearingLoadingMessage": [Function],
-                                "setFontSize": [Function],
-                                "setHasUnseenChangelog": [Function],
-                                "setIsLoading": [Function],
-                                "setLastSeenChangelogHeader": [Function],
-                                "setLastViewedFile": [Function],
-                                "setLoadingMessage": [Function],
-                                "setShouldLiveSync": [Function],
-                                "setShouldStoreSettingsInSyncBackend": [Function],
-                                "setShouldTapTodoToAdvance": [Function],
-                                "unloadStaticFile": [Function],
-                              }
-                            }
-                            color="rgba(38, 143, 214, 1)"
-                            focusedHeader={null}
-                            hasContent={true}
-                            header={
-                              Immutable.Map {
-                                "titleLine": Immutable.Map {
-                                  "title": Immutable.List [
-                                    Immutable.Map {
-                                      "type": "text",
-                                      "contents": "Top level header",
-                                    },
-                                  ],
-                                  "rawTitle": "Top level header",
-                                  "todoKeyword": undefined,
-                                  "tags": Immutable.List [],
-                                },
-                                "rawDescription": "",
-                                "description": Immutable.List [],
-                                "opened": false,
-                                "id": 19,
-                                "nestingLevel": 1,
-                                "planningItems": Immutable.List [],
-                                "propertyListItems": Immutable.List [],
-                              }
-                            }
-                            inEditMode={false}
-                            isFocused={false}
-                            isSelected={false}
-                            onRef={[Function]}
-                            org={
-                              Object {
-                                "addHeader": [Function],
-                                "addHeaderAndEdit": [Function],
-                                "addNewPlanningItem": [Function],
-                                "addNewTableColumn": [Function],
-                                "addNewTableRow": [Function],
-                                "advanceCheckboxState": [Function],
-                                "advanceTodoState": [Function],
-                                "applyOpennessState": [Function],
-                                "clearPendingCapture": [Function],
-                                "displayFile": [Function],
-                                "enterEditMode": [Function],
-                                "exitEditMode": [Function],
-                                "focusHeader": [Function],
-                                "insertCapture": [Function],
-                                "insertPendingCapture": [Function],
-                                "moveHeaderDown": [Function],
-                                "moveHeaderLeft": [Function],
-                                "moveHeaderRight": [Function],
-                                "moveHeaderUp": [Function],
-                                "moveSubtreeLeft": [Function],
-                                "moveSubtreeRight": [Function],
-                                "moveTableColumnLeft": [Function],
-                                "moveTableColumnRight": [Function],
-                                "moveTableRowDown": [Function],
-                                "moveTableRowUp": [Function],
-                                "noOp": [Function],
-                                "openHeader": [Function],
-                                "removeHeader": [Function],
-                                "removeTableColumn": [Function],
-                                "removeTableRow": [Function],
-                                "reorderPropertyList": [Function],
-                                "reorderTags": [Function],
-                                "selectHeader": [Function],
-                                "selectHeaderAndOpenParents": [Function],
-                                "selectNextSiblingHeader": [Function],
-                                "selectNextVisibleHeader": [Function],
-                                "selectPreviousVisibleHeader": [Function],
-                                "setDirty": [Function],
-                                "setHeaderTags": [Function],
-                                "setLastSyncAt": [Function],
-                                "setOrgFileErrorMessage": [Function],
-                                "setSelectedTableCellId": [Function],
-                                "stopDisplayingFile": [Function],
-                                "sync": [Function],
-                                "toggleHeaderOpened": [Function],
-                                "unfocusHeader": [Function],
-                                "updateHeaderDescription": [Function],
-                                "updateHeaderTitle": [Function],
-                                "updatePlanningItemTimestamp": [Function],
-                                "updatePropertyListItems": [Function],
-                                "updateTableCellValue": [Function],
-                                "updateTimestampWithId": [Function],
-                              }
-                            }
-                          >
-                            <Motion
-                              onRest={[Function]}
-                              style={
-                                Object {
-                                  "heightFactor": 1,
-                                  "marginLeft": Object {
-                                    "damping": 26,
-                                    "precision": 0.01,
-                                    "stiffness": 300,
-                                    "val": 0,
-                                  },
-                                  "paddingLeft": 20,
-                                }
-                              }
-                            >
-                              <div
-                                className="header"
-                                onClick={[Function]}
-                                onMouseDown={[Function]}
-                                onMouseMove={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseUp={[Function]}
-                                onTouchCancel={[Function]}
-                                onTouchEnd={[Function]}
-                                onTouchMove={[Function]}
-                                onTouchStart={[Function]}
-                                style={
-                                  Object {
-                                    "marginLeft": 0,
-                                    "paddingLeft": 20,
-                                  }
-                                }
-                              >
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": 0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="left-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": 0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": -0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="right-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": -0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <div
-                                  className="header__bullet"
-                                  style={
-                                    Object {
-                                      "color": "rgba(38, 143, 214, 1)",
-                                      "marginLeft": -16,
-                                    }
-                                  }
-                                >
-                                  *
-                                </div>
-                                <Connect(TitleLine)
-                                  color="rgba(38, 143, 214, 1)"
-                                  hasContent={true}
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "Top level header",
-                                          },
-                                        ],
-                                        "rawTitle": "Top level header",
-                                        "todoKeyword": undefined,
-                                        "tags": Immutable.List [],
-                                      },
-                                      "rawDescription": "",
-                                      "description": Immutable.List [],
-                                      "opened": false,
-                                      "id": 19,
-                                      "nestingLevel": 1,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                  isSelected={false}
-                                >
-                                  <TitleLine
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    color="rgba(38, 143, 214, 1)"
-                                    hasContent={true}
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "Top level header",
-                                            },
-                                          ],
-                                          "rawTitle": "Top level header",
-                                          "todoKeyword": undefined,
-                                          "tags": Immutable.List [],
-                                        },
-                                        "rawDescription": "",
-                                        "description": Immutable.List [],
-                                        "opened": false,
-                                        "id": 19,
-                                        "nestingLevel": 1,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                  >
-                                    <div
-                                      className="title-line"
-                                      onClick={[Function]}
-                                      style={
-                                        Object {
-                                          "width": 0,
-                                        }
-                                      }
-                                    >
-                                      <div>
-                                        <span
-                                          style={
-                                            Object {
-                                              "color": "rgba(38, 143, 214, 1)",
-                                              "wordBreak": "break-word",
-                                            }
-                                          }
-                                        >
-                                          <_default
-                                            parts={
-                                              Immutable.List [
-                                                Immutable.Map {
-                                                  "type": "text",
-                                                  "contents": "Top level header",
-                                                },
-                                              ]
-                                            }
-                                            subPartDataAndHandlers={
-                                              Object {
-                                                "onTimestampClick": [Function],
-                                                "shouldDisableActions": undefined,
-                                              }
-                                            }
-                                          >
-                                            <span>
-                                              Top level header
-                                            </span>
-                                          </_default>
-                                          ...
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </TitleLine>
-                                </Connect(TitleLine)>
-                                <UnmountClosed
-                                  isOpened={false}
-                                  springConfig={
-                                    Object {
-                                      "stiffness": 300,
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "marginRight": -0,
-                                    }
-                                  }
-                                />
-                                <Connect(HeaderContent)
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "Top level header",
-                                          },
-                                        ],
-                                        "rawTitle": "Top level header",
-                                        "todoKeyword": undefined,
-                                        "tags": Immutable.List [],
-                                      },
-                                      "rawDescription": "",
-                                      "description": Immutable.List [],
-                                      "opened": false,
-                                      "id": 19,
-                                      "nestingLevel": 1,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                >
-                                  <HeaderContent
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "Top level header",
-                                            },
-                                          ],
-                                          "rawTitle": "Top level header",
-                                          "todoKeyword": undefined,
-                                          "tags": Immutable.List [],
-                                        },
-                                        "rawDescription": "",
-                                        "description": Immutable.List [],
-                                        "opened": false,
-                                        "id": 19,
-                                        "nestingLevel": 1,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    inTableEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                  >
-                                    <div />
-                                  </HeaderContent>
-                                </Connect(HeaderContent)>
-                              </div>
-                            </Motion>
-                          </Header>
-                        </Connect(Header)>
-                        <Connect(Header)
-                          color="rgba(38, 143, 214, 1)"
-                          hasContent={true}
-                          header={
-                            Immutable.Map {
-                              "titleLine": Immutable.Map {
-                                "title": Immutable.List [
-                                  Immutable.Map {
-                                    "type": "text",
-                                    "contents": "Another top level header",
-                                  },
-                                ],
-                                "rawTitle": "Another top level header",
-                                "todoKeyword": undefined,
-                                "tags": Immutable.List [],
-                              },
-                              "rawDescription": "Some description content",
-                              "description": Immutable.List [
-                                Immutable.Map {
-                                  "type": "text",
-                                  "contents": "Some description content",
-                                },
-                              ],
-                              "opened": false,
-                              "id": 23,
-                              "nestingLevel": 1,
-                              "planningItems": Immutable.List [],
-                              "propertyListItems": Immutable.List [],
-                            }
-                          }
-                          isSelected={false}
-                          key="23"
-                          onRef={[Function]}
-                        >
-                          <Header
-                            base={
-                              Object {
-                                "activatePopup": [Function],
-                                "clearModalStack": [Function],
-                                "closePopup": [Function],
-                                "hideLoadingMessage": [Function],
-                                "loadStaticFile": [Function],
-                                "popModalPage": [Function],
-                                "pushModalPage": [Function],
-                                "restoreBaseSettings": [Function],
-                                "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                "setAgendaDefaultDeadlineDelayValue": [Function],
-                                "setBulletStyle": [Function],
-                                "setCustomKeybinding": [Function],
-                                "setDisappearingLoadingMessage": [Function],
-                                "setFontSize": [Function],
-                                "setHasUnseenChangelog": [Function],
-                                "setIsLoading": [Function],
-                                "setLastSeenChangelogHeader": [Function],
-                                "setLastViewedFile": [Function],
-                                "setLoadingMessage": [Function],
-                                "setShouldLiveSync": [Function],
-                                "setShouldStoreSettingsInSyncBackend": [Function],
-                                "setShouldTapTodoToAdvance": [Function],
-                                "unloadStaticFile": [Function],
-                              }
-                            }
-                            color="rgba(38, 143, 214, 1)"
-                            focusedHeader={null}
-                            hasContent={true}
-                            header={
-                              Immutable.Map {
-                                "titleLine": Immutable.Map {
-                                  "title": Immutable.List [
-                                    Immutable.Map {
-                                      "type": "text",
-                                      "contents": "Another top level header",
-                                    },
-                                  ],
-                                  "rawTitle": "Another top level header",
-                                  "todoKeyword": undefined,
-                                  "tags": Immutable.List [],
-                                },
-                                "rawDescription": "Some description content",
-                                "description": Immutable.List [
-                                  Immutable.Map {
-                                    "type": "text",
-                                    "contents": "Some description content",
-                                  },
-                                ],
-                                "opened": false,
-                                "id": 23,
-                                "nestingLevel": 1,
-                                "planningItems": Immutable.List [],
-                                "propertyListItems": Immutable.List [],
-                              }
-                            }
-                            inEditMode={false}
-                            isFocused={false}
-                            isSelected={false}
-                            onRef={[Function]}
-                            org={
-                              Object {
-                                "addHeader": [Function],
-                                "addHeaderAndEdit": [Function],
-                                "addNewPlanningItem": [Function],
-                                "addNewTableColumn": [Function],
-                                "addNewTableRow": [Function],
-                                "advanceCheckboxState": [Function],
-                                "advanceTodoState": [Function],
-                                "applyOpennessState": [Function],
-                                "clearPendingCapture": [Function],
-                                "displayFile": [Function],
-                                "enterEditMode": [Function],
-                                "exitEditMode": [Function],
-                                "focusHeader": [Function],
-                                "insertCapture": [Function],
-                                "insertPendingCapture": [Function],
-                                "moveHeaderDown": [Function],
-                                "moveHeaderLeft": [Function],
-                                "moveHeaderRight": [Function],
-                                "moveHeaderUp": [Function],
-                                "moveSubtreeLeft": [Function],
-                                "moveSubtreeRight": [Function],
-                                "moveTableColumnLeft": [Function],
-                                "moveTableColumnRight": [Function],
-                                "moveTableRowDown": [Function],
-                                "moveTableRowUp": [Function],
-                                "noOp": [Function],
-                                "openHeader": [Function],
-                                "removeHeader": [Function],
-                                "removeTableColumn": [Function],
-                                "removeTableRow": [Function],
-                                "reorderPropertyList": [Function],
-                                "reorderTags": [Function],
-                                "selectHeader": [Function],
-                                "selectHeaderAndOpenParents": [Function],
-                                "selectNextSiblingHeader": [Function],
-                                "selectNextVisibleHeader": [Function],
-                                "selectPreviousVisibleHeader": [Function],
-                                "setDirty": [Function],
-                                "setHeaderTags": [Function],
-                                "setLastSyncAt": [Function],
-                                "setOrgFileErrorMessage": [Function],
-                                "setSelectedTableCellId": [Function],
-                                "stopDisplayingFile": [Function],
-                                "sync": [Function],
-                                "toggleHeaderOpened": [Function],
-                                "unfocusHeader": [Function],
-                                "updateHeaderDescription": [Function],
-                                "updateHeaderTitle": [Function],
-                                "updatePlanningItemTimestamp": [Function],
-                                "updatePropertyListItems": [Function],
-                                "updateTableCellValue": [Function],
-                                "updateTimestampWithId": [Function],
-                              }
-                            }
-                          >
-                            <Motion
-                              onRest={[Function]}
-                              style={
-                                Object {
-                                  "heightFactor": 1,
-                                  "marginLeft": Object {
-                                    "damping": 26,
-                                    "precision": 0.01,
-                                    "stiffness": 300,
-                                    "val": 0,
-                                  },
-                                  "paddingLeft": 20,
-                                }
-                              }
-                            >
-                              <div
-                                className="header"
-                                onClick={[Function]}
-                                onMouseDown={[Function]}
-                                onMouseMove={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseUp={[Function]}
-                                onTouchCancel={[Function]}
-                                onTouchEnd={[Function]}
-                                onTouchMove={[Function]}
-                                onTouchStart={[Function]}
-                                style={
-                                  Object {
-                                    "marginLeft": 0,
-                                    "paddingLeft": 20,
-                                  }
-                                }
-                              >
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": 0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="left-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": 0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": -0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="right-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": -0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <div
-                                  className="header__bullet"
-                                  style={
-                                    Object {
-                                      "color": "rgba(38, 143, 214, 1)",
-                                      "marginLeft": -16,
-                                    }
-                                  }
-                                >
-                                  *
-                                </div>
-                                <Connect(TitleLine)
-                                  color="rgba(38, 143, 214, 1)"
-                                  hasContent={true}
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "Another top level header",
-                                          },
-                                        ],
-                                        "rawTitle": "Another top level header",
-                                        "todoKeyword": undefined,
-                                        "tags": Immutable.List [],
-                                      },
-                                      "rawDescription": "Some description content",
-                                      "description": Immutable.List [
-                                        Immutable.Map {
-                                          "type": "text",
-                                          "contents": "Some description content",
-                                        },
-                                      ],
-                                      "opened": false,
-                                      "id": 23,
-                                      "nestingLevel": 1,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                  isSelected={false}
-                                >
-                                  <TitleLine
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    color="rgba(38, 143, 214, 1)"
-                                    hasContent={true}
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "Another top level header",
-                                            },
-                                          ],
-                                          "rawTitle": "Another top level header",
-                                          "todoKeyword": undefined,
-                                          "tags": Immutable.List [],
-                                        },
-                                        "rawDescription": "Some description content",
-                                        "description": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "Some description content",
-                                          },
-                                        ],
-                                        "opened": false,
-                                        "id": 23,
-                                        "nestingLevel": 1,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                  >
-                                    <div
-                                      className="title-line"
-                                      onClick={[Function]}
-                                      style={
-                                        Object {
-                                          "width": 0,
-                                        }
-                                      }
-                                    >
-                                      <div>
-                                        <span
-                                          style={
-                                            Object {
-                                              "color": "rgba(38, 143, 214, 1)",
-                                              "wordBreak": "break-word",
-                                            }
-                                          }
-                                        >
-                                          <_default
-                                            parts={
-                                              Immutable.List [
-                                                Immutable.Map {
-                                                  "type": "text",
-                                                  "contents": "Another top level header",
-                                                },
-                                              ]
-                                            }
-                                            subPartDataAndHandlers={
-                                              Object {
-                                                "onTimestampClick": [Function],
-                                                "shouldDisableActions": undefined,
-                                              }
-                                            }
-                                          >
-                                            <span>
-                                              Another top level header
-                                            </span>
-                                          </_default>
-                                          ...
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </TitleLine>
-                                </Connect(TitleLine)>
-                                <UnmountClosed
-                                  isOpened={false}
-                                  springConfig={
-                                    Object {
-                                      "stiffness": 300,
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "marginRight": -0,
-                                    }
-                                  }
-                                />
-                                <Connect(HeaderContent)
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "Another top level header",
-                                          },
-                                        ],
-                                        "rawTitle": "Another top level header",
-                                        "todoKeyword": undefined,
-                                        "tags": Immutable.List [],
-                                      },
-                                      "rawDescription": "Some description content",
-                                      "description": Immutable.List [
-                                        Immutable.Map {
-                                          "type": "text",
-                                          "contents": "Some description content",
-                                        },
-                                      ],
-                                      "opened": false,
-                                      "id": 23,
-                                      "nestingLevel": 1,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                >
-                                  <HeaderContent
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "Another top level header",
-                                            },
-                                          ],
-                                          "rawTitle": "Another top level header",
-                                          "todoKeyword": undefined,
-                                          "tags": Immutable.List [],
-                                        },
-                                        "rawDescription": "Some description content",
-                                        "description": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "Some description content",
-                                          },
-                                        ],
-                                        "opened": false,
-                                        "id": 23,
-                                        "nestingLevel": 1,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    inTableEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                  >
-                                    <div />
-                                  </HeaderContent>
-                                </Connect(HeaderContent)>
-                              </div>
-                            </Motion>
-                          </Header>
-                        </Connect(Header)>
-                        <Connect(Header)
-                          color="rgba(38, 143, 214, 1)"
-                          hasContent={false}
-                          header={
-                            Immutable.Map {
-                              "titleLine": Immutable.Map {
-                                "title": Immutable.List [
-                                  Immutable.Map {
-                                    "type": "text",
-                                    "contents": "A header with tags                                              ",
-                                  },
-                                ],
-                                "rawTitle": "A header with tags                                              ",
-                                "todoKeyword": undefined,
-                                "tags": Immutable.List [
-                                  "tag1",
-                                  "tag2",
-                                ],
-                              },
-                              "rawDescription": "",
-                              "description": Immutable.List [],
-                              "opened": false,
-                              "id": 24,
-                              "nestingLevel": 1,
-                              "planningItems": Immutable.List [],
-                              "propertyListItems": Immutable.List [],
-                            }
-                          }
-                          isSelected={false}
-                          key="24"
-                          onRef={[Function]}
-                        >
-                          <Header
-                            base={
-                              Object {
-                                "activatePopup": [Function],
-                                "clearModalStack": [Function],
-                                "closePopup": [Function],
-                                "hideLoadingMessage": [Function],
-                                "loadStaticFile": [Function],
-                                "popModalPage": [Function],
-                                "pushModalPage": [Function],
-                                "restoreBaseSettings": [Function],
-                                "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                "setAgendaDefaultDeadlineDelayValue": [Function],
-                                "setBulletStyle": [Function],
-                                "setCustomKeybinding": [Function],
-                                "setDisappearingLoadingMessage": [Function],
-                                "setFontSize": [Function],
-                                "setHasUnseenChangelog": [Function],
-                                "setIsLoading": [Function],
-                                "setLastSeenChangelogHeader": [Function],
-                                "setLastViewedFile": [Function],
-                                "setLoadingMessage": [Function],
-                                "setShouldLiveSync": [Function],
-                                "setShouldStoreSettingsInSyncBackend": [Function],
-                                "setShouldTapTodoToAdvance": [Function],
-                                "unloadStaticFile": [Function],
-                              }
-                            }
-                            color="rgba(38, 143, 214, 1)"
-                            focusedHeader={null}
-                            hasContent={false}
-                            header={
-                              Immutable.Map {
-                                "titleLine": Immutable.Map {
-                                  "title": Immutable.List [
-                                    Immutable.Map {
-                                      "type": "text",
-                                      "contents": "A header with tags                                              ",
-                                    },
-                                  ],
-                                  "rawTitle": "A header with tags                                              ",
-                                  "todoKeyword": undefined,
-                                  "tags": Immutable.List [
-                                    "tag1",
-                                    "tag2",
-                                  ],
-                                },
-                                "rawDescription": "",
-                                "description": Immutable.List [],
-                                "opened": false,
-                                "id": 24,
-                                "nestingLevel": 1,
-                                "planningItems": Immutable.List [],
-                                "propertyListItems": Immutable.List [],
-                              }
-                            }
-                            inEditMode={false}
-                            isFocused={false}
-                            isSelected={false}
-                            onRef={[Function]}
-                            org={
-                              Object {
-                                "addHeader": [Function],
-                                "addHeaderAndEdit": [Function],
-                                "addNewPlanningItem": [Function],
-                                "addNewTableColumn": [Function],
-                                "addNewTableRow": [Function],
-                                "advanceCheckboxState": [Function],
-                                "advanceTodoState": [Function],
-                                "applyOpennessState": [Function],
-                                "clearPendingCapture": [Function],
-                                "displayFile": [Function],
-                                "enterEditMode": [Function],
-                                "exitEditMode": [Function],
-                                "focusHeader": [Function],
-                                "insertCapture": [Function],
-                                "insertPendingCapture": [Function],
-                                "moveHeaderDown": [Function],
-                                "moveHeaderLeft": [Function],
-                                "moveHeaderRight": [Function],
-                                "moveHeaderUp": [Function],
-                                "moveSubtreeLeft": [Function],
-                                "moveSubtreeRight": [Function],
-                                "moveTableColumnLeft": [Function],
-                                "moveTableColumnRight": [Function],
-                                "moveTableRowDown": [Function],
-                                "moveTableRowUp": [Function],
-                                "noOp": [Function],
-                                "openHeader": [Function],
-                                "removeHeader": [Function],
-                                "removeTableColumn": [Function],
-                                "removeTableRow": [Function],
-                                "reorderPropertyList": [Function],
-                                "reorderTags": [Function],
-                                "selectHeader": [Function],
-                                "selectHeaderAndOpenParents": [Function],
-                                "selectNextSiblingHeader": [Function],
-                                "selectNextVisibleHeader": [Function],
-                                "selectPreviousVisibleHeader": [Function],
-                                "setDirty": [Function],
-                                "setHeaderTags": [Function],
-                                "setLastSyncAt": [Function],
-                                "setOrgFileErrorMessage": [Function],
-                                "setSelectedTableCellId": [Function],
-                                "stopDisplayingFile": [Function],
-                                "sync": [Function],
-                                "toggleHeaderOpened": [Function],
-                                "unfocusHeader": [Function],
-                                "updateHeaderDescription": [Function],
-                                "updateHeaderTitle": [Function],
-                                "updatePlanningItemTimestamp": [Function],
-                                "updatePropertyListItems": [Function],
-                                "updateTableCellValue": [Function],
-                                "updateTimestampWithId": [Function],
-                              }
-                            }
-                          >
-                            <Motion
-                              onRest={[Function]}
-                              style={
-                                Object {
-                                  "heightFactor": 1,
-                                  "marginLeft": Object {
-                                    "damping": 26,
-                                    "precision": 0.01,
-                                    "stiffness": 300,
-                                    "val": 0,
-                                  },
-                                  "paddingLeft": 20,
-                                }
-                              }
-                            >
-                              <div
-                                className="header"
-                                onClick={[Function]}
-                                onMouseDown={[Function]}
-                                onMouseMove={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseUp={[Function]}
-                                onTouchCancel={[Function]}
-                                onTouchEnd={[Function]}
-                                onTouchMove={[Function]}
-                                onTouchStart={[Function]}
-                                style={
-                                  Object {
-                                    "marginLeft": 0,
-                                    "paddingLeft": 20,
-                                  }
-                                }
-                              >
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": 0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="left-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": 0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": -0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="right-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": -0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <div
-                                  className="header__bullet"
-                                  style={
-                                    Object {
-                                      "color": "rgba(38, 143, 214, 1)",
-                                      "marginLeft": -16,
-                                    }
-                                  }
-                                >
-                                  *
-                                </div>
-                                <Connect(TitleLine)
-                                  color="rgba(38, 143, 214, 1)"
-                                  hasContent={false}
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "A header with tags                                              ",
-                                          },
-                                        ],
-                                        "rawTitle": "A header with tags                                              ",
-                                        "todoKeyword": undefined,
-                                        "tags": Immutable.List [
-                                          "tag1",
-                                          "tag2",
-                                        ],
-                                      },
-                                      "rawDescription": "",
-                                      "description": Immutable.List [],
-                                      "opened": false,
-                                      "id": 24,
-                                      "nestingLevel": 1,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                  isSelected={false}
-                                >
-                                  <TitleLine
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    color="rgba(38, 143, 214, 1)"
-                                    hasContent={false}
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "A header with tags                                              ",
-                                            },
-                                          ],
-                                          "rawTitle": "A header with tags                                              ",
-                                          "todoKeyword": undefined,
-                                          "tags": Immutable.List [
-                                            "tag1",
-                                            "tag2",
-                                          ],
-                                        },
-                                        "rawDescription": "",
-                                        "description": Immutable.List [],
-                                        "opened": false,
-                                        "id": 24,
-                                        "nestingLevel": 1,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                  >
-                                    <div
-                                      className="title-line"
-                                      onClick={[Function]}
-                                      style={
-                                        Object {
-                                          "width": 0,
-                                        }
-                                      }
-                                    >
-                                      <div>
-                                        <span
-                                          style={
-                                            Object {
-                                              "color": "rgba(38, 143, 214, 1)",
-                                              "wordBreak": "break-word",
-                                            }
-                                          }
-                                        >
-                                          <_default
-                                            parts={
-                                              Immutable.List [
-                                                Immutable.Map {
-                                                  "type": "text",
-                                                  "contents": "A header with tags                                              ",
-                                                },
-                                              ]
-                                            }
-                                            subPartDataAndHandlers={
-                                              Object {
-                                                "onTimestampClick": [Function],
-                                                "shouldDisableActions": undefined,
-                                              }
-                                            }
-                                          >
-                                            <span>
-                                              A header with tags                                              
-                                            </span>
-                                          </_default>
-                                        </span>
-                                        <div>
-                                          <div
-                                            className="header-tag"
-                                            key="tag1"
-                                          >
-                                            tag1
-                                          </div>
-                                          <div
-                                            className="header-tag"
-                                            key="tag2"
-                                          >
-                                            tag2
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </TitleLine>
-                                </Connect(TitleLine)>
-                                <UnmountClosed
-                                  isOpened={false}
-                                  springConfig={
-                                    Object {
-                                      "stiffness": 300,
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "marginRight": -0,
-                                    }
-                                  }
-                                />
-                                <Connect(HeaderContent)
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "A header with tags                                              ",
-                                          },
-                                        ],
-                                        "rawTitle": "A header with tags                                              ",
-                                        "todoKeyword": undefined,
-                                        "tags": Immutable.List [
-                                          "tag1",
-                                          "tag2",
-                                        ],
-                                      },
-                                      "rawDescription": "",
-                                      "description": Immutable.List [],
-                                      "opened": false,
-                                      "id": 24,
-                                      "nestingLevel": 1,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                >
-                                  <HeaderContent
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "A header with tags                                              ",
-                                            },
-                                          ],
-                                          "rawTitle": "A header with tags                                              ",
-                                          "todoKeyword": undefined,
-                                          "tags": Immutable.List [
-                                            "tag1",
-                                            "tag2",
-                                          ],
-                                        },
-                                        "rawDescription": "",
-                                        "description": Immutable.List [],
-                                        "opened": false,
-                                        "id": 24,
-                                        "nestingLevel": 1,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    inTableEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                  >
-                                    <div />
-                                  </HeaderContent>
-                                </Connect(HeaderContent)>
-                              </div>
-                            </Motion>
-                          </Header>
-                        </Connect(Header)>
-                        <Connect(Header)
-                          color="rgba(38, 143, 214, 1)"
-                          hasContent={false}
-                          header={
-                            Immutable.Map {
-                              "titleLine": Immutable.Map {
-                                "title": Immutable.List [
-                                  Immutable.Map {
-                                    "type": "text",
-                                    "contents": "A header with ",
-                                  },
-                                  Immutable.Map {
-                                    "id": 25,
-                                    "type": "link",
-                                    "contents": Immutable.Map {
-                                      "uri": "https://google.com",
-                                      "title": "a link",
-                                    },
-                                  },
-                                ],
-                                "rawTitle": "A header with [[https://google.com][a link]]",
-                                "todoKeyword": undefined,
-                                "tags": Immutable.List [],
-                              },
-                              "rawDescription": "",
-                              "description": Immutable.List [],
-                              "opened": false,
-                              "id": 26,
-                              "nestingLevel": 1,
-                              "planningItems": Immutable.List [],
-                              "propertyListItems": Immutable.List [],
-                            }
-                          }
-                          isSelected={false}
-                          key="26"
-                          onRef={[Function]}
-                        >
-                          <Header
-                            base={
-                              Object {
-                                "activatePopup": [Function],
-                                "clearModalStack": [Function],
-                                "closePopup": [Function],
-                                "hideLoadingMessage": [Function],
-                                "loadStaticFile": [Function],
-                                "popModalPage": [Function],
-                                "pushModalPage": [Function],
-                                "restoreBaseSettings": [Function],
-                                "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                "setAgendaDefaultDeadlineDelayValue": [Function],
-                                "setBulletStyle": [Function],
-                                "setCustomKeybinding": [Function],
-                                "setDisappearingLoadingMessage": [Function],
-                                "setFontSize": [Function],
-                                "setHasUnseenChangelog": [Function],
-                                "setIsLoading": [Function],
-                                "setLastSeenChangelogHeader": [Function],
-                                "setLastViewedFile": [Function],
-                                "setLoadingMessage": [Function],
-                                "setShouldLiveSync": [Function],
-                                "setShouldStoreSettingsInSyncBackend": [Function],
-                                "setShouldTapTodoToAdvance": [Function],
-                                "unloadStaticFile": [Function],
-                              }
-                            }
-                            color="rgba(38, 143, 214, 1)"
-                            focusedHeader={null}
-                            hasContent={false}
-                            header={
-                              Immutable.Map {
-                                "titleLine": Immutable.Map {
-                                  "title": Immutable.List [
-                                    Immutable.Map {
-                                      "type": "text",
-                                      "contents": "A header with ",
-                                    },
-                                    Immutable.Map {
-                                      "id": 25,
-                                      "type": "link",
-                                      "contents": Immutable.Map {
-                                        "uri": "https://google.com",
-                                        "title": "a link",
-                                      },
-                                    },
-                                  ],
-                                  "rawTitle": "A header with [[https://google.com][a link]]",
-                                  "todoKeyword": undefined,
-                                  "tags": Immutable.List [],
-                                },
-                                "rawDescription": "",
-                                "description": Immutable.List [],
-                                "opened": false,
-                                "id": 26,
-                                "nestingLevel": 1,
-                                "planningItems": Immutable.List [],
-                                "propertyListItems": Immutable.List [],
-                              }
-                            }
-                            inEditMode={false}
-                            isFocused={false}
-                            isSelected={false}
-                            onRef={[Function]}
-                            org={
-                              Object {
-                                "addHeader": [Function],
-                                "addHeaderAndEdit": [Function],
-                                "addNewPlanningItem": [Function],
-                                "addNewTableColumn": [Function],
-                                "addNewTableRow": [Function],
-                                "advanceCheckboxState": [Function],
-                                "advanceTodoState": [Function],
-                                "applyOpennessState": [Function],
-                                "clearPendingCapture": [Function],
-                                "displayFile": [Function],
-                                "enterEditMode": [Function],
-                                "exitEditMode": [Function],
-                                "focusHeader": [Function],
-                                "insertCapture": [Function],
-                                "insertPendingCapture": [Function],
-                                "moveHeaderDown": [Function],
-                                "moveHeaderLeft": [Function],
-                                "moveHeaderRight": [Function],
-                                "moveHeaderUp": [Function],
-                                "moveSubtreeLeft": [Function],
-                                "moveSubtreeRight": [Function],
-                                "moveTableColumnLeft": [Function],
-                                "moveTableColumnRight": [Function],
-                                "moveTableRowDown": [Function],
-                                "moveTableRowUp": [Function],
-                                "noOp": [Function],
-                                "openHeader": [Function],
-                                "removeHeader": [Function],
-                                "removeTableColumn": [Function],
-                                "removeTableRow": [Function],
-                                "reorderPropertyList": [Function],
-                                "reorderTags": [Function],
-                                "selectHeader": [Function],
-                                "selectHeaderAndOpenParents": [Function],
-                                "selectNextSiblingHeader": [Function],
-                                "selectNextVisibleHeader": [Function],
-                                "selectPreviousVisibleHeader": [Function],
-                                "setDirty": [Function],
-                                "setHeaderTags": [Function],
-                                "setLastSyncAt": [Function],
-                                "setOrgFileErrorMessage": [Function],
-                                "setSelectedTableCellId": [Function],
-                                "stopDisplayingFile": [Function],
-                                "sync": [Function],
-                                "toggleHeaderOpened": [Function],
-                                "unfocusHeader": [Function],
-                                "updateHeaderDescription": [Function],
-                                "updateHeaderTitle": [Function],
-                                "updatePlanningItemTimestamp": [Function],
-                                "updatePropertyListItems": [Function],
-                                "updateTableCellValue": [Function],
-                                "updateTimestampWithId": [Function],
-                              }
-                            }
-                          >
-                            <Motion
-                              onRest={[Function]}
-                              style={
-                                Object {
-                                  "heightFactor": 1,
-                                  "marginLeft": Object {
-                                    "damping": 26,
-                                    "precision": 0.01,
-                                    "stiffness": 300,
-                                    "val": 0,
-                                  },
-                                  "paddingLeft": 20,
-                                }
-                              }
-                            >
-                              <div
-                                className="header"
-                                onClick={[Function]}
-                                onMouseDown={[Function]}
-                                onMouseMove={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseUp={[Function]}
-                                onTouchCancel={[Function]}
-                                onTouchEnd={[Function]}
-                                onTouchMove={[Function]}
-                                onTouchStart={[Function]}
-                                style={
-                                  Object {
-                                    "marginLeft": 0,
-                                    "paddingLeft": 20,
-                                  }
-                                }
-                              >
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": 0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="left-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": 0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": -0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="right-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": -0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <div
-                                  className="header__bullet"
-                                  style={
-                                    Object {
-                                      "color": "rgba(38, 143, 214, 1)",
-                                      "marginLeft": -16,
-                                    }
-                                  }
-                                >
-                                  *
-                                </div>
-                                <Connect(TitleLine)
-                                  color="rgba(38, 143, 214, 1)"
-                                  hasContent={false}
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "A header with ",
-                                          },
-                                          Immutable.Map {
-                                            "id": 25,
-                                            "type": "link",
-                                            "contents": Immutable.Map {
-                                              "uri": "https://google.com",
-                                              "title": "a link",
-                                            },
-                                          },
-                                        ],
-                                        "rawTitle": "A header with [[https://google.com][a link]]",
-                                        "todoKeyword": undefined,
-                                        "tags": Immutable.List [],
-                                      },
-                                      "rawDescription": "",
-                                      "description": Immutable.List [],
-                                      "opened": false,
-                                      "id": 26,
-                                      "nestingLevel": 1,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                  isSelected={false}
-                                >
-                                  <TitleLine
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    color="rgba(38, 143, 214, 1)"
-                                    hasContent={false}
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "A header with ",
-                                            },
-                                            Immutable.Map {
-                                              "id": 25,
-                                              "type": "link",
-                                              "contents": Immutable.Map {
-                                                "uri": "https://google.com",
-                                                "title": "a link",
-                                              },
-                                            },
-                                          ],
-                                          "rawTitle": "A header with [[https://google.com][a link]]",
-                                          "todoKeyword": undefined,
-                                          "tags": Immutable.List [],
-                                        },
-                                        "rawDescription": "",
-                                        "description": Immutable.List [],
-                                        "opened": false,
-                                        "id": 26,
-                                        "nestingLevel": 1,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                  >
-                                    <div
-                                      className="title-line"
-                                      onClick={[Function]}
-                                      style={
-                                        Object {
-                                          "width": 0,
-                                        }
-                                      }
-                                    >
-                                      <div>
-                                        <span
-                                          style={
-                                            Object {
-                                              "color": "rgba(38, 143, 214, 1)",
-                                              "wordBreak": "break-word",
-                                            }
-                                          }
-                                        >
-                                          <_default
-                                            parts={
-                                              Immutable.List [
-                                                Immutable.Map {
-                                                  "type": "text",
-                                                  "contents": "A header with ",
-                                                },
-                                                Immutable.Map {
-                                                  "id": 25,
-                                                  "type": "link",
-                                                  "contents": Immutable.Map {
-                                                    "uri": "https://google.com",
-                                                    "title": "a link",
-                                                  },
-                                                },
-                                              ]
-                                            }
-                                            subPartDataAndHandlers={
-                                              Object {
-                                                "onTimestampClick": [Function],
-                                                "shouldDisableActions": undefined,
-                                              }
-                                            }
-                                          >
-                                            <span>
-                                              A header with 
-                                              <a
-                                                href="https://google.com"
-                                                key="25"
-                                                rel="noopener noreferrer"
-                                                target="_blank"
-                                              >
-                                                a link
-                                              </a>
-                                            </span>
-                                          </_default>
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </TitleLine>
-                                </Connect(TitleLine)>
-                                <UnmountClosed
-                                  isOpened={false}
-                                  springConfig={
-                                    Object {
-                                      "stiffness": 300,
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "marginRight": -0,
-                                    }
-                                  }
-                                />
-                                <Connect(HeaderContent)
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "A header with ",
-                                          },
-                                          Immutable.Map {
-                                            "id": 25,
-                                            "type": "link",
-                                            "contents": Immutable.Map {
-                                              "uri": "https://google.com",
-                                              "title": "a link",
-                                            },
-                                          },
-                                        ],
-                                        "rawTitle": "A header with [[https://google.com][a link]]",
-                                        "todoKeyword": undefined,
-                                        "tags": Immutable.List [],
-                                      },
-                                      "rawDescription": "",
-                                      "description": Immutable.List [],
-                                      "opened": false,
-                                      "id": 26,
-                                      "nestingLevel": 1,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                >
-                                  <HeaderContent
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "A header with ",
-                                            },
-                                            Immutable.Map {
-                                              "id": 25,
-                                              "type": "link",
-                                              "contents": Immutable.Map {
-                                                "uri": "https://google.com",
-                                                "title": "a link",
-                                              },
-                                            },
-                                          ],
-                                          "rawTitle": "A header with [[https://google.com][a link]]",
-                                          "todoKeyword": undefined,
-                                          "tags": Immutable.List [],
-                                        },
-                                        "rawDescription": "",
-                                        "description": Immutable.List [],
-                                        "opened": false,
-                                        "id": 26,
-                                        "nestingLevel": 1,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    inTableEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                  >
-                                    <div />
-                                  </HeaderContent>
-                                </Connect(HeaderContent)>
-                              </div>
-                            </Motion>
-                          </Header>
-                        </Connect(Header)>
-                      </div>
-                    </HeaderList>
-                  </Connect(HeaderList)>
-                  <Connect(ActionDrawer)>
-                    <ActionDrawer
-                      base={
-                        Object {
-                          "activatePopup": [Function],
-                          "clearModalStack": [Function],
-                          "closePopup": [Function],
-                          "hideLoadingMessage": [Function],
-                          "loadStaticFile": [Function],
-                          "popModalPage": [Function],
-                          "pushModalPage": [Function],
-                          "restoreBaseSettings": [Function],
-                          "setAgendaDefaultDeadlineDelayUnit": [Function],
-                          "setAgendaDefaultDeadlineDelayValue": [Function],
-                          "setBulletStyle": [Function],
-                          "setCustomKeybinding": [Function],
-                          "setDisappearingLoadingMessage": [Function],
-                          "setFontSize": [Function],
-                          "setHasUnseenChangelog": [Function],
-                          "setIsLoading": [Function],
-                          "setLastSeenChangelogHeader": [Function],
-                          "setLastViewedFile": [Function],
-                          "setLoadingMessage": [Function],
-                          "setShouldLiveSync": [Function],
-                          "setShouldStoreSettingsInSyncBackend": [Function],
-                          "setShouldTapTodoToAdvance": [Function],
-                          "unloadStaticFile": [Function],
-                        }
-                      }
-                      capture={
-                        Object {
-                          "addNewEmptyCaptureTemplate": [Function],
-                          "addNewTemplateHeaderPath": [Function],
-                          "addNewTemplateOrgFileAvailability": [Function],
-                          "deleteTemplate": [Function],
-                          "removeTemplateHeaderPath": [Function],
-                          "removeTemplateOrgFileAvailability": [Function],
-                          "reorderCaptureTemplate": [Function],
-                          "restoreCaptureSettings": [Function],
-                          "updateTemplateFieldPathValue": [Function],
-                        }
-                      }
-                      captureTemplates={Array []}
-                      inEditMode={false}
-                      isFocusedHeaderActive={false}
-                      org={
-                        Object {
-                          "addHeader": [Function],
-                          "addHeaderAndEdit": [Function],
-                          "addNewPlanningItem": [Function],
-                          "addNewTableColumn": [Function],
-                          "addNewTableRow": [Function],
-                          "advanceCheckboxState": [Function],
-                          "advanceTodoState": [Function],
-                          "applyOpennessState": [Function],
-                          "clearPendingCapture": [Function],
-                          "displayFile": [Function],
-                          "enterEditMode": [Function],
-                          "exitEditMode": [Function],
-                          "focusHeader": [Function],
-                          "insertCapture": [Function],
-                          "insertPendingCapture": [Function],
-                          "moveHeaderDown": [Function],
-                          "moveHeaderLeft": [Function],
-                          "moveHeaderRight": [Function],
-                          "moveHeaderUp": [Function],
-                          "moveSubtreeLeft": [Function],
-                          "moveSubtreeRight": [Function],
-                          "moveTableColumnLeft": [Function],
-                          "moveTableColumnRight": [Function],
-                          "moveTableRowDown": [Function],
-                          "moveTableRowUp": [Function],
-                          "noOp": [Function],
-                          "openHeader": [Function],
-                          "removeHeader": [Function],
-                          "removeTableColumn": [Function],
-                          "removeTableRow": [Function],
-                          "reorderPropertyList": [Function],
-                          "reorderTags": [Function],
-                          "selectHeader": [Function],
-                          "selectHeaderAndOpenParents": [Function],
-                          "selectNextSiblingHeader": [Function],
-                          "selectNextVisibleHeader": [Function],
-                          "selectPreviousVisibleHeader": [Function],
-                          "setDirty": [Function],
-                          "setHeaderTags": [Function],
-                          "setLastSyncAt": [Function],
-                          "setOrgFileErrorMessage": [Function],
-                          "setSelectedTableCellId": [Function],
-                          "stopDisplayingFile": [Function],
-                          "sync": [Function],
-                          "toggleHeaderOpened": [Function],
-                          "unfocusHeader": [Function],
-                          "updateHeaderDescription": [Function],
-                          "updateHeaderTitle": [Function],
-                          "updatePlanningItemTimestamp": [Function],
-                          "updatePropertyListItems": [Function],
-                          "updateTableCellValue": [Function],
-                          "updateTimestampWithId": [Function],
-                        }
-                      }
-                      path="/some/test/file"
-                    >
-                      <div
-                        className="action-drawer-container nice-scroll"
-                      >
-                        <ActionButton
-                          iconName="cloud"
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "opacity": 1,
-                            }
-                          }
-                          subIconName="sync-alt"
-                          tooltip="Sync changes"
-                        >
-                          <button
-                            className="btn btn--circle action-drawer__btn fas fa-lg fa-cloud action-drawer__btn--with-sub-icon"
-                            onClick={[Function]}
-                            style={
-                              Object {
-                                "opacity": 1,
-                              }
-                            }
-                            title="Sync changes"
-                          >
-                            <i
-                              className="fas fa-xs fa-sync-alt action-drawer__btn__sub-icon"
-                            />
-                          </button>
-                        </ActionButton>
-                        <Motion
-                          style={
-                            Object {
-                              "bottomRowYOffset": Object {
-                                "damping": 26,
-                                "precision": 0.01,
-                                "stiffness": 300,
-                                "val": 0,
-                              },
-                              "centerXOffset": Object {
-                                "damping": 26,
-                                "precision": 0.01,
-                                "stiffness": 300,
-                                "val": 0,
-                              },
-                              "firstColumnXOffset": Object {
-                                "damping": 26,
-                                "precision": 0.01,
-                                "stiffness": 300,
-                                "val": 0,
-                              },
-                              "secondColumnXOffset": Object {
-                                "damping": 26,
-                                "precision": 0.01,
-                                "stiffness": 300,
-                                "val": 0,
-                              },
-                              "topRowYOffset": Object {
-                                "damping": 26,
-                                "precision": 0.01,
-                                "stiffness": 300,
-                                "val": 0,
-                              },
-                            }
-                          }
-                        >
-                          <div
-                            className="action-drawer__arrow-buttons-container"
-                            style={
-                              Object {
-                                "left": 0,
-                              }
-                            }
-                          >
-                            <ActionButton
-                              additionalClassName="action-drawer__arrow-button"
-                              iconName="arrow-up"
-                              isDisabled={false}
-                              onClick={[Function]}
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "boxShadow": "none",
-                                  "opacity": 1,
-                                }
-                              }
-                              subIconName={null}
-                              tooltip="Move header up"
-                            >
-                              <button
-                                className="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-arrow-up"
-                                onClick={[Function]}
-                                style={
-                                  Object {
-                                    "bottom": 0,
-                                    "boxShadow": "none",
-                                    "opacity": 1,
-                                  }
-                                }
-                                title="Move header up"
-                              />
-                            </ActionButton>
-                            <ActionButton
-                              additionalClassName="action-drawer__arrow-button"
-                              iconName="arrow-down"
-                              isDisabled={false}
-                              onClick={[Function]}
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "boxShadow": "none",
-                                  "opacity": 1,
-                                }
-                              }
-                              subIconName={null}
-                              tooltip="Move header down"
-                            >
-                              <button
-                                className="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-arrow-down"
-                                onClick={[Function]}
-                                style={
-                                  Object {
-                                    "bottom": 0,
-                                    "boxShadow": "none",
-                                    "opacity": 1,
-                                  }
-                                }
-                                title="Move header down"
-                              />
-                            </ActionButton>
-                            <ActionButton
-                              additionalClassName="action-drawer__arrow-button"
-                              iconName="arrow-left"
-                              isDisabled={false}
-                              onClick={[Function]}
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "boxShadow": "none",
-                                  "opacity": 1,
-                                  "right": 0,
-                                }
-                              }
-                              subIconName={null}
-                              tooltip="Move header left"
-                            >
-                              <button
-                                className="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-arrow-left"
-                                onClick={[Function]}
-                                style={
-                                  Object {
-                                    "bottom": 0,
-                                    "boxShadow": "none",
-                                    "opacity": 1,
-                                    "right": 0,
-                                  }
-                                }
-                                title="Move header left"
-                              />
-                            </ActionButton>
-                            <ActionButton
-                              additionalClassName="action-drawer__arrow-button"
-                              iconName="arrow-right"
-                              isDisabled={false}
-                              onClick={[Function]}
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "boxShadow": "none",
-                                  "left": 0,
-                                  "opacity": 1,
-                                }
-                              }
-                              subIconName={null}
-                              tooltip="Move header right"
-                            >
-                              <button
-                                className="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-arrow-right"
-                                onClick={[Function]}
-                                style={
-                                  Object {
-                                    "bottom": 0,
-                                    "boxShadow": "none",
-                                    "left": 0,
-                                    "opacity": 1,
-                                  }
-                                }
-                                title="Move header right"
-                              />
-                            </ActionButton>
-                            <ActionButton
-                              additionalClassName="action-drawer__arrow-button"
-                              iconName="chevron-left"
-                              isDisabled={false}
-                              onClick={[Function]}
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "boxShadow": "none",
-                                  "opacity": 1,
-                                  "right": 0,
-                                }
-                              }
-                              tooltip="Move entire subtree left"
-                            >
-                              <button
-                                className="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-chevron-left"
-                                onClick={[Function]}
-                                style={
-                                  Object {
-                                    "bottom": 0,
-                                    "boxShadow": "none",
-                                    "opacity": 1,
-                                    "right": 0,
-                                  }
-                                }
-                                title="Move entire subtree left"
-                              />
-                            </ActionButton>
-                            <ActionButton
-                              additionalClassName="action-drawer__arrow-button"
-                              iconName="chevron-right"
-                              isDisabled={false}
-                              onClick={[Function]}
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "boxShadow": "none",
-                                  "left": 0,
-                                  "opacity": 1,
-                                }
-                              }
-                              tooltip="Move entire subtree right"
-                            >
-                              <button
-                                className="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-chevron-right"
-                                onClick={[Function]}
-                                style={
-                                  Object {
-                                    "bottom": 0,
-                                    "boxShadow": "none",
-                                    "left": 0,
-                                    "opacity": 1,
-                                  }
-                                }
-                                title="Move entire subtree right"
-                              />
-                            </ActionButton>
-                            <ActionButton
-                              additionalClassName="action-drawer__main-arrow-button"
-                              iconName="arrows-alt"
-                              isDisabled={false}
-                              onClick={[Function]}
-                              onRef={
-                                Object {
-                                  "current": <button
-                                    class="btn btn--circle action-drawer__btn action-drawer__main-arrow-button fas fa-lg fa-arrows-alt"
-                                    style="opacity: 1;"
-                                    title="Show movement buttons"
-                                  />,
-                                }
-                              }
-                              style={
-                                Object {
-                                  "opacity": 1,
-                                }
-                              }
-                              subIconName={null}
-                              tooltip="Show movement buttons"
-                            >
-                              <button
-                                className="btn btn--circle action-drawer__btn action-drawer__main-arrow-button fas fa-lg fa-arrows-alt"
-                                onClick={[Function]}
-                                style={
-                                  Object {
-                                    "opacity": 1,
-                                  }
-                                }
-                                title="Show movement buttons"
-                              />
-                            </ActionButton>
-                          </div>
-                        </Motion>
-                        <ActionButton
-                          iconName="calendar-alt"
-                          isDisabled={false}
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "opacity": 1,
-                            }
-                          }
-                          tooltip="Show agenda"
-                        >
-                          <button
-                            className="btn btn--circle action-drawer__btn fas fa-lg fa-calendar-alt"
-                            onClick={[Function]}
-                            style={
-                              Object {
-                                "opacity": 1,
-                              }
-                            }
-                            title="Show agenda"
-                          />
-                        </ActionButton>
-                        <Motion
-                          style={
-                            Object {
-                              "bottom": Object {
-                                "damping": 26,
-                                "precision": 0.01,
-                                "stiffness": 300,
-                                "val": 0,
-                              },
-                            }
-                          }
-                        >
-                          <div
-                            className="action-drawer__capture-buttons-container"
-                          >
-                            <ActionButton
-                              iconName="list-ul"
-                              isDisabled={false}
-                              onClick={[Function]}
-                              style={
-                                Object {
-                                  "opacity": 1,
-                                  "position": "relative",
-                                  "zIndex": 1,
-                                }
-                              }
-                              tooltip="Show capture templates"
-                            >
-                              <button
-                                className="btn btn--circle action-drawer__btn fas fa-lg fa-list-ul"
-                                onClick={[Function]}
-                                style={
-                                  Object {
-                                    "opacity": 1,
-                                    "position": "relative",
-                                    "zIndex": 1,
-                                  }
-                                }
-                                title="Show capture templates"
-                              />
-                            </ActionButton>
-                          </div>
-                        </Motion>
-                      </div>
-                    </ActionDrawer>
-                  </Connect(ActionDrawer)>
+                  tag1
+                </div>
+                <div
+                  class="header-tag"
+                >
+                  tag2
                 </div>
               </div>
-            </FocusTrap>
-          </HotKeys>
-        </OrgFile>
-      </Connect(OrgFile)>
-    </Provider>
-  </Router>
-</MemoryRouter>
+            </div>
+          </div>
+          <div />
+        </div>
+        <div
+          class="header"
+          style="padding-left: 20px; margin-left: 0px;"
+        >
+          <div
+            class="left-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="right-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="header__bullet"
+            style="margin-left: -16px;"
+          >
+            *
+          </div>
+          <div
+            class="title-line"
+            style="width: 0px;"
+          >
+            
+            <div>
+              <span
+                style="word-break: break-word;"
+              >
+                <span>
+                  A header with 
+                  <a
+                    href="https://google.com"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    a link
+                  </a>
+                </span>
+                
+              </span>
+            </div>
+          </div>
+          <div />
+        </div>
+      </div>
+      <div
+        class="action-drawer-container nice-scroll"
+      >
+        <button
+          class="btn btn--circle action-drawer__btn fas fa-lg fa-cloud action-drawer__btn--with-sub-icon"
+          style="opacity: 1;"
+          title="Sync changes"
+        >
+          <i
+            class="fas fa-xs fa-sync-alt action-drawer__btn__sub-icon"
+          />
+        </button>
+        <div
+          class="action-drawer__arrow-buttons-container"
+          style="left: 0px;"
+        >
+          <button
+            class="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-arrow-up"
+            style="opacity: 1; box-shadow: none; bottom: 0px;"
+            title="Move header up"
+          />
+          <button
+            class="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-arrow-down"
+            style="opacity: 1; box-shadow: none; bottom: 0px;"
+            title="Move header down"
+          />
+          <button
+            class="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-arrow-left"
+            style="opacity: 1; box-shadow: none; bottom: 0px; right: 0px;"
+            title="Move header left"
+          />
+          <button
+            class="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-arrow-right"
+            style="opacity: 1; box-shadow: none; bottom: 0px; left: 0px;"
+            title="Move header right"
+          />
+          <button
+            class="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-chevron-left"
+            style="opacity: 1; box-shadow: none; bottom: 0px; right: 0px;"
+            title="Move entire subtree left"
+          />
+          <button
+            class="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-chevron-right"
+            style="opacity: 1; box-shadow: none; bottom: 0px; left: 0px;"
+            title="Move entire subtree right"
+          />
+          <button
+            class="btn btn--circle action-drawer__btn action-drawer__main-arrow-button fas fa-lg fa-arrows-alt"
+            style="opacity: 1;"
+            title="Show movement buttons"
+          />
+        </div>
+        <button
+          class="btn btn--circle action-drawer__btn fas fa-lg fa-calendar-alt"
+          style="opacity: 1;"
+          title="Show agenda"
+        />
+        <div
+          class="action-drawer__capture-buttons-container"
+        >
+          <button
+            class="btn btn--circle action-drawer__btn fas fa-lg fa-list-ul"
+            style="opacity: 1; position: relative; z-index: 1;"
+            title="Show capture templates"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 `;
 
 exports[`Rendering an org file Can advance todo state for selected header in an org file 1`] = `
@@ -9150,6 +5906,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
               "setLoadingMessage": [Function],
               "setShouldLiveSync": [Function],
               "setShouldStoreSettingsInSyncBackend": [Function],
+              "setShouldSyncOnBecomingVisibile": [Function],
               "setShouldTapTodoToAdvance": [Function],
               "unloadStaticFile": [Function],
             }
@@ -9225,7 +5982,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                 "rawDescription": "",
                 "description": Immutable.List [],
                 "opened": true,
-                "id": 27,
+                                        "id": 27,
                 "nestingLevel": 1,
                 "planningItems": Immutable.List [],
                 "propertyListItems": Immutable.List [],
@@ -9245,7 +6002,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                 "rawDescription": "",
                 "description": Immutable.List [],
                 "opened": false,
-                "id": 28,
+                                        "id": 28,
                 "nestingLevel": 2,
                 "planningItems": Immutable.List [],
                 "propertyListItems": Immutable.List [],
@@ -9265,7 +6022,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                 "rawDescription": "",
                 "description": Immutable.List [],
                 "opened": false,
-                "id": 29,
+                                        "id": 29,
                 "nestingLevel": 2,
                 "planningItems": Immutable.List [],
                 "propertyListItems": Immutable.List [],
@@ -9285,7 +6042,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                 "rawDescription": "",
                 "description": Immutable.List [],
                 "opened": false,
-                "id": 30,
+                                        "id": 30,
                 "nestingLevel": 2,
                 "planningItems": Immutable.List [],
                 "propertyListItems": Immutable.List [],
@@ -9310,7 +6067,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                   },
                 ],
                 "opened": false,
-                "id": 31,
+                                        "id": 31,
                 "nestingLevel": 1,
                 "planningItems": Immutable.List [],
                 "propertyListItems": Immutable.List [],
@@ -9333,7 +6090,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                 "rawDescription": "",
                 "description": Immutable.List [],
                 "opened": false,
-                "id": 32,
+                "id": 8,
                 "nestingLevel": 1,
                 "planningItems": Immutable.List [],
                 "propertyListItems": Immutable.List [],
@@ -9346,7 +6103,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                       "contents": "A header with ",
                     },
                     Immutable.Map {
-                      "id": 33,
+                                              "id": 33,
                       "type": "link",
                       "contents": Immutable.Map {
                         "uri": "https://google.com",
@@ -9361,7 +6118,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                 "rawDescription": "",
                 "description": Immutable.List [],
                 "opened": false,
-                "id": 34,
+                "id": 10,
                 "nestingLevel": 1,
                 "planningItems": Immutable.List [],
                 "propertyListItems": Immutable.List [],
@@ -9543,7 +6300,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                             "rawDescription": "",
                             "description": Immutable.List [],
                             "opened": true,
-                            "id": 27,
+                                      "id": 27,
                             "nestingLevel": 1,
                             "planningItems": Immutable.List [],
                             "propertyListItems": Immutable.List [],
@@ -9563,7 +6320,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                             "rawDescription": "",
                             "description": Immutable.List [],
                             "opened": false,
-                            "id": 28,
+                                      "id": 28,
                             "nestingLevel": 2,
                             "planningItems": Immutable.List [],
                             "propertyListItems": Immutable.List [],
@@ -9583,7 +6340,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                             "rawDescription": "",
                             "description": Immutable.List [],
                             "opened": false,
-                            "id": 29,
+                                      "id": 29,
                             "nestingLevel": 2,
                             "planningItems": Immutable.List [],
                             "propertyListItems": Immutable.List [],
@@ -9603,7 +6360,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                             "rawDescription": "",
                             "description": Immutable.List [],
                             "opened": false,
-                            "id": 30,
+                                      "id": 30,
                             "nestingLevel": 2,
                             "planningItems": Immutable.List [],
                             "propertyListItems": Immutable.List [],
@@ -9628,7 +6385,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                               },
                             ],
                             "opened": false,
-                            "id": 31,
+                                      "id": 31,
                             "nestingLevel": 1,
                             "planningItems": Immutable.List [],
                             "propertyListItems": Immutable.List [],
@@ -9651,7 +6408,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                             "rawDescription": "",
                             "description": Immutable.List [],
                             "opened": false,
-                            "id": 32,
+                                        "id": 32,
                             "nestingLevel": 1,
                             "planningItems": Immutable.List [],
                             "propertyListItems": Immutable.List [],
@@ -9664,7 +6421,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                   "contents": "A header with ",
                                 },
                                 Immutable.Map {
-                                  "id": 33,
+                                            "id": 33,
                                   "type": "link",
                                   "contents": Immutable.Map {
                                     "uri": "https://google.com",
@@ -9767,7 +6524,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                 "rawDescription": "",
                                 "description": Immutable.List [],
                                 "opened": true,
-                                "id": 27,
+                                        "id": 27,
                                 "nestingLevel": 1,
                                 "planningItems": Immutable.List [],
                                 "propertyListItems": Immutable.List [],
@@ -10015,7 +6772,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                         "rawDescription": "",
                                         "description": Immutable.List [],
                                         "opened": true,
-                                        "id": 27,
+                                "id": 27,
                                         "nestingLevel": 1,
                                         "planningItems": Immutable.List [],
                                         "propertyListItems": Immutable.List [],
@@ -10320,7 +7077,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                       "rawDescription": "",
                                       "description": Immutable.List [],
                                       "opened": true,
-                                      "id": 27,
+                            "id": 27,
                                       "nestingLevel": 1,
                                       "planningItems": Immutable.List [],
                                       "propertyListItems": Immutable.List [],
@@ -10351,6 +7108,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                         "setLoadingMessage": [Function],
                                         "setShouldLiveSync": [Function],
                                         "setShouldStoreSettingsInSyncBackend": [Function],
+                                        "setShouldSyncOnBecomingVisibile": [Function],
                                         "setShouldTapTodoToAdvance": [Function],
                                         "unloadStaticFile": [Function],
                                       }
@@ -10371,7 +7129,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                         "rawDescription": "",
                                         "description": Immutable.List [],
                                         "opened": true,
-                                        "id": 27,
+                "id": 27,
                                         "nestingLevel": 1,
                                         "planningItems": Immutable.List [],
                                         "propertyListItems": Immutable.List [],
@@ -10562,7 +7320,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                 "rawDescription": "",
                                 "description": Immutable.List [],
                                 "opened": false,
-                                "id": 28,
+                                        "id": 28,
                                 "nestingLevel": 2,
                                 "planningItems": Immutable.List [],
                                 "propertyListItems": Immutable.List [],
@@ -10810,7 +7568,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                         "rawDescription": "",
                                         "description": Immutable.List [],
                                         "opened": false,
-                                        "id": 28,
+                                "id": 28,
                                         "nestingLevel": 2,
                                         "planningItems": Immutable.List [],
                                         "propertyListItems": Immutable.List [],
@@ -10948,7 +7706,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                       "rawDescription": "",
                                       "description": Immutable.List [],
                                       "opened": false,
-                                      "id": 28,
+                            "id": 28,
                                       "nestingLevel": 2,
                                       "planningItems": Immutable.List [],
                                       "propertyListItems": Immutable.List [],
@@ -10999,7 +7757,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                         "rawDescription": "",
                                         "description": Immutable.List [],
                                         "opened": false,
-                                        "id": 28,
+                "id": 28,
                                         "nestingLevel": 2,
                                         "planningItems": Immutable.List [],
                                         "propertyListItems": Immutable.List [],
@@ -11149,7 +7907,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                 "rawDescription": "",
                                 "description": Immutable.List [],
                                 "opened": false,
-                                "id": 29,
+                                        "id": 29,
                                 "nestingLevel": 2,
                                 "planningItems": Immutable.List [],
                                 "propertyListItems": Immutable.List [],
@@ -11397,7 +8155,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                         "rawDescription": "",
                                         "description": Immutable.List [],
                                         "opened": false,
-                                        "id": 29,
+                                "id": 29,
                                         "nestingLevel": 2,
                                         "planningItems": Immutable.List [],
                                         "propertyListItems": Immutable.List [],
@@ -11541,7 +8299,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                       "rawDescription": "",
                                       "description": Immutable.List [],
                                       "opened": false,
-                                      "id": 29,
+                            "id": 29,
                                       "nestingLevel": 2,
                                       "planningItems": Immutable.List [],
                                       "propertyListItems": Immutable.List [],
@@ -11592,7 +8350,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                         "rawDescription": "",
                                         "description": Immutable.List [],
                                         "opened": false,
-                                        "id": 29,
+                "id": 29,
                                         "nestingLevel": 2,
                                         "planningItems": Immutable.List [],
                                         "propertyListItems": Immutable.List [],
@@ -11742,7 +8500,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                 "rawDescription": "",
                                 "description": Immutable.List [],
                                 "opened": false,
-                                "id": 30,
+                                        "id": 30,
                                 "nestingLevel": 2,
                                 "planningItems": Immutable.List [],
                                 "propertyListItems": Immutable.List [],
@@ -11990,7 +8748,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                         "rawDescription": "",
                                         "description": Immutable.List [],
                                         "opened": false,
-                                        "id": 30,
+                                "id": 30,
                                         "nestingLevel": 2,
                                         "planningItems": Immutable.List [],
                                         "propertyListItems": Immutable.List [],
@@ -12134,7 +8892,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                       "rawDescription": "",
                                       "description": Immutable.List [],
                                       "opened": false,
-                                      "id": 30,
+                            "id": 30,
                                       "nestingLevel": 2,
                                       "planningItems": Immutable.List [],
                                       "propertyListItems": Immutable.List [],
@@ -12185,7 +8943,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                         "rawDescription": "",
                                         "description": Immutable.List [],
                                         "opened": false,
-                                        "id": 30,
+                "id": 30,
                                         "nestingLevel": 2,
                                         "planningItems": Immutable.List [],
                                         "propertyListItems": Immutable.List [],
@@ -12345,7 +9103,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                   },
                                 ],
                                 "opened": false,
-                                "id": 31,
+                                        "id": 31,
                                 "nestingLevel": 1,
                                 "planningItems": Immutable.List [],
                                 "propertyListItems": Immutable.List [],
@@ -12544,7 +9302,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                         },
                                       ],
                                       "opened": false,
-                                      "id": 31,
+                "id": 31,
                                       "nestingLevel": 1,
                                       "planningItems": Immutable.List [],
                                       "propertyListItems": Immutable.List [],
@@ -12603,7 +9361,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                           },
                                         ],
                                         "opened": false,
-                                        "id": 31,
+                                      "id": 31,
                                         "nestingLevel": 1,
                                         "planningItems": Immutable.List [],
                                         "propertyListItems": Immutable.List [],
@@ -12747,7 +9505,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                         },
                                       ],
                                       "opened": false,
-                                      "id": 31,
+                                "id": 31,
                                       "nestingLevel": 1,
                                       "planningItems": Immutable.List [],
                                       "propertyListItems": Immutable.List [],
@@ -12803,7 +9561,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                           },
                                         ],
                                         "opened": false,
-                                        "id": 31,
+                            "id": 31,
                                         "nestingLevel": 1,
                                         "planningItems": Immutable.List [],
                                         "propertyListItems": Immutable.List [],
@@ -12899,14 +9657,14 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                               "rawDescription": "",
                               "description": Immutable.List [],
                               "opened": false,
-                              "id": 32,
+                "id": 32,
                               "nestingLevel": 1,
                               "planningItems": Immutable.List [],
                               "propertyListItems": Immutable.List [],
                             }
                           }
                           isSelected={false}
-                          key="32"
+                          key="8"
                           onRef={[Function]}
                         >
                           <Header
@@ -12959,7 +9717,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                 "rawDescription": "",
                                 "description": Immutable.List [],
                                 "opened": false,
-                                "id": 32,
+                            "id": 32,
                                 "nestingLevel": 1,
                                 "planningItems": Immutable.List [],
                                 "propertyListItems": Immutable.List [],
@@ -13422,7 +10180,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                         "rawDescription": "",
                                         "description": Immutable.List [],
                                         "opened": false,
-                                        "id": 32,
+                                "id": 32,
                                         "nestingLevel": 1,
                                         "planningItems": Immutable.List [],
                                         "propertyListItems": Immutable.List [],
@@ -13508,7 +10266,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                     "contents": "A header with ",
                                   },
                                   Immutable.Map {
-                                    "id": 33,
+                      "id": 33,
                                     "type": "link",
                                     "contents": Immutable.Map {
                                       "uri": "https://google.com",
@@ -13523,14 +10281,14 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                               "rawDescription": "",
                               "description": Immutable.List [],
                               "opened": false,
-                              "id": 34,
+                "id": 34,
                               "nestingLevel": 1,
                               "planningItems": Immutable.List [],
                               "propertyListItems": Immutable.List [],
                             }
                           }
                           isSelected={false}
-                          key="34"
+                          key="10"
                           onRef={[Function]}
                         >
                           <Header
@@ -13561,7 +10319,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                 "unloadStaticFile": [Function],
                               }
                             }
-                            color="rgba(38, 143, 214, 1)"
+                            color="var(--blue)"
                             focusedHeader={null}
                             hasContent={false}
                             header={
@@ -13573,7 +10331,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                       "contents": "A header with ",
                                     },
                                     Immutable.Map {
-                                      "id": 33,
+                                  "id": 33,
                                       "type": "link",
                                       "contents": Immutable.Map {
                                         "uri": "https://google.com",
@@ -13588,7 +10346,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                 "rawDescription": "",
                                 "description": Immutable.List [],
                                 "opened": false,
-                                "id": 34,
+                                        "id": 34,
                                 "nestingLevel": 1,
                                 "planningItems": Immutable.List [],
                                 "propertyListItems": Immutable.List [],
@@ -13775,7 +10533,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                             "contents": "A header with ",
                                           },
                                           Immutable.Map {
-                                            "id": 33,
+                                                  "id": 33,
                                             "type": "link",
                                             "contents": Immutable.Map {
                                               "uri": "https://google.com",
@@ -13826,7 +10584,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                         "unloadStaticFile": [Function],
                                       }
                                     }
-                                    color="rgba(38, 143, 214, 1)"
+                                    color="var(--blue)"
                                     hasContent={false}
                                     header={
                                       Immutable.Map {
@@ -13943,7 +10701,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                                   "contents": "A header with ",
                                                 },
                                                 Immutable.Map {
-                                                  "id": 33,
+                                            "id": 33,
                                                   "type": "link",
                                                   "contents": Immutable.Map {
                                                     "uri": "https://google.com",
@@ -13999,7 +10757,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                             "contents": "A header with ",
                                           },
                                           Immutable.Map {
-                                            "id": 33,
+                                      "id": 33,
                                             "type": "link",
                                             "contents": Immutable.Map {
                                               "uri": "https://google.com",
@@ -14058,7 +10816,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                               "contents": "A header with ",
                                             },
                                             Immutable.Map {
-                                              "id": 33,
+                                    "id": 33,
                                               "type": "link",
                                               "contents": Immutable.Map {
                                                 "uri": "https://google.com",
@@ -14073,7 +10831,7 @@ exports[`Rendering an org file Can select a header in an org file 1`] = `
                                         "rawDescription": "",
                                         "description": Immutable.List [],
                                         "opened": false,
-                                        "id": 34,
+                                "id": 34,
                                         "nestingLevel": 1,
                                         "planningItems": Immutable.List [],
                                         "propertyListItems": Immutable.List [],

--- a/src/components/OrgFile/__snapshots__/OrgFile.test.js.snap
+++ b/src/components/OrgFile/__snapshots__/OrgFile.test.js.snap
@@ -289,11087 +289,1359 @@ exports[`Rendering an org file <OrgFile /> renders an org file 1`] = `
 `;
 
 exports[`Rendering an org file Can advance todo state for selected header in an org file 1`] = `
-<MemoryRouter
-  keyLength={0}
->
-  <Router
-    history={
-      Object {
-        "action": "POP",
-        "block": [Function],
-        "canGo": [Function],
-        "createHref": [Function],
-        "entries": Array [
-          Object {
-            "hash": "",
-            "pathname": "/",
-            "search": "",
-            "state": undefined,
-          },
-        ],
-        "go": [Function],
-        "goBack": [Function],
-        "goForward": [Function],
-        "index": 0,
-        "length": 1,
-        "listen": [Function],
-        "location": Object {
-          "hash": "",
-          "pathname": "/",
-          "search": "",
-          "state": undefined,
-        },
-        "push": [Function],
-        "replace": [Function],
-      }
-    }
+<div>
+  <div
+    tabindex="-1"
   >
-    <Provider
-      store={
-        Object {
-          "dispatch": [Function],
-          "getState": [Function],
-          "replaceReducer": [Function],
-          "subscribe": [Function],
-          Symbol(observable): [Function],
-        }
-      }
+    <div
+      class="org-file-container"
+      tabindex="-1"
     >
-      <Connect(OrgFile)
-        path="/some/test/file"
+      <div
+        class="header-list-container"
       >
-        <OrgFile
-          activePopupData={null}
-          activePopupType={null}
-          base={
-            Object {
-              "activatePopup": [Function],
-              "clearModalStack": [Function],
-              "closePopup": [Function],
-              "hideLoadingMessage": [Function],
-              "loadStaticFile": [Function],
-              "popModalPage": [Function],
-              "pushModalPage": [Function],
-              "restoreBaseSettings": [Function],
-              "setAgendaDefaultDeadlineDelayUnit": [Function],
-              "setAgendaDefaultDeadlineDelayValue": [Function],
-              "setBulletStyle": [Function],
-              "setCustomKeybinding": [Function],
-              "setDisappearingLoadingMessage": [Function],
-              "setFontSize": [Function],
-              "setHasUnseenChangelog": [Function],
-              "setIsLoading": [Function],
-              "setLastSeenChangelogHeader": [Function],
-              "setLastViewedFile": [Function],
-              "setLoadingMessage": [Function],
-              "setShouldLiveSync": [Function],
-              "setShouldStoreSettingsInSyncBackend": [Function],
-              "setShouldTapTodoToAdvance": [Function],
-              "unloadStaticFile": [Function],
-            }
-          }
-          capture={
-            Object {
-              "addNewEmptyCaptureTemplate": [Function],
-              "addNewTemplateHeaderPath": [Function],
-              "addNewTemplateOrgFileAvailability": [Function],
-              "deleteTemplate": [Function],
-              "removeTemplateHeaderPath": [Function],
-              "removeTemplateOrgFileAvailability": [Function],
-              "reorderCaptureTemplate": [Function],
-              "restoreCaptureSettings": [Function],
-              "updateTemplateFieldPathValue": [Function],
-            }
-          }
-          captureTemplates={
-            Array [
-              Immutable.List [
-                Immutable.Map {
-                  "headerPaths": Immutable.List [
-                    "Capture",
-                    "Groceries",
-                  ],
-                  "iconName": "lemon",
-                  "letter": "",
-                  "isAvailableInAllOrgFiles": false,
-                  "isSample": true,
-                  "orgFilesWhereAvailable": Immutable.List [],
-                  "template": "* TODO %?",
-                  "id": 1,
-                  "shouldPrepend": false,
-                  "description": "Groceries",
-                },
-                Immutable.Map {
-                  "headerPaths": Immutable.List [
-                    "Capture",
-                    "Deeply",
-                    "Nested",
-                    "Headers",
-                    "Work",
-                    "Too!",
-                  ],
-                  "iconName": "fighter-jet",
-                  "letter": "",
-                  "isAvailableInAllOrgFiles": false,
-                  "isSample": true,
-                  "orgFilesWhereAvailable": Immutable.List [],
-                  "template": "* You can insert timestamps too! %T %?",
-                  "id": 2,
-                  "shouldPrepend": true,
-                  "description": "Deeply nested header",
-                },
-              ],
-            ]
-          }
-          customKeybindings={Immutable.Map {}}
-          headers={
-            Immutable.List [
-              Immutable.Map {
-                "titleLine": Immutable.Map {
-                  "title": Immutable.List [
-                    Immutable.Map {
-                      "type": "text",
-                      "contents": "Top level header",
-                    },
-                  ],
-                  "rawTitle": "Top level header",
-                  "todoKeyword": undefined,
-                  "tags": Immutable.List [],
-                },
-                "rawDescription": "",
-                "description": Immutable.List [],
-                "opened": true,
-                "id": 35,
-                "nestingLevel": 1,
-                "planningItems": Immutable.List [],
-                "propertyListItems": Immutable.List [],
-              },
-              Immutable.Map {
-                "titleLine": Immutable.Map {
-                  "title": Immutable.List [
-                    Immutable.Map {
-                      "type": "text",
-                      "contents": "A nested header",
-                    },
-                  ],
-                  "rawTitle": "A nested header",
-                  "todoKeyword": undefined,
-                  "tags": Immutable.List [],
-                },
-                "rawDescription": "",
-                "description": Immutable.List [],
-                "opened": false,
-                "id": 36,
-                "nestingLevel": 2,
-                "planningItems": Immutable.List [],
-                "propertyListItems": Immutable.List [],
-              },
-              Immutable.Map {
-                "titleLine": Immutable.Map {
-                  "title": Immutable.List [
-                    Immutable.Map {
-                      "type": "text",
-                      "contents": "A todo item",
-                    },
-                  ],
-                  "rawTitle": "A todo item",
-                  "todoKeyword": "TODO",
-                  "tags": Immutable.List [],
-                },
-                "rawDescription": "",
-                "description": Immutable.List [],
-                "opened": false,
-                "id": 37,
-                "nestingLevel": 2,
-                "planningItems": Immutable.List [],
-                "propertyListItems": Immutable.List [],
-              },
-              Immutable.Map {
-                "titleLine": Immutable.Map {
-                  "title": Immutable.List [
-                    Immutable.Map {
-                      "type": "text",
-                      "contents": "A finished todo item",
-                    },
-                  ],
-                  "rawTitle": "A finished todo item",
-                  "todoKeyword": "DONE",
-                  "tags": Immutable.List [],
-                },
-                "rawDescription": "",
-                "description": Immutable.List [],
-                "opened": false,
-                "id": 38,
-                "nestingLevel": 2,
-                "planningItems": Immutable.List [],
-                "propertyListItems": Immutable.List [],
-              },
-              Immutable.Map {
-                "titleLine": Immutable.Map {
-                  "title": Immutable.List [
-                    Immutable.Map {
-                      "type": "text",
-                      "contents": "Another top level header",
-                    },
-                  ],
-                  "rawTitle": "Another top level header",
-                  "todoKeyword": undefined,
-                  "tags": Immutable.List [],
-                },
-                "rawDescription": "Some description content",
-                "description": Immutable.List [
-                  Immutable.Map {
-                    "type": "text",
-                    "contents": "Some description content",
-                  },
-                ],
-                "opened": false,
-                "id": 39,
-                "nestingLevel": 1,
-                "planningItems": Immutable.List [],
-                "propertyListItems": Immutable.List [],
-              },
-              Immutable.Map {
-                "titleLine": Immutable.Map {
-                  "title": Immutable.List [
-                    Immutable.Map {
-                      "type": "text",
-                      "contents": "A header with tags                                              ",
-                    },
-                  ],
-                  "rawTitle": "A header with tags                                              ",
-                  "todoKeyword": undefined,
-                  "tags": Immutable.List [
-                    "tag1",
-                    "tag2",
-                  ],
-                },
-                "rawDescription": "",
-                "description": Immutable.List [],
-                "opened": false,
-                "id": 40,
-                "nestingLevel": 1,
-                "planningItems": Immutable.List [],
-                "propertyListItems": Immutable.List [],
-              },
-              Immutable.Map {
-                "titleLine": Immutable.Map {
-                  "title": Immutable.List [
-                    Immutable.Map {
-                      "type": "text",
-                      "contents": "A header with ",
-                    },
-                    Immutable.Map {
-                      "id": 41,
-                      "type": "link",
-                      "contents": Immutable.Map {
-                        "uri": "https://google.com",
-                        "title": "a link",
-                      },
-                    },
-                  ],
-                  "rawTitle": "A header with [[https://google.com][a link]]",
-                  "todoKeyword": undefined,
-                  "tags": Immutable.List [],
-                },
-                "rawDescription": "",
-                "description": Immutable.List [],
-                "opened": false,
-                "id": 42,
-                "nestingLevel": 1,
-                "planningItems": Immutable.List [],
-                "propertyListItems": Immutable.List [],
-              },
-            ]
-          }
-          inEditMode={false}
-          loadedPath="/some/test/file"
-          org={
-            Object {
-              "addHeader": [Function],
-              "addHeaderAndEdit": [Function],
-              "addNewPlanningItem": [Function],
-              "addNewTableColumn": [Function],
-              "addNewTableRow": [Function],
-              "advanceCheckboxState": [Function],
-              "advanceTodoState": [Function],
-              "applyOpennessState": [Function],
-              "clearPendingCapture": [Function],
-              "displayFile": [Function],
-              "enterEditMode": [Function],
-              "exitEditMode": [Function],
-              "focusHeader": [Function],
-              "insertCapture": [Function],
-              "insertPendingCapture": [Function],
-              "moveHeaderDown": [Function],
-              "moveHeaderLeft": [Function],
-              "moveHeaderRight": [Function],
-              "moveHeaderUp": [Function],
-              "moveSubtreeLeft": [Function],
-              "moveSubtreeRight": [Function],
-              "moveTableColumnLeft": [Function],
-              "moveTableColumnRight": [Function],
-              "moveTableRowDown": [Function],
-              "moveTableRowUp": [Function],
-              "noOp": [Function],
-              "openHeader": [Function],
-              "removeHeader": [Function],
-              "removeTableColumn": [Function],
-              "removeTableRow": [Function],
-              "reorderPropertyList": [Function],
-              "reorderTags": [Function],
-              "selectHeader": [Function],
-              "selectHeaderAndOpenParents": [Function],
-              "selectNextSiblingHeader": [Function],
-              "selectNextVisibleHeader": [Function],
-              "selectPreviousVisibleHeader": [Function],
-              "setDirty": [Function],
-              "setHeaderTags": [Function],
-              "setLastSyncAt": [Function],
-              "setOrgFileErrorMessage": [Function],
-              "setSelectedTableCellId": [Function],
-              "stopDisplayingFile": [Function],
-              "sync": [Function],
-              "toggleHeaderOpened": [Function],
-              "unfocusHeader": [Function],
-              "updateHeaderDescription": [Function],
-              "updateHeaderTitle": [Function],
-              "updatePlanningItemTimestamp": [Function],
-              "updatePropertyListItems": [Function],
-              "updateTableCellValue": [Function],
-              "updateTimestampWithId": [Function],
-            }
-          }
-          path="/some/test/file"
-          selectedHeader={
-            Immutable.Map {
-              "titleLine": Immutable.Map {
-                "title": Immutable.List [
-                  Immutable.Map {
-                    "type": "text",
-                    "contents": "Top level header",
-                  },
-                ],
-                "rawTitle": "Top level header",
-                "todoKeyword": undefined,
-                "tags": Immutable.List [],
-              },
-              "rawDescription": "",
-              "description": Immutable.List [],
-              "opened": true,
-              "id": 35,
-              "nestingLevel": 1,
-              "planningItems": Immutable.List [],
-              "propertyListItems": Immutable.List [],
-            }
-          }
-          selectedHeaderId={35}
-          syncBackend={
-            Object {
-              "downloadFile": [Function],
-              "getDirectoryListing": [Function],
-              "loadMoreDirectoryListing": [Function],
-              "pushBackup": [Function],
-              "setCurrentFileBrowserDirectoryListing": [Function],
-              "setIsLoadingMoreDirectoryListing": [Function],
-              "signOut": [Function],
-            }
-          }
-          undo={
-            Object {
-              "clearHistory": [Function],
-              "jump": [Function],
-              "jumpToFuture": [Function],
-              "jumpToPast": [Function],
-              "redo": [Function],
-              "undo": [Function],
-            }
-          }
+        <div
+          class="header header--selected"
+          style="padding-left: 20px; margin-left: 0px;"
         >
-          <HotKeys
-            handlers={
-              Object {
-                "addHeader": [Function],
-                "advanceTodo": [Function],
-                "editDescription": [Function],
-                "editTitle": [Function],
-                "exitEditMode": [Function],
-                "moveHeaderDown": [Function],
-                "moveHeaderLeft": [Function],
-                "moveHeaderRight": [Function],
-                "moveHeaderUp": [Function],
-                "removeHeader": [Function],
-                "selectNextVisibleHeader": [Function],
-                "selectPreviousVisibleHeader": [Function],
-                "toggleHeaderOpened": [Function],
-                "undo": [Function],
-              }
-            }
-            keyMap={
-              Object {
-                "addHeader": "ctrl+enter",
-                "advanceTodo": "ctrl+t",
-                "editDescription": "ctrl+d",
-                "editTitle": "ctrl+h",
-                "exitEditMode": "command+enter",
-                "moveHeaderDown": "ctrl+command+n",
-                "moveHeaderLeft": "ctrl+command+b",
-                "moveHeaderRight": "ctrl+command+f",
-                "moveHeaderUp": "ctrl+command+p",
-                "removeHeader": "backspace",
-                "selectNextVisibleHeader": "ctrl+n",
-                "selectPreviousVisibleHeader": "ctrl+p",
-                "toggleHeaderOpened": "tab",
-                "undo": "ctrl+shift+-",
-              }
-            }
+          <div
+            class="left-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
           >
-            <FocusTrap
-              component="div"
-              onBlur={[Function]}
-              onFocus={[Function]}
+            <i
+              class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="right-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="header__bullet"
+            style="margin-left: -16px;"
+          >
+            *
+          </div>
+          <div
+            class="title-line"
+            style="width: 0px;"
+          >
+            
+            <div>
+              <span
+                style="word-break: break-word;"
+              >
+                <span>
+                  Top level header
+                </span>
+                
+              </span>
+            </div>
+          </div>
+          <div
+            class="ReactCollapse--collapse"
+            style="overflow: hidden; height: 0px; margin-right: 0px;"
+          >
+            <div
+              class="ReactCollapse--content"
             >
               <div
-                onBlur={[Function]}
-                onFocus={[Function]}
-                tabIndex="-1"
+                class="header-action-drawer-container"
               >
                 <div
-                  className="org-file-container"
-                  tabIndex="-1"
+                  class="header-action-drawer__row"
                 >
-                  <Connect(HeaderList)>
-                    <HeaderList
-                      headers={
-                        Immutable.List [
-                          Immutable.Map {
-                            "titleLine": Immutable.Map {
-                              "title": Immutable.List [
-                                Immutable.Map {
-                                  "type": "text",
-                                  "contents": "Top level header",
-                                },
-                              ],
-                              "rawTitle": "Top level header",
-                              "todoKeyword": undefined,
-                              "tags": Immutable.List [],
-                            },
-                            "rawDescription": "",
-                            "description": Immutable.List [],
-                            "opened": true,
-                            "id": 35,
-                            "nestingLevel": 1,
-                            "planningItems": Immutable.List [],
-                            "propertyListItems": Immutable.List [],
-                          },
-                          Immutable.Map {
-                            "titleLine": Immutable.Map {
-                              "title": Immutable.List [
-                                Immutable.Map {
-                                  "type": "text",
-                                  "contents": "A nested header",
-                                },
-                              ],
-                              "rawTitle": "A nested header",
-                              "todoKeyword": undefined,
-                              "tags": Immutable.List [],
-                            },
-                            "rawDescription": "",
-                            "description": Immutable.List [],
-                            "opened": false,
-                            "id": 36,
-                            "nestingLevel": 2,
-                            "planningItems": Immutable.List [],
-                            "propertyListItems": Immutable.List [],
-                          },
-                          Immutable.Map {
-                            "titleLine": Immutable.Map {
-                              "title": Immutable.List [
-                                Immutable.Map {
-                                  "type": "text",
-                                  "contents": "A todo item",
-                                },
-                              ],
-                              "rawTitle": "A todo item",
-                              "todoKeyword": "TODO",
-                              "tags": Immutable.List [],
-                            },
-                            "rawDescription": "",
-                            "description": Immutable.List [],
-                            "opened": false,
-                            "id": 37,
-                            "nestingLevel": 2,
-                            "planningItems": Immutable.List [],
-                            "propertyListItems": Immutable.List [],
-                          },
-                          Immutable.Map {
-                            "titleLine": Immutable.Map {
-                              "title": Immutable.List [
-                                Immutable.Map {
-                                  "type": "text",
-                                  "contents": "A finished todo item",
-                                },
-                              ],
-                              "rawTitle": "A finished todo item",
-                              "todoKeyword": "DONE",
-                              "tags": Immutable.List [],
-                            },
-                            "rawDescription": "",
-                            "description": Immutable.List [],
-                            "opened": false,
-                            "id": 38,
-                            "nestingLevel": 2,
-                            "planningItems": Immutable.List [],
-                            "propertyListItems": Immutable.List [],
-                          },
-                          Immutable.Map {
-                            "titleLine": Immutable.Map {
-                              "title": Immutable.List [
-                                Immutable.Map {
-                                  "type": "text",
-                                  "contents": "Another top level header",
-                                },
-                              ],
-                              "rawTitle": "Another top level header",
-                              "todoKeyword": undefined,
-                              "tags": Immutable.List [],
-                            },
-                            "rawDescription": "Some description content",
-                            "description": Immutable.List [
-                              Immutable.Map {
-                                "type": "text",
-                                "contents": "Some description content",
-                              },
-                            ],
-                            "opened": false,
-                            "id": 39,
-                            "nestingLevel": 1,
-                            "planningItems": Immutable.List [],
-                            "propertyListItems": Immutable.List [],
-                          },
-                          Immutable.Map {
-                            "titleLine": Immutable.Map {
-                              "title": Immutable.List [
-                                Immutable.Map {
-                                  "type": "text",
-                                  "contents": "A header with tags                                              ",
-                                },
-                              ],
-                              "rawTitle": "A header with tags                                              ",
-                              "todoKeyword": undefined,
-                              "tags": Immutable.List [
-                                "tag1",
-                                "tag2",
-                              ],
-                            },
-                            "rawDescription": "",
-                            "description": Immutable.List [],
-                            "opened": false,
-                            "id": 40,
-                            "nestingLevel": 1,
-                            "planningItems": Immutable.List [],
-                            "propertyListItems": Immutable.List [],
-                          },
-                          Immutable.Map {
-                            "titleLine": Immutable.Map {
-                              "title": Immutable.List [
-                                Immutable.Map {
-                                  "type": "text",
-                                  "contents": "A header with ",
-                                },
-                                Immutable.Map {
-                                  "id": 41,
-                                  "type": "link",
-                                  "contents": Immutable.Map {
-                                    "uri": "https://google.com",
-                                    "title": "a link",
-                                  },
-                                },
-                              ],
-                              "rawTitle": "A header with [[https://google.com][a link]]",
-                              "todoKeyword": undefined,
-                              "tags": Immutable.List [],
-                            },
-                            "rawDescription": "",
-                            "description": Immutable.List [],
-                            "opened": false,
-                            "id": 42,
-                            "nestingLevel": 1,
-                            "planningItems": Immutable.List [],
-                            "propertyListItems": Immutable.List [],
-                          },
-                        ]
-                      }
-                      selectedHeaderId={35}
-                    >
-                      <div
-                        className="header-list-container"
-                      >
-                        <Connect(Header)
-                          color="rgba(38, 143, 214, 1)"
-                          hasContent={true}
-                          header={
-                            Immutable.Map {
-                              "titleLine": Immutable.Map {
-                                "title": Immutable.List [
-                                  Immutable.Map {
-                                    "type": "text",
-                                    "contents": "Top level header",
-                                  },
-                                ],
-                                "rawTitle": "Top level header",
-                                "todoKeyword": undefined,
-                                "tags": Immutable.List [],
-                              },
-                              "rawDescription": "",
-                              "description": Immutable.List [],
-                              "opened": true,
-                              "id": 35,
-                              "nestingLevel": 1,
-                              "planningItems": Immutable.List [],
-                              "propertyListItems": Immutable.List [],
-                            }
-                          }
-                          isSelected={true}
-                          key="35"
-                          onRef={[Function]}
-                        >
-                          <Header
-                            base={
-                              Object {
-                                "activatePopup": [Function],
-                                "clearModalStack": [Function],
-                                "closePopup": [Function],
-                                "hideLoadingMessage": [Function],
-                                "loadStaticFile": [Function],
-                                "popModalPage": [Function],
-                                "pushModalPage": [Function],
-                                "restoreBaseSettings": [Function],
-                                "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                "setAgendaDefaultDeadlineDelayValue": [Function],
-                                "setBulletStyle": [Function],
-                                "setCustomKeybinding": [Function],
-                                "setDisappearingLoadingMessage": [Function],
-                                "setFontSize": [Function],
-                                "setHasUnseenChangelog": [Function],
-                                "setIsLoading": [Function],
-                                "setLastSeenChangelogHeader": [Function],
-                                "setLastViewedFile": [Function],
-                                "setLoadingMessage": [Function],
-                                "setShouldLiveSync": [Function],
-                                "setShouldStoreSettingsInSyncBackend": [Function],
-                                "setShouldTapTodoToAdvance": [Function],
-                                "unloadStaticFile": [Function],
-                              }
-                            }
-                            color="rgba(38, 143, 214, 1)"
-                            focusedHeader={null}
-                            hasContent={true}
-                            header={
-                              Immutable.Map {
-                                "titleLine": Immutable.Map {
-                                  "title": Immutable.List [
-                                    Immutable.Map {
-                                      "type": "text",
-                                      "contents": "Top level header",
-                                    },
-                                  ],
-                                  "rawTitle": "Top level header",
-                                  "todoKeyword": undefined,
-                                  "tags": Immutable.List [],
-                                },
-                                "rawDescription": "",
-                                "description": Immutable.List [],
-                                "opened": true,
-                                "id": 35,
-                                "nestingLevel": 1,
-                                "planningItems": Immutable.List [],
-                                "propertyListItems": Immutable.List [],
-                              }
-                            }
-                            inEditMode={false}
-                            isFocused={false}
-                            isSelected={true}
-                            onRef={[Function]}
-                            org={
-                              Object {
-                                "addHeader": [Function],
-                                "addHeaderAndEdit": [Function],
-                                "addNewPlanningItem": [Function],
-                                "addNewTableColumn": [Function],
-                                "addNewTableRow": [Function],
-                                "advanceCheckboxState": [Function],
-                                "advanceTodoState": [Function],
-                                "applyOpennessState": [Function],
-                                "clearPendingCapture": [Function],
-                                "displayFile": [Function],
-                                "enterEditMode": [Function],
-                                "exitEditMode": [Function],
-                                "focusHeader": [Function],
-                                "insertCapture": [Function],
-                                "insertPendingCapture": [Function],
-                                "moveHeaderDown": [Function],
-                                "moveHeaderLeft": [Function],
-                                "moveHeaderRight": [Function],
-                                "moveHeaderUp": [Function],
-                                "moveSubtreeLeft": [Function],
-                                "moveSubtreeRight": [Function],
-                                "moveTableColumnLeft": [Function],
-                                "moveTableColumnRight": [Function],
-                                "moveTableRowDown": [Function],
-                                "moveTableRowUp": [Function],
-                                "noOp": [Function],
-                                "openHeader": [Function],
-                                "removeHeader": [Function],
-                                "removeTableColumn": [Function],
-                                "removeTableRow": [Function],
-                                "reorderPropertyList": [Function],
-                                "reorderTags": [Function],
-                                "selectHeader": [Function],
-                                "selectHeaderAndOpenParents": [Function],
-                                "selectNextSiblingHeader": [Function],
-                                "selectNextVisibleHeader": [Function],
-                                "selectPreviousVisibleHeader": [Function],
-                                "setDirty": [Function],
-                                "setHeaderTags": [Function],
-                                "setLastSyncAt": [Function],
-                                "setOrgFileErrorMessage": [Function],
-                                "setSelectedTableCellId": [Function],
-                                "stopDisplayingFile": [Function],
-                                "sync": [Function],
-                                "toggleHeaderOpened": [Function],
-                                "unfocusHeader": [Function],
-                                "updateHeaderDescription": [Function],
-                                "updateHeaderTitle": [Function],
-                                "updatePlanningItemTimestamp": [Function],
-                                "updatePropertyListItems": [Function],
-                                "updateTableCellValue": [Function],
-                                "updateTimestampWithId": [Function],
-                              }
-                            }
-                          >
-                            <Motion
-                              onRest={[Function]}
-                              style={
-                                Object {
-                                  "heightFactor": 1,
-                                  "marginLeft": Object {
-                                    "damping": 26,
-                                    "precision": 0.01,
-                                    "stiffness": 300,
-                                    "val": 0,
-                                  },
-                                  "paddingLeft": 20,
-                                }
-                              }
-                            >
-                              <div
-                                className="header header--selected"
-                                onClick={[Function]}
-                                onMouseDown={[Function]}
-                                onMouseMove={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseUp={[Function]}
-                                onTouchCancel={[Function]}
-                                onTouchEnd={[Function]}
-                                onTouchMove={[Function]}
-                                onTouchStart={[Function]}
-                                style={
-                                  Object {
-                                    "marginLeft": 0,
-                                    "paddingLeft": 20,
-                                  }
-                                }
-                              >
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": 0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="left-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": 0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": -0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="right-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": -0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <div
-                                  className="header__bullet"
-                                  style={
-                                    Object {
-                                      "color": "rgba(38, 143, 214, 1)",
-                                      "marginLeft": -16,
-                                    }
-                                  }
-                                >
-                                  *
-                                </div>
-                                <Connect(TitleLine)
-                                  color="rgba(38, 143, 214, 1)"
-                                  hasContent={true}
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "Top level header",
-                                          },
-                                        ],
-                                        "rawTitle": "Top level header",
-                                        "todoKeyword": undefined,
-                                        "tags": Immutable.List [],
-                                      },
-                                      "rawDescription": "",
-                                      "description": Immutable.List [],
-                                      "opened": true,
-                                      "id": 35,
-                                      "nestingLevel": 1,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                  isSelected={true}
-                                >
-                                  <TitleLine
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    color="rgba(38, 143, 214, 1)"
-                                    hasContent={true}
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "Top level header",
-                                            },
-                                          ],
-                                          "rawTitle": "Top level header",
-                                          "todoKeyword": undefined,
-                                          "tags": Immutable.List [],
-                                        },
-                                        "rawDescription": "",
-                                        "description": Immutable.List [],
-                                        "opened": true,
-                                        "id": 35,
-                                        "nestingLevel": 1,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    isSelected={true}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                  >
-                                    <div
-                                      className="title-line"
-                                      onClick={[Function]}
-                                      style={
-                                        Object {
-                                          "width": 0,
-                                        }
-                                      }
-                                    >
-                                      <div>
-                                        <span
-                                          style={
-                                            Object {
-                                              "color": "rgba(38, 143, 214, 1)",
-                                              "wordBreak": "break-word",
-                                            }
-                                          }
-                                        >
-                                          <_default
-                                            parts={
-                                              Immutable.List [
-                                                Immutable.Map {
-                                                  "type": "text",
-                                                  "contents": "Top level header",
-                                                },
-                                              ]
-                                            }
-                                            subPartDataAndHandlers={
-                                              Object {
-                                                "onTimestampClick": [Function],
-                                                "shouldDisableActions": undefined,
-                                              }
-                                            }
-                                          >
-                                            <span>
-                                              Top level header
-                                            </span>
-                                          </_default>
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </TitleLine>
-                                </Connect(TitleLine)>
-                                <UnmountClosed
-                                  isOpened={true}
-                                  springConfig={
-                                    Object {
-                                      "stiffness": 300,
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "marginRight": -0,
-                                    }
-                                  }
-                                >
-                                  <Collapse
-                                    fixedHeight={-1}
-                                    forceInitialAnimation={true}
-                                    hasNestedCollapse={false}
-                                    isOpened={true}
-                                    onMeasure={[Function]}
-                                    onRender={[Function]}
-                                    onRest={[Function]}
-                                    springConfig={
-                                      Object {
-                                        "stiffness": 300,
-                                      }
-                                    }
-                                    style={
-                                      Object {
-                                        "marginRight": -0,
-                                      }
-                                    }
-                                    theme={
-                                      Object {
-                                        "collapse": "ReactCollapse--collapse",
-                                        "content": "ReactCollapse--content",
-                                      }
-                                    }
-                                  >
-                                    <Motion
-                                      defaultStyle={
-                                        Object {
-                                          "height": 0,
-                                        }
-                                      }
-                                      onRest={[Function]}
-                                      style={
-                                        Object {
-                                          "height": Object {
-                                            "damping": 26,
-                                            "precision": 1,
-                                            "stiffness": 300,
-                                            "val": 0,
-                                          },
-                                        }
-                                      }
-                                    >
-                                      <div
-                                        className="ReactCollapse--collapse"
-                                        style={
-                                          Object {
-                                            "height": 0,
-                                            "marginRight": -0,
-                                            "overflow": "hidden",
-                                          }
-                                        }
-                                      >
-                                        <div
-                                          className="ReactCollapse--content"
-                                        >
-                                          <HeaderActionDrawer
-                                            isFocused={false}
-                                            onAddNewHeader={[Function]}
-                                            onDeadlineClick={[Function]}
-                                            onEnterDescriptionEditMode={[Function]}
-                                            onEnterTitleEditMode={[Function]}
-                                            onFocus={[Function]}
-                                            onScheduledClick={[Function]}
-                                            onTagsClick={[Function]}
-                                            onUnfocus={[Function]}
-                                          >
-                                            <div
-                                              className="header-action-drawer-container"
-                                            >
-                                              <div
-                                                className="header-action-drawer__row"
-                                              >
-                                                <div
-                                                  className="header-action-drawer__ff-click-catcher-container"
-                                                  onClick={[Function]}
-                                                >
-                                                  <div
-                                                    className="header-action-drawer__ff-click-catcher"
-                                                  />
-                                                  <i
-                                                    className="fas fa-pencil-alt fa-lg"
-                                                  />
-                                                </div>
-                                                <span
-                                                  className="header-action-drawer__separator"
-                                                />
-                                                <div
-                                                  className="header-action-drawer__ff-click-catcher-container"
-                                                  onClick={[Function]}
-                                                >
-                                                  <div
-                                                    className="header-action-drawer__ff-click-catcher"
-                                                  />
-                                                  <i
-                                                    className="fas fa-edit fa-lg"
-                                                  />
-                                                </div>
-                                                <span
-                                                  className="header-action-drawer__separator"
-                                                />
-                                                <div
-                                                  className="header-action-drawer__ff-click-catcher-container"
-                                                  onClick={[Function]}
-                                                >
-                                                  <div
-                                                    className="header-action-drawer__ff-click-catcher"
-                                                  />
-                                                  <i
-                                                    className="fas fa-tags fa-lg"
-                                                  />
-                                                </div>
-                                                <span
-                                                  className="header-action-drawer__separator"
-                                                />
-                                                <div
-                                                  className="header-action-drawer__ff-click-catcher-container"
-                                                  onClick={[Function]}
-                                                >
-                                                  <div
-                                                    className="header-action-drawer__ff-click-catcher"
-                                                  />
-                                                  <i
-                                                    className="fas fa-compress fa-lg"
-                                                  />
-                                                </div>
-                                                <span
-                                                  className="header-action-drawer__separator"
-                                                />
-                                                <div
-                                                  className="header-action-drawer__ff-click-catcher-container"
-                                                  onClick={[Function]}
-                                                >
-                                                  <div
-                                                    className="header-action-drawer__ff-click-catcher"
-                                                  />
-                                                  <i
-                                                    className="fas fa-plus fa-lg"
-                                                  />
-                                                </div>
-                                              </div>
-                                              <div
-                                                className="header-action-drawer__row"
-                                              >
-                                                <div
-                                                  className="header-action-drawer__deadline-scheduled-button"
-                                                  onClick={[Function]}
-                                                >
-                                                  Deadline
-                                                </div>
-                                                <span
-                                                  className="header-action-drawer__separator"
-                                                />
-                                                <div
-                                                  className="header-action-drawer__deadline-scheduled-button"
-                                                  onClick={[Function]}
-                                                >
-                                                  Scheduled
-                                                </div>
-                                              </div>
-                                            </div>
-                                          </HeaderActionDrawer>
-                                        </div>
-                                      </div>
-                                    </Motion>
-                                  </Collapse>
-                                </UnmountClosed>
-                                <Connect(HeaderContent)
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "Top level header",
-                                          },
-                                        ],
-                                        "rawTitle": "Top level header",
-                                        "todoKeyword": undefined,
-                                        "tags": Immutable.List [],
-                                      },
-                                      "rawDescription": "",
-                                      "description": Immutable.List [],
-                                      "opened": true,
-                                      "id": 35,
-                                      "nestingLevel": 1,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                >
-                                  <HeaderContent
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "Top level header",
-                                            },
-                                          ],
-                                          "rawTitle": "Top level header",
-                                          "todoKeyword": undefined,
-                                          "tags": Immutable.List [],
-                                        },
-                                        "rawDescription": "",
-                                        "description": Immutable.List [],
-                                        "opened": true,
-                                        "id": 35,
-                                        "nestingLevel": 1,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    inTableEditMode={false}
-                                    isSelected={true}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                    selectedTableCellId={null}
-                                  >
-                                    <div
-                                      className="header-content-container nice-scroll"
-                                      style={
-                                        Object {
-                                          "width": 0,
-                                        }
-                                      }
-                                    >
-                                      <PlanningItems
-                                        onClick={[Function]}
-                                        planningItems={Immutable.List []}
-                                      />
-                                      <_default
-                                        onEdit={[Function]}
-                                        onTimestampClick={[Function]}
-                                        propertyListItems={Immutable.List []}
-                                      />
-                                      <_default
-                                        parts={Immutable.List []}
-                                        subPartDataAndHandlers={
-                                          Object {
-                                            "inTableEditMode": false,
-                                            "onAddNewTableColumn": [Function],
-                                            "onAddNewTableRow": [Function],
-                                            "onCheckboxClick": [Function],
-                                            "onEnterTableEditMode": [Function],
-                                            "onExitTableEditMode": [Function],
-                                            "onRemoveTableColumn": [Function],
-                                            "onRemoveTableRow": [Function],
-                                            "onTableCellSelect": [Function],
-                                            "onTableCellValueUpdate": [Function],
-                                            "onTimestampClick": [Function],
-                                            "selectedTableCellId": null,
-                                            "shouldDisableActions": undefined,
-                                          }
-                                        }
-                                      >
-                                        <span>
-                                          <Component />
-                                        </span>
-                                      </_default>
-                                    </div>
-                                  </HeaderContent>
-                                </Connect(HeaderContent)>
-                              </div>
-                            </Motion>
-                          </Header>
-                        </Connect(Header)>
-                        <Connect(Header)
-                          color="rgba(42, 164, 168, 1)"
-                          hasContent={false}
-                          header={
-                            Immutable.Map {
-                              "titleLine": Immutable.Map {
-                                "title": Immutable.List [
-                                  Immutable.Map {
-                                    "type": "text",
-                                    "contents": "A nested header",
-                                  },
-                                ],
-                                "rawTitle": "A nested header",
-                                "todoKeyword": undefined,
-                                "tags": Immutable.List [],
-                              },
-                              "rawDescription": "",
-                              "description": Immutable.List [],
-                              "opened": false,
-                              "id": 36,
-                              "nestingLevel": 2,
-                              "planningItems": Immutable.List [],
-                              "propertyListItems": Immutable.List [],
-                            }
-                          }
-                          isSelected={false}
-                          key="36"
-                          onRef={[Function]}
-                        >
-                          <Header
-                            base={
-                              Object {
-                                "activatePopup": [Function],
-                                "clearModalStack": [Function],
-                                "closePopup": [Function],
-                                "hideLoadingMessage": [Function],
-                                "loadStaticFile": [Function],
-                                "popModalPage": [Function],
-                                "pushModalPage": [Function],
-                                "restoreBaseSettings": [Function],
-                                "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                "setAgendaDefaultDeadlineDelayValue": [Function],
-                                "setBulletStyle": [Function],
-                                "setCustomKeybinding": [Function],
-                                "setDisappearingLoadingMessage": [Function],
-                                "setFontSize": [Function],
-                                "setHasUnseenChangelog": [Function],
-                                "setIsLoading": [Function],
-                                "setLastSeenChangelogHeader": [Function],
-                                "setLastViewedFile": [Function],
-                                "setLoadingMessage": [Function],
-                                "setShouldLiveSync": [Function],
-                                "setShouldStoreSettingsInSyncBackend": [Function],
-                                "setShouldTapTodoToAdvance": [Function],
-                                "unloadStaticFile": [Function],
-                              }
-                            }
-                            color="rgba(42, 164, 168, 1)"
-                            focusedHeader={null}
-                            hasContent={false}
-                            header={
-                              Immutable.Map {
-                                "titleLine": Immutable.Map {
-                                  "title": Immutable.List [
-                                    Immutable.Map {
-                                      "type": "text",
-                                      "contents": "A nested header",
-                                    },
-                                  ],
-                                  "rawTitle": "A nested header",
-                                  "todoKeyword": undefined,
-                                  "tags": Immutable.List [],
-                                },
-                                "rawDescription": "",
-                                "description": Immutable.List [],
-                                "opened": false,
-                                "id": 36,
-                                "nestingLevel": 2,
-                                "planningItems": Immutable.List [],
-                                "propertyListItems": Immutable.List [],
-                              }
-                            }
-                            inEditMode={false}
-                            isFocused={false}
-                            isSelected={false}
-                            onRef={[Function]}
-                            org={
-                              Object {
-                                "addHeader": [Function],
-                                "addHeaderAndEdit": [Function],
-                                "addNewPlanningItem": [Function],
-                                "addNewTableColumn": [Function],
-                                "addNewTableRow": [Function],
-                                "advanceCheckboxState": [Function],
-                                "advanceTodoState": [Function],
-                                "applyOpennessState": [Function],
-                                "clearPendingCapture": [Function],
-                                "displayFile": [Function],
-                                "enterEditMode": [Function],
-                                "exitEditMode": [Function],
-                                "focusHeader": [Function],
-                                "insertCapture": [Function],
-                                "insertPendingCapture": [Function],
-                                "moveHeaderDown": [Function],
-                                "moveHeaderLeft": [Function],
-                                "moveHeaderRight": [Function],
-                                "moveHeaderUp": [Function],
-                                "moveSubtreeLeft": [Function],
-                                "moveSubtreeRight": [Function],
-                                "moveTableColumnLeft": [Function],
-                                "moveTableColumnRight": [Function],
-                                "moveTableRowDown": [Function],
-                                "moveTableRowUp": [Function],
-                                "noOp": [Function],
-                                "openHeader": [Function],
-                                "removeHeader": [Function],
-                                "removeTableColumn": [Function],
-                                "removeTableRow": [Function],
-                                "reorderPropertyList": [Function],
-                                "reorderTags": [Function],
-                                "selectHeader": [Function],
-                                "selectHeaderAndOpenParents": [Function],
-                                "selectNextSiblingHeader": [Function],
-                                "selectNextVisibleHeader": [Function],
-                                "selectPreviousVisibleHeader": [Function],
-                                "setDirty": [Function],
-                                "setHeaderTags": [Function],
-                                "setLastSyncAt": [Function],
-                                "setOrgFileErrorMessage": [Function],
-                                "setSelectedTableCellId": [Function],
-                                "stopDisplayingFile": [Function],
-                                "sync": [Function],
-                                "toggleHeaderOpened": [Function],
-                                "unfocusHeader": [Function],
-                                "updateHeaderDescription": [Function],
-                                "updateHeaderTitle": [Function],
-                                "updatePlanningItemTimestamp": [Function],
-                                "updatePropertyListItems": [Function],
-                                "updateTableCellValue": [Function],
-                                "updateTimestampWithId": [Function],
-                              }
-                            }
-                          >
-                            <Motion
-                              onRest={[Function]}
-                              style={
-                                Object {
-                                  "heightFactor": 1,
-                                  "marginLeft": Object {
-                                    "damping": 26,
-                                    "precision": 0.01,
-                                    "stiffness": 300,
-                                    "val": 0,
-                                  },
-                                  "paddingLeft": 40,
-                                }
-                              }
-                            >
-                              <div
-                                className="header"
-                                onClick={[Function]}
-                                onMouseDown={[Function]}
-                                onMouseMove={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseUp={[Function]}
-                                onTouchCancel={[Function]}
-                                onTouchEnd={[Function]}
-                                onTouchMove={[Function]}
-                                onTouchStart={[Function]}
-                                style={
-                                  Object {
-                                    "marginLeft": 0,
-                                    "paddingLeft": 40,
-                                  }
-                                }
-                              >
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": 0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="left-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": 0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": -0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="right-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": -0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <div
-                                  className="header__bullet"
-                                  style={
-                                    Object {
-                                      "color": "rgba(42, 164, 168, 1)",
-                                      "marginLeft": -16,
-                                    }
-                                  }
-                                >
-                                  *
-                                </div>
-                                <Connect(TitleLine)
-                                  color="rgba(42, 164, 168, 1)"
-                                  hasContent={false}
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "A nested header",
-                                          },
-                                        ],
-                                        "rawTitle": "A nested header",
-                                        "todoKeyword": undefined,
-                                        "tags": Immutable.List [],
-                                      },
-                                      "rawDescription": "",
-                                      "description": Immutable.List [],
-                                      "opened": false,
-                                      "id": 36,
-                                      "nestingLevel": 2,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                  isSelected={false}
-                                >
-                                  <TitleLine
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    color="rgba(42, 164, 168, 1)"
-                                    hasContent={false}
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "A nested header",
-                                            },
-                                          ],
-                                          "rawTitle": "A nested header",
-                                          "todoKeyword": undefined,
-                                          "tags": Immutable.List [],
-                                        },
-                                        "rawDescription": "",
-                                        "description": Immutable.List [],
-                                        "opened": false,
-                                        "id": 36,
-                                        "nestingLevel": 2,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                  >
-                                    <div
-                                      className="title-line"
-                                      onClick={[Function]}
-                                      style={
-                                        Object {
-                                          "width": 0,
-                                        }
-                                      }
-                                    >
-                                      <div>
-                                        <span
-                                          style={
-                                            Object {
-                                              "color": "rgba(42, 164, 168, 1)",
-                                              "wordBreak": "break-word",
-                                            }
-                                          }
-                                        >
-                                          <_default
-                                            parts={
-                                              Immutable.List [
-                                                Immutable.Map {
-                                                  "type": "text",
-                                                  "contents": "A nested header",
-                                                },
-                                              ]
-                                            }
-                                            subPartDataAndHandlers={
-                                              Object {
-                                                "onTimestampClick": [Function],
-                                                "shouldDisableActions": undefined,
-                                              }
-                                            }
-                                          >
-                                            <span>
-                                              A nested header
-                                            </span>
-                                          </_default>
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </TitleLine>
-                                </Connect(TitleLine)>
-                                <UnmountClosed
-                                  isOpened={false}
-                                  springConfig={
-                                    Object {
-                                      "stiffness": 300,
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "marginRight": -0,
-                                    }
-                                  }
-                                />
-                                <Connect(HeaderContent)
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "A nested header",
-                                          },
-                                        ],
-                                        "rawTitle": "A nested header",
-                                        "todoKeyword": undefined,
-                                        "tags": Immutable.List [],
-                                      },
-                                      "rawDescription": "",
-                                      "description": Immutable.List [],
-                                      "opened": false,
-                                      "id": 36,
-                                      "nestingLevel": 2,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                >
-                                  <HeaderContent
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "A nested header",
-                                            },
-                                          ],
-                                          "rawTitle": "A nested header",
-                                          "todoKeyword": undefined,
-                                          "tags": Immutable.List [],
-                                        },
-                                        "rawDescription": "",
-                                        "description": Immutable.List [],
-                                        "opened": false,
-                                        "id": 36,
-                                        "nestingLevel": 2,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    inTableEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                    selectedTableCellId={null}
-                                  >
-                                    <div />
-                                  </HeaderContent>
-                                </Connect(HeaderContent)>
-                              </div>
-                            </Motion>
-                          </Header>
-                        </Connect(Header)>
-                        <Connect(Header)
-                          color="rgba(42, 164, 168, 1)"
-                          hasContent={false}
-                          header={
-                            Immutable.Map {
-                              "titleLine": Immutable.Map {
-                                "title": Immutable.List [
-                                  Immutable.Map {
-                                    "type": "text",
-                                    "contents": "A todo item",
-                                  },
-                                ],
-                                "rawTitle": "A todo item",
-                                "todoKeyword": "TODO",
-                                "tags": Immutable.List [],
-                              },
-                              "rawDescription": "",
-                              "description": Immutable.List [],
-                              "opened": false,
-                              "id": 37,
-                              "nestingLevel": 2,
-                              "planningItems": Immutable.List [],
-                              "propertyListItems": Immutable.List [],
-                            }
-                          }
-                          isSelected={false}
-                          key="37"
-                          onRef={[Function]}
-                        >
-                          <Header
-                            base={
-                              Object {
-                                "activatePopup": [Function],
-                                "clearModalStack": [Function],
-                                "closePopup": [Function],
-                                "hideLoadingMessage": [Function],
-                                "loadStaticFile": [Function],
-                                "popModalPage": [Function],
-                                "pushModalPage": [Function],
-                                "restoreBaseSettings": [Function],
-                                "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                "setAgendaDefaultDeadlineDelayValue": [Function],
-                                "setBulletStyle": [Function],
-                                "setCustomKeybinding": [Function],
-                                "setDisappearingLoadingMessage": [Function],
-                                "setFontSize": [Function],
-                                "setHasUnseenChangelog": [Function],
-                                "setIsLoading": [Function],
-                                "setLastSeenChangelogHeader": [Function],
-                                "setLastViewedFile": [Function],
-                                "setLoadingMessage": [Function],
-                                "setShouldLiveSync": [Function],
-                                "setShouldStoreSettingsInSyncBackend": [Function],
-                                "setShouldTapTodoToAdvance": [Function],
-                                "unloadStaticFile": [Function],
-                              }
-                            }
-                            color="rgba(42, 164, 168, 1)"
-                            focusedHeader={null}
-                            hasContent={false}
-                            header={
-                              Immutable.Map {
-                                "titleLine": Immutable.Map {
-                                  "title": Immutable.List [
-                                    Immutable.Map {
-                                      "type": "text",
-                                      "contents": "A todo item",
-                                    },
-                                  ],
-                                  "rawTitle": "A todo item",
-                                  "todoKeyword": "TODO",
-                                  "tags": Immutable.List [],
-                                },
-                                "rawDescription": "",
-                                "description": Immutable.List [],
-                                "opened": false,
-                                "id": 37,
-                                "nestingLevel": 2,
-                                "planningItems": Immutable.List [],
-                                "propertyListItems": Immutable.List [],
-                              }
-                            }
-                            inEditMode={false}
-                            isFocused={false}
-                            isSelected={false}
-                            onRef={[Function]}
-                            org={
-                              Object {
-                                "addHeader": [Function],
-                                "addHeaderAndEdit": [Function],
-                                "addNewPlanningItem": [Function],
-                                "addNewTableColumn": [Function],
-                                "addNewTableRow": [Function],
-                                "advanceCheckboxState": [Function],
-                                "advanceTodoState": [Function],
-                                "applyOpennessState": [Function],
-                                "clearPendingCapture": [Function],
-                                "displayFile": [Function],
-                                "enterEditMode": [Function],
-                                "exitEditMode": [Function],
-                                "focusHeader": [Function],
-                                "insertCapture": [Function],
-                                "insertPendingCapture": [Function],
-                                "moveHeaderDown": [Function],
-                                "moveHeaderLeft": [Function],
-                                "moveHeaderRight": [Function],
-                                "moveHeaderUp": [Function],
-                                "moveSubtreeLeft": [Function],
-                                "moveSubtreeRight": [Function],
-                                "moveTableColumnLeft": [Function],
-                                "moveTableColumnRight": [Function],
-                                "moveTableRowDown": [Function],
-                                "moveTableRowUp": [Function],
-                                "noOp": [Function],
-                                "openHeader": [Function],
-                                "removeHeader": [Function],
-                                "removeTableColumn": [Function],
-                                "removeTableRow": [Function],
-                                "reorderPropertyList": [Function],
-                                "reorderTags": [Function],
-                                "selectHeader": [Function],
-                                "selectHeaderAndOpenParents": [Function],
-                                "selectNextSiblingHeader": [Function],
-                                "selectNextVisibleHeader": [Function],
-                                "selectPreviousVisibleHeader": [Function],
-                                "setDirty": [Function],
-                                "setHeaderTags": [Function],
-                                "setLastSyncAt": [Function],
-                                "setOrgFileErrorMessage": [Function],
-                                "setSelectedTableCellId": [Function],
-                                "stopDisplayingFile": [Function],
-                                "sync": [Function],
-                                "toggleHeaderOpened": [Function],
-                                "unfocusHeader": [Function],
-                                "updateHeaderDescription": [Function],
-                                "updateHeaderTitle": [Function],
-                                "updatePlanningItemTimestamp": [Function],
-                                "updatePropertyListItems": [Function],
-                                "updateTableCellValue": [Function],
-                                "updateTimestampWithId": [Function],
-                              }
-                            }
-                          >
-                            <Motion
-                              onRest={[Function]}
-                              style={
-                                Object {
-                                  "heightFactor": 1,
-                                  "marginLeft": Object {
-                                    "damping": 26,
-                                    "precision": 0.01,
-                                    "stiffness": 300,
-                                    "val": 0,
-                                  },
-                                  "paddingLeft": 40,
-                                }
-                              }
-                            >
-                              <div
-                                className="header"
-                                onClick={[Function]}
-                                onMouseDown={[Function]}
-                                onMouseMove={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseUp={[Function]}
-                                onTouchCancel={[Function]}
-                                onTouchEnd={[Function]}
-                                onTouchMove={[Function]}
-                                onTouchStart={[Function]}
-                                style={
-                                  Object {
-                                    "marginLeft": 0,
-                                    "paddingLeft": 40,
-                                  }
-                                }
-                              >
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": 0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="left-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": 0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": -0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="right-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": -0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <div
-                                  className="header__bullet"
-                                  style={
-                                    Object {
-                                      "color": "rgba(42, 164, 168, 1)",
-                                      "marginLeft": -16,
-                                    }
-                                  }
-                                >
-                                  *
-                                </div>
-                                <Connect(TitleLine)
-                                  color="rgba(42, 164, 168, 1)"
-                                  hasContent={false}
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "A todo item",
-                                          },
-                                        ],
-                                        "rawTitle": "A todo item",
-                                        "todoKeyword": "TODO",
-                                        "tags": Immutable.List [],
-                                      },
-                                      "rawDescription": "",
-                                      "description": Immutable.List [],
-                                      "opened": false,
-                                      "id": 37,
-                                      "nestingLevel": 2,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                  isSelected={false}
-                                >
-                                  <TitleLine
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    color="rgba(42, 164, 168, 1)"
-                                    hasContent={false}
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "A todo item",
-                                            },
-                                          ],
-                                          "rawTitle": "A todo item",
-                                          "todoKeyword": "TODO",
-                                          "tags": Immutable.List [],
-                                        },
-                                        "rawDescription": "",
-                                        "description": Immutable.List [],
-                                        "opened": false,
-                                        "id": 37,
-                                        "nestingLevel": 2,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                  >
-                                    <div
-                                      className="title-line"
-                                      onClick={[Function]}
-                                      style={
-                                        Object {
-                                          "width": 0,
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="todo-keyword todo-keyword--todo"
-                                        onClick={[Function]}
-                                      >
-                                        TODO
-                                      </span>
-                                      <div>
-                                        <span
-                                          style={
-                                            Object {
-                                              "color": "rgba(42, 164, 168, 1)",
-                                              "wordBreak": "break-word",
-                                            }
-                                          }
-                                        >
-                                          <_default
-                                            parts={
-                                              Immutable.List [
-                                                Immutable.Map {
-                                                  "type": "text",
-                                                  "contents": "A todo item",
-                                                },
-                                              ]
-                                            }
-                                            subPartDataAndHandlers={
-                                              Object {
-                                                "onTimestampClick": [Function],
-                                                "shouldDisableActions": undefined,
-                                              }
-                                            }
-                                          >
-                                            <span>
-                                              A todo item
-                                            </span>
-                                          </_default>
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </TitleLine>
-                                </Connect(TitleLine)>
-                                <UnmountClosed
-                                  isOpened={false}
-                                  springConfig={
-                                    Object {
-                                      "stiffness": 300,
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "marginRight": -0,
-                                    }
-                                  }
-                                />
-                                <Connect(HeaderContent)
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "A todo item",
-                                          },
-                                        ],
-                                        "rawTitle": "A todo item",
-                                        "todoKeyword": "TODO",
-                                        "tags": Immutable.List [],
-                                      },
-                                      "rawDescription": "",
-                                      "description": Immutable.List [],
-                                      "opened": false,
-                                      "id": 37,
-                                      "nestingLevel": 2,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                >
-                                  <HeaderContent
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "A todo item",
-                                            },
-                                          ],
-                                          "rawTitle": "A todo item",
-                                          "todoKeyword": "TODO",
-                                          "tags": Immutable.List [],
-                                        },
-                                        "rawDescription": "",
-                                        "description": Immutable.List [],
-                                        "opened": false,
-                                        "id": 37,
-                                        "nestingLevel": 2,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    inTableEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                    selectedTableCellId={null}
-                                  >
-                                    <div />
-                                  </HeaderContent>
-                                </Connect(HeaderContent)>
-                              </div>
-                            </Motion>
-                          </Header>
-                        </Connect(Header)>
-                        <Connect(Header)
-                          color="rgba(42, 164, 168, 1)"
-                          hasContent={false}
-                          header={
-                            Immutable.Map {
-                              "titleLine": Immutable.Map {
-                                "title": Immutable.List [
-                                  Immutable.Map {
-                                    "type": "text",
-                                    "contents": "A finished todo item",
-                                  },
-                                ],
-                                "rawTitle": "A finished todo item",
-                                "todoKeyword": "DONE",
-                                "tags": Immutable.List [],
-                              },
-                              "rawDescription": "",
-                              "description": Immutable.List [],
-                              "opened": false,
-                              "id": 38,
-                              "nestingLevel": 2,
-                              "planningItems": Immutable.List [],
-                              "propertyListItems": Immutable.List [],
-                            }
-                          }
-                          isSelected={false}
-                          key="38"
-                          onRef={[Function]}
-                        >
-                          <Header
-                            base={
-                              Object {
-                                "activatePopup": [Function],
-                                "clearModalStack": [Function],
-                                "closePopup": [Function],
-                                "hideLoadingMessage": [Function],
-                                "loadStaticFile": [Function],
-                                "popModalPage": [Function],
-                                "pushModalPage": [Function],
-                                "restoreBaseSettings": [Function],
-                                "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                "setAgendaDefaultDeadlineDelayValue": [Function],
-                                "setBulletStyle": [Function],
-                                "setCustomKeybinding": [Function],
-                                "setDisappearingLoadingMessage": [Function],
-                                "setFontSize": [Function],
-                                "setHasUnseenChangelog": [Function],
-                                "setIsLoading": [Function],
-                                "setLastSeenChangelogHeader": [Function],
-                                "setLastViewedFile": [Function],
-                                "setLoadingMessage": [Function],
-                                "setShouldLiveSync": [Function],
-                                "setShouldStoreSettingsInSyncBackend": [Function],
-                                "setShouldTapTodoToAdvance": [Function],
-                                "unloadStaticFile": [Function],
-                              }
-                            }
-                            color="rgba(42, 164, 168, 1)"
-                            focusedHeader={null}
-                            hasContent={false}
-                            header={
-                              Immutable.Map {
-                                "titleLine": Immutable.Map {
-                                  "title": Immutable.List [
-                                    Immutable.Map {
-                                      "type": "text",
-                                      "contents": "A finished todo item",
-                                    },
-                                  ],
-                                  "rawTitle": "A finished todo item",
-                                  "todoKeyword": "DONE",
-                                  "tags": Immutable.List [],
-                                },
-                                "rawDescription": "",
-                                "description": Immutable.List [],
-                                "opened": false,
-                                "id": 38,
-                                "nestingLevel": 2,
-                                "planningItems": Immutable.List [],
-                                "propertyListItems": Immutable.List [],
-                              }
-                            }
-                            inEditMode={false}
-                            isFocused={false}
-                            isSelected={false}
-                            onRef={[Function]}
-                            org={
-                              Object {
-                                "addHeader": [Function],
-                                "addHeaderAndEdit": [Function],
-                                "addNewPlanningItem": [Function],
-                                "addNewTableColumn": [Function],
-                                "addNewTableRow": [Function],
-                                "advanceCheckboxState": [Function],
-                                "advanceTodoState": [Function],
-                                "applyOpennessState": [Function],
-                                "clearPendingCapture": [Function],
-                                "displayFile": [Function],
-                                "enterEditMode": [Function],
-                                "exitEditMode": [Function],
-                                "focusHeader": [Function],
-                                "insertCapture": [Function],
-                                "insertPendingCapture": [Function],
-                                "moveHeaderDown": [Function],
-                                "moveHeaderLeft": [Function],
-                                "moveHeaderRight": [Function],
-                                "moveHeaderUp": [Function],
-                                "moveSubtreeLeft": [Function],
-                                "moveSubtreeRight": [Function],
-                                "moveTableColumnLeft": [Function],
-                                "moveTableColumnRight": [Function],
-                                "moveTableRowDown": [Function],
-                                "moveTableRowUp": [Function],
-                                "noOp": [Function],
-                                "openHeader": [Function],
-                                "removeHeader": [Function],
-                                "removeTableColumn": [Function],
-                                "removeTableRow": [Function],
-                                "reorderPropertyList": [Function],
-                                "reorderTags": [Function],
-                                "selectHeader": [Function],
-                                "selectHeaderAndOpenParents": [Function],
-                                "selectNextSiblingHeader": [Function],
-                                "selectNextVisibleHeader": [Function],
-                                "selectPreviousVisibleHeader": [Function],
-                                "setDirty": [Function],
-                                "setHeaderTags": [Function],
-                                "setLastSyncAt": [Function],
-                                "setOrgFileErrorMessage": [Function],
-                                "setSelectedTableCellId": [Function],
-                                "stopDisplayingFile": [Function],
-                                "sync": [Function],
-                                "toggleHeaderOpened": [Function],
-                                "unfocusHeader": [Function],
-                                "updateHeaderDescription": [Function],
-                                "updateHeaderTitle": [Function],
-                                "updatePlanningItemTimestamp": [Function],
-                                "updatePropertyListItems": [Function],
-                                "updateTableCellValue": [Function],
-                                "updateTimestampWithId": [Function],
-                              }
-                            }
-                          >
-                            <Motion
-                              onRest={[Function]}
-                              style={
-                                Object {
-                                  "heightFactor": 1,
-                                  "marginLeft": Object {
-                                    "damping": 26,
-                                    "precision": 0.01,
-                                    "stiffness": 300,
-                                    "val": 0,
-                                  },
-                                  "paddingLeft": 40,
-                                }
-                              }
-                            >
-                              <div
-                                className="header"
-                                onClick={[Function]}
-                                onMouseDown={[Function]}
-                                onMouseMove={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseUp={[Function]}
-                                onTouchCancel={[Function]}
-                                onTouchEnd={[Function]}
-                                onTouchMove={[Function]}
-                                onTouchStart={[Function]}
-                                style={
-                                  Object {
-                                    "marginLeft": 0,
-                                    "paddingLeft": 40,
-                                  }
-                                }
-                              >
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": 0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="left-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": 0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": -0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="right-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": -0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <div
-                                  className="header__bullet"
-                                  style={
-                                    Object {
-                                      "color": "rgba(42, 164, 168, 1)",
-                                      "marginLeft": -16,
-                                    }
-                                  }
-                                >
-                                  *
-                                </div>
-                                <Connect(TitleLine)
-                                  color="rgba(42, 164, 168, 1)"
-                                  hasContent={false}
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "A finished todo item",
-                                          },
-                                        ],
-                                        "rawTitle": "A finished todo item",
-                                        "todoKeyword": "DONE",
-                                        "tags": Immutable.List [],
-                                      },
-                                      "rawDescription": "",
-                                      "description": Immutable.List [],
-                                      "opened": false,
-                                      "id": 38,
-                                      "nestingLevel": 2,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                  isSelected={false}
-                                >
-                                  <TitleLine
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    color="rgba(42, 164, 168, 1)"
-                                    hasContent={false}
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "A finished todo item",
-                                            },
-                                          ],
-                                          "rawTitle": "A finished todo item",
-                                          "todoKeyword": "DONE",
-                                          "tags": Immutable.List [],
-                                        },
-                                        "rawDescription": "",
-                                        "description": Immutable.List [],
-                                        "opened": false,
-                                        "id": 38,
-                                        "nestingLevel": 2,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                  >
-                                    <div
-                                      className="title-line"
-                                      onClick={[Function]}
-                                      style={
-                                        Object {
-                                          "width": 0,
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="todo-keyword todo-keyword--done"
-                                        onClick={[Function]}
-                                      >
-                                        DONE
-                                      </span>
-                                      <div>
-                                        <span
-                                          style={
-                                            Object {
-                                              "color": "rgba(42, 164, 168, 1)",
-                                              "wordBreak": "break-word",
-                                            }
-                                          }
-                                        >
-                                          <_default
-                                            parts={
-                                              Immutable.List [
-                                                Immutable.Map {
-                                                  "type": "text",
-                                                  "contents": "A finished todo item",
-                                                },
-                                              ]
-                                            }
-                                            subPartDataAndHandlers={
-                                              Object {
-                                                "onTimestampClick": [Function],
-                                                "shouldDisableActions": undefined,
-                                              }
-                                            }
-                                          >
-                                            <span>
-                                              A finished todo item
-                                            </span>
-                                          </_default>
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </TitleLine>
-                                </Connect(TitleLine)>
-                                <UnmountClosed
-                                  isOpened={false}
-                                  springConfig={
-                                    Object {
-                                      "stiffness": 300,
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "marginRight": -0,
-                                    }
-                                  }
-                                />
-                                <Connect(HeaderContent)
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "A finished todo item",
-                                          },
-                                        ],
-                                        "rawTitle": "A finished todo item",
-                                        "todoKeyword": "DONE",
-                                        "tags": Immutable.List [],
-                                      },
-                                      "rawDescription": "",
-                                      "description": Immutable.List [],
-                                      "opened": false,
-                                      "id": 38,
-                                      "nestingLevel": 2,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                >
-                                  <HeaderContent
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "A finished todo item",
-                                            },
-                                          ],
-                                          "rawTitle": "A finished todo item",
-                                          "todoKeyword": "DONE",
-                                          "tags": Immutable.List [],
-                                        },
-                                        "rawDescription": "",
-                                        "description": Immutable.List [],
-                                        "opened": false,
-                                        "id": 38,
-                                        "nestingLevel": 2,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    inTableEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                    selectedTableCellId={null}
-                                  >
-                                    <div />
-                                  </HeaderContent>
-                                </Connect(HeaderContent)>
-                              </div>
-                            </Motion>
-                          </Header>
-                        </Connect(Header)>
-                        <Connect(Header)
-                          color="rgba(38, 143, 214, 1)"
-                          hasContent={true}
-                          header={
-                            Immutable.Map {
-                              "titleLine": Immutable.Map {
-                                "title": Immutable.List [
-                                  Immutable.Map {
-                                    "type": "text",
-                                    "contents": "Another top level header",
-                                  },
-                                ],
-                                "rawTitle": "Another top level header",
-                                "todoKeyword": undefined,
-                                "tags": Immutable.List [],
-                              },
-                              "rawDescription": "Some description content",
-                              "description": Immutable.List [
-                                Immutable.Map {
-                                  "type": "text",
-                                  "contents": "Some description content",
-                                },
-                              ],
-                              "opened": false,
-                              "id": 39,
-                              "nestingLevel": 1,
-                              "planningItems": Immutable.List [],
-                              "propertyListItems": Immutable.List [],
-                            }
-                          }
-                          isSelected={false}
-                          key="39"
-                          onRef={[Function]}
-                        >
-                          <Header
-                            base={
-                              Object {
-                                "activatePopup": [Function],
-                                "clearModalStack": [Function],
-                                "closePopup": [Function],
-                                "hideLoadingMessage": [Function],
-                                "loadStaticFile": [Function],
-                                "popModalPage": [Function],
-                                "pushModalPage": [Function],
-                                "restoreBaseSettings": [Function],
-                                "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                "setAgendaDefaultDeadlineDelayValue": [Function],
-                                "setBulletStyle": [Function],
-                                "setCustomKeybinding": [Function],
-                                "setDisappearingLoadingMessage": [Function],
-                                "setFontSize": [Function],
-                                "setHasUnseenChangelog": [Function],
-                                "setIsLoading": [Function],
-                                "setLastSeenChangelogHeader": [Function],
-                                "setLastViewedFile": [Function],
-                                "setLoadingMessage": [Function],
-                                "setShouldLiveSync": [Function],
-                                "setShouldStoreSettingsInSyncBackend": [Function],
-                                "setShouldTapTodoToAdvance": [Function],
-                                "unloadStaticFile": [Function],
-                              }
-                            }
-                            color="rgba(38, 143, 214, 1)"
-                            focusedHeader={null}
-                            hasContent={true}
-                            header={
-                              Immutable.Map {
-                                "titleLine": Immutable.Map {
-                                  "title": Immutable.List [
-                                    Immutable.Map {
-                                      "type": "text",
-                                      "contents": "Another top level header",
-                                    },
-                                  ],
-                                  "rawTitle": "Another top level header",
-                                  "todoKeyword": undefined,
-                                  "tags": Immutable.List [],
-                                },
-                                "rawDescription": "Some description content",
-                                "description": Immutable.List [
-                                  Immutable.Map {
-                                    "type": "text",
-                                    "contents": "Some description content",
-                                  },
-                                ],
-                                "opened": false,
-                                "id": 39,
-                                "nestingLevel": 1,
-                                "planningItems": Immutable.List [],
-                                "propertyListItems": Immutable.List [],
-                              }
-                            }
-                            inEditMode={false}
-                            isFocused={false}
-                            isSelected={false}
-                            onRef={[Function]}
-                            org={
-                              Object {
-                                "addHeader": [Function],
-                                "addHeaderAndEdit": [Function],
-                                "addNewPlanningItem": [Function],
-                                "addNewTableColumn": [Function],
-                                "addNewTableRow": [Function],
-                                "advanceCheckboxState": [Function],
-                                "advanceTodoState": [Function],
-                                "applyOpennessState": [Function],
-                                "clearPendingCapture": [Function],
-                                "displayFile": [Function],
-                                "enterEditMode": [Function],
-                                "exitEditMode": [Function],
-                                "focusHeader": [Function],
-                                "insertCapture": [Function],
-                                "insertPendingCapture": [Function],
-                                "moveHeaderDown": [Function],
-                                "moveHeaderLeft": [Function],
-                                "moveHeaderRight": [Function],
-                                "moveHeaderUp": [Function],
-                                "moveSubtreeLeft": [Function],
-                                "moveSubtreeRight": [Function],
-                                "moveTableColumnLeft": [Function],
-                                "moveTableColumnRight": [Function],
-                                "moveTableRowDown": [Function],
-                                "moveTableRowUp": [Function],
-                                "noOp": [Function],
-                                "openHeader": [Function],
-                                "removeHeader": [Function],
-                                "removeTableColumn": [Function],
-                                "removeTableRow": [Function],
-                                "reorderPropertyList": [Function],
-                                "reorderTags": [Function],
-                                "selectHeader": [Function],
-                                "selectHeaderAndOpenParents": [Function],
-                                "selectNextSiblingHeader": [Function],
-                                "selectNextVisibleHeader": [Function],
-                                "selectPreviousVisibleHeader": [Function],
-                                "setDirty": [Function],
-                                "setHeaderTags": [Function],
-                                "setLastSyncAt": [Function],
-                                "setOrgFileErrorMessage": [Function],
-                                "setSelectedTableCellId": [Function],
-                                "stopDisplayingFile": [Function],
-                                "sync": [Function],
-                                "toggleHeaderOpened": [Function],
-                                "unfocusHeader": [Function],
-                                "updateHeaderDescription": [Function],
-                                "updateHeaderTitle": [Function],
-                                "updatePlanningItemTimestamp": [Function],
-                                "updatePropertyListItems": [Function],
-                                "updateTableCellValue": [Function],
-                                "updateTimestampWithId": [Function],
-                              }
-                            }
-                          >
-                            <Motion
-                              onRest={[Function]}
-                              style={
-                                Object {
-                                  "heightFactor": 1,
-                                  "marginLeft": Object {
-                                    "damping": 26,
-                                    "precision": 0.01,
-                                    "stiffness": 300,
-                                    "val": 0,
-                                  },
-                                  "paddingLeft": 20,
-                                }
-                              }
-                            >
-                              <div
-                                className="header"
-                                onClick={[Function]}
-                                onMouseDown={[Function]}
-                                onMouseMove={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseUp={[Function]}
-                                onTouchCancel={[Function]}
-                                onTouchEnd={[Function]}
-                                onTouchMove={[Function]}
-                                onTouchStart={[Function]}
-                                style={
-                                  Object {
-                                    "marginLeft": 0,
-                                    "paddingLeft": 20,
-                                  }
-                                }
-                              >
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": 0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="left-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": 0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": -0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="right-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": -0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <div
-                                  className="header__bullet"
-                                  style={
-                                    Object {
-                                      "color": "rgba(38, 143, 214, 1)",
-                                      "marginLeft": -16,
-                                    }
-                                  }
-                                >
-                                  *
-                                </div>
-                                <Connect(TitleLine)
-                                  color="rgba(38, 143, 214, 1)"
-                                  hasContent={true}
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "Another top level header",
-                                          },
-                                        ],
-                                        "rawTitle": "Another top level header",
-                                        "todoKeyword": undefined,
-                                        "tags": Immutable.List [],
-                                      },
-                                      "rawDescription": "Some description content",
-                                      "description": Immutable.List [
-                                        Immutable.Map {
-                                          "type": "text",
-                                          "contents": "Some description content",
-                                        },
-                                      ],
-                                      "opened": false,
-                                      "id": 39,
-                                      "nestingLevel": 1,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                  isSelected={false}
-                                >
-                                  <TitleLine
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    color="rgba(38, 143, 214, 1)"
-                                    hasContent={true}
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "Another top level header",
-                                            },
-                                          ],
-                                          "rawTitle": "Another top level header",
-                                          "todoKeyword": undefined,
-                                          "tags": Immutable.List [],
-                                        },
-                                        "rawDescription": "Some description content",
-                                        "description": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "Some description content",
-                                          },
-                                        ],
-                                        "opened": false,
-                                        "id": 39,
-                                        "nestingLevel": 1,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                  >
-                                    <div
-                                      className="title-line"
-                                      onClick={[Function]}
-                                      style={
-                                        Object {
-                                          "width": 0,
-                                        }
-                                      }
-                                    >
-                                      <div>
-                                        <span
-                                          style={
-                                            Object {
-                                              "color": "rgba(38, 143, 214, 1)",
-                                              "wordBreak": "break-word",
-                                            }
-                                          }
-                                        >
-                                          <_default
-                                            parts={
-                                              Immutable.List [
-                                                Immutable.Map {
-                                                  "type": "text",
-                                                  "contents": "Another top level header",
-                                                },
-                                              ]
-                                            }
-                                            subPartDataAndHandlers={
-                                              Object {
-                                                "onTimestampClick": [Function],
-                                                "shouldDisableActions": undefined,
-                                              }
-                                            }
-                                          >
-                                            <span>
-                                              Another top level header
-                                            </span>
-                                          </_default>
-                                          ...
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </TitleLine>
-                                </Connect(TitleLine)>
-                                <UnmountClosed
-                                  isOpened={false}
-                                  springConfig={
-                                    Object {
-                                      "stiffness": 300,
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "marginRight": -0,
-                                    }
-                                  }
-                                />
-                                <Connect(HeaderContent)
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "Another top level header",
-                                          },
-                                        ],
-                                        "rawTitle": "Another top level header",
-                                        "todoKeyword": undefined,
-                                        "tags": Immutable.List [],
-                                      },
-                                      "rawDescription": "Some description content",
-                                      "description": Immutable.List [
-                                        Immutable.Map {
-                                          "type": "text",
-                                          "contents": "Some description content",
-                                        },
-                                      ],
-                                      "opened": false,
-                                      "id": 39,
-                                      "nestingLevel": 1,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                >
-                                  <HeaderContent
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "Another top level header",
-                                            },
-                                          ],
-                                          "rawTitle": "Another top level header",
-                                          "todoKeyword": undefined,
-                                          "tags": Immutable.List [],
-                                        },
-                                        "rawDescription": "Some description content",
-                                        "description": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "Some description content",
-                                          },
-                                        ],
-                                        "opened": false,
-                                        "id": 39,
-                                        "nestingLevel": 1,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    inTableEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                    selectedTableCellId={null}
-                                  >
-                                    <div />
-                                  </HeaderContent>
-                                </Connect(HeaderContent)>
-                              </div>
-                            </Motion>
-                          </Header>
-                        </Connect(Header)>
-                        <Connect(Header)
-                          color="rgba(38, 143, 214, 1)"
-                          hasContent={false}
-                          header={
-                            Immutable.Map {
-                              "titleLine": Immutable.Map {
-                                "title": Immutable.List [
-                                  Immutable.Map {
-                                    "type": "text",
-                                    "contents": "A header with tags                                              ",
-                                  },
-                                ],
-                                "rawTitle": "A header with tags                                              ",
-                                "todoKeyword": undefined,
-                                "tags": Immutable.List [
-                                  "tag1",
-                                  "tag2",
-                                ],
-                              },
-                              "rawDescription": "",
-                              "description": Immutable.List [],
-                              "opened": false,
-                              "id": 40,
-                              "nestingLevel": 1,
-                              "planningItems": Immutable.List [],
-                              "propertyListItems": Immutable.List [],
-                            }
-                          }
-                          isSelected={false}
-                          key="40"
-                          onRef={[Function]}
-                        >
-                          <Header
-                            base={
-                              Object {
-                                "activatePopup": [Function],
-                                "clearModalStack": [Function],
-                                "closePopup": [Function],
-                                "hideLoadingMessage": [Function],
-                                "loadStaticFile": [Function],
-                                "popModalPage": [Function],
-                                "pushModalPage": [Function],
-                                "restoreBaseSettings": [Function],
-                                "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                "setAgendaDefaultDeadlineDelayValue": [Function],
-                                "setBulletStyle": [Function],
-                                "setCustomKeybinding": [Function],
-                                "setDisappearingLoadingMessage": [Function],
-                                "setFontSize": [Function],
-                                "setHasUnseenChangelog": [Function],
-                                "setIsLoading": [Function],
-                                "setLastSeenChangelogHeader": [Function],
-                                "setLastViewedFile": [Function],
-                                "setLoadingMessage": [Function],
-                                "setShouldLiveSync": [Function],
-                                "setShouldStoreSettingsInSyncBackend": [Function],
-                                "setShouldTapTodoToAdvance": [Function],
-                                "unloadStaticFile": [Function],
-                              }
-                            }
-                            color="rgba(38, 143, 214, 1)"
-                            focusedHeader={null}
-                            hasContent={false}
-                            header={
-                              Immutable.Map {
-                                "titleLine": Immutable.Map {
-                                  "title": Immutable.List [
-                                    Immutable.Map {
-                                      "type": "text",
-                                      "contents": "A header with tags                                              ",
-                                    },
-                                  ],
-                                  "rawTitle": "A header with tags                                              ",
-                                  "todoKeyword": undefined,
-                                  "tags": Immutable.List [
-                                    "tag1",
-                                    "tag2",
-                                  ],
-                                },
-                                "rawDescription": "",
-                                "description": Immutable.List [],
-                                "opened": false,
-                                "id": 40,
-                                "nestingLevel": 1,
-                                "planningItems": Immutable.List [],
-                                "propertyListItems": Immutable.List [],
-                              }
-                            }
-                            inEditMode={false}
-                            isFocused={false}
-                            isSelected={false}
-                            onRef={[Function]}
-                            org={
-                              Object {
-                                "addHeader": [Function],
-                                "addHeaderAndEdit": [Function],
-                                "addNewPlanningItem": [Function],
-                                "addNewTableColumn": [Function],
-                                "addNewTableRow": [Function],
-                                "advanceCheckboxState": [Function],
-                                "advanceTodoState": [Function],
-                                "applyOpennessState": [Function],
-                                "clearPendingCapture": [Function],
-                                "displayFile": [Function],
-                                "enterEditMode": [Function],
-                                "exitEditMode": [Function],
-                                "focusHeader": [Function],
-                                "insertCapture": [Function],
-                                "insertPendingCapture": [Function],
-                                "moveHeaderDown": [Function],
-                                "moveHeaderLeft": [Function],
-                                "moveHeaderRight": [Function],
-                                "moveHeaderUp": [Function],
-                                "moveSubtreeLeft": [Function],
-                                "moveSubtreeRight": [Function],
-                                "moveTableColumnLeft": [Function],
-                                "moveTableColumnRight": [Function],
-                                "moveTableRowDown": [Function],
-                                "moveTableRowUp": [Function],
-                                "noOp": [Function],
-                                "openHeader": [Function],
-                                "removeHeader": [Function],
-                                "removeTableColumn": [Function],
-                                "removeTableRow": [Function],
-                                "reorderPropertyList": [Function],
-                                "reorderTags": [Function],
-                                "selectHeader": [Function],
-                                "selectHeaderAndOpenParents": [Function],
-                                "selectNextSiblingHeader": [Function],
-                                "selectNextVisibleHeader": [Function],
-                                "selectPreviousVisibleHeader": [Function],
-                                "setDirty": [Function],
-                                "setHeaderTags": [Function],
-                                "setLastSyncAt": [Function],
-                                "setOrgFileErrorMessage": [Function],
-                                "setSelectedTableCellId": [Function],
-                                "stopDisplayingFile": [Function],
-                                "sync": [Function],
-                                "toggleHeaderOpened": [Function],
-                                "unfocusHeader": [Function],
-                                "updateHeaderDescription": [Function],
-                                "updateHeaderTitle": [Function],
-                                "updatePlanningItemTimestamp": [Function],
-                                "updatePropertyListItems": [Function],
-                                "updateTableCellValue": [Function],
-                                "updateTimestampWithId": [Function],
-                              }
-                            }
-                          >
-                            <Motion
-                              onRest={[Function]}
-                              style={
-                                Object {
-                                  "heightFactor": 1,
-                                  "marginLeft": Object {
-                                    "damping": 26,
-                                    "precision": 0.01,
-                                    "stiffness": 300,
-                                    "val": 0,
-                                  },
-                                  "paddingLeft": 20,
-                                }
-                              }
-                            >
-                              <div
-                                className="header"
-                                onClick={[Function]}
-                                onMouseDown={[Function]}
-                                onMouseMove={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseUp={[Function]}
-                                onTouchCancel={[Function]}
-                                onTouchEnd={[Function]}
-                                onTouchMove={[Function]}
-                                onTouchStart={[Function]}
-                                style={
-                                  Object {
-                                    "marginLeft": 0,
-                                    "paddingLeft": 20,
-                                  }
-                                }
-                              >
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": 0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="left-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": 0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": -0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="right-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": -0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <div
-                                  className="header__bullet"
-                                  style={
-                                    Object {
-                                      "color": "rgba(38, 143, 214, 1)",
-                                      "marginLeft": -16,
-                                    }
-                                  }
-                                >
-                                  *
-                                </div>
-                                <Connect(TitleLine)
-                                  color="rgba(38, 143, 214, 1)"
-                                  hasContent={false}
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "A header with tags                                              ",
-                                          },
-                                        ],
-                                        "rawTitle": "A header with tags                                              ",
-                                        "todoKeyword": undefined,
-                                        "tags": Immutable.List [
-                                          "tag1",
-                                          "tag2",
-                                        ],
-                                      },
-                                      "rawDescription": "",
-                                      "description": Immutable.List [],
-                                      "opened": false,
-                                      "id": 40,
-                                      "nestingLevel": 1,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                  isSelected={false}
-                                >
-                                  <TitleLine
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    color="rgba(38, 143, 214, 1)"
-                                    hasContent={false}
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "A header with tags                                              ",
-                                            },
-                                          ],
-                                          "rawTitle": "A header with tags                                              ",
-                                          "todoKeyword": undefined,
-                                          "tags": Immutable.List [
-                                            "tag1",
-                                            "tag2",
-                                          ],
-                                        },
-                                        "rawDescription": "",
-                                        "description": Immutable.List [],
-                                        "opened": false,
-                                        "id": 40,
-                                        "nestingLevel": 1,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                  >
-                                    <div
-                                      className="title-line"
-                                      onClick={[Function]}
-                                      style={
-                                        Object {
-                                          "width": 0,
-                                        }
-                                      }
-                                    >
-                                      <div>
-                                        <span
-                                          style={
-                                            Object {
-                                              "color": "rgba(38, 143, 214, 1)",
-                                              "wordBreak": "break-word",
-                                            }
-                                          }
-                                        >
-                                          <_default
-                                            parts={
-                                              Immutable.List [
-                                                Immutable.Map {
-                                                  "type": "text",
-                                                  "contents": "A header with tags                                              ",
-                                                },
-                                              ]
-                                            }
-                                            subPartDataAndHandlers={
-                                              Object {
-                                                "onTimestampClick": [Function],
-                                                "shouldDisableActions": undefined,
-                                              }
-                                            }
-                                          >
-                                            <span>
-                                              A header with tags                                              
-                                            </span>
-                                          </_default>
-                                        </span>
-                                        <div>
-                                          <div
-                                            className="header-tag"
-                                            key="tag1"
-                                          >
-                                            tag1
-                                          </div>
-                                          <div
-                                            className="header-tag"
-                                            key="tag2"
-                                          >
-                                            tag2
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </TitleLine>
-                                </Connect(TitleLine)>
-                                <UnmountClosed
-                                  isOpened={false}
-                                  springConfig={
-                                    Object {
-                                      "stiffness": 300,
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "marginRight": -0,
-                                    }
-                                  }
-                                />
-                                <Connect(HeaderContent)
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "A header with tags                                              ",
-                                          },
-                                        ],
-                                        "rawTitle": "A header with tags                                              ",
-                                        "todoKeyword": undefined,
-                                        "tags": Immutable.List [
-                                          "tag1",
-                                          "tag2",
-                                        ],
-                                      },
-                                      "rawDescription": "",
-                                      "description": Immutable.List [],
-                                      "opened": false,
-                                      "id": 40,
-                                      "nestingLevel": 1,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                >
-                                  <HeaderContent
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "A header with tags                                              ",
-                                            },
-                                          ],
-                                          "rawTitle": "A header with tags                                              ",
-                                          "todoKeyword": undefined,
-                                          "tags": Immutable.List [
-                                            "tag1",
-                                            "tag2",
-                                          ],
-                                        },
-                                        "rawDescription": "",
-                                        "description": Immutable.List [],
-                                        "opened": false,
-                                        "id": 40,
-                                        "nestingLevel": 1,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    inTableEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                    selectedTableCellId={null}
-                                  >
-                                    <div />
-                                  </HeaderContent>
-                                </Connect(HeaderContent)>
-                              </div>
-                            </Motion>
-                          </Header>
-                        </Connect(Header)>
-                        <Connect(Header)
-                          color="rgba(38, 143, 214, 1)"
-                          hasContent={false}
-                          header={
-                            Immutable.Map {
-                              "titleLine": Immutable.Map {
-                                "title": Immutable.List [
-                                  Immutable.Map {
-                                    "type": "text",
-                                    "contents": "A header with ",
-                                  },
-                                  Immutable.Map {
-                                    "id": 41,
-                                    "type": "link",
-                                    "contents": Immutable.Map {
-                                      "uri": "https://google.com",
-                                      "title": "a link",
-                                    },
-                                  },
-                                ],
-                                "rawTitle": "A header with [[https://google.com][a link]]",
-                                "todoKeyword": undefined,
-                                "tags": Immutable.List [],
-                              },
-                              "rawDescription": "",
-                              "description": Immutable.List [],
-                              "opened": false,
-                              "id": 42,
-                              "nestingLevel": 1,
-                              "planningItems": Immutable.List [],
-                              "propertyListItems": Immutable.List [],
-                            }
-                          }
-                          isSelected={false}
-                          key="42"
-                          onRef={[Function]}
-                        >
-                          <Header
-                            base={
-                              Object {
-                                "activatePopup": [Function],
-                                "clearModalStack": [Function],
-                                "closePopup": [Function],
-                                "hideLoadingMessage": [Function],
-                                "loadStaticFile": [Function],
-                                "popModalPage": [Function],
-                                "pushModalPage": [Function],
-                                "restoreBaseSettings": [Function],
-                                "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                "setAgendaDefaultDeadlineDelayValue": [Function],
-                                "setBulletStyle": [Function],
-                                "setCustomKeybinding": [Function],
-                                "setDisappearingLoadingMessage": [Function],
-                                "setFontSize": [Function],
-                                "setHasUnseenChangelog": [Function],
-                                "setIsLoading": [Function],
-                                "setLastSeenChangelogHeader": [Function],
-                                "setLastViewedFile": [Function],
-                                "setLoadingMessage": [Function],
-                                "setShouldLiveSync": [Function],
-                                "setShouldStoreSettingsInSyncBackend": [Function],
-                                "setShouldTapTodoToAdvance": [Function],
-                                "unloadStaticFile": [Function],
-                              }
-                            }
-                            color="rgba(38, 143, 214, 1)"
-                            focusedHeader={null}
-                            hasContent={false}
-                            header={
-                              Immutable.Map {
-                                "titleLine": Immutable.Map {
-                                  "title": Immutable.List [
-                                    Immutable.Map {
-                                      "type": "text",
-                                      "contents": "A header with ",
-                                    },
-                                    Immutable.Map {
-                                      "id": 41,
-                                      "type": "link",
-                                      "contents": Immutable.Map {
-                                        "uri": "https://google.com",
-                                        "title": "a link",
-                                      },
-                                    },
-                                  ],
-                                  "rawTitle": "A header with [[https://google.com][a link]]",
-                                  "todoKeyword": undefined,
-                                  "tags": Immutable.List [],
-                                },
-                                "rawDescription": "",
-                                "description": Immutable.List [],
-                                "opened": false,
-                                "id": 42,
-                                "nestingLevel": 1,
-                                "planningItems": Immutable.List [],
-                                "propertyListItems": Immutable.List [],
-                              }
-                            }
-                            inEditMode={false}
-                            isFocused={false}
-                            isSelected={false}
-                            onRef={[Function]}
-                            org={
-                              Object {
-                                "addHeader": [Function],
-                                "addHeaderAndEdit": [Function],
-                                "addNewPlanningItem": [Function],
-                                "addNewTableColumn": [Function],
-                                "addNewTableRow": [Function],
-                                "advanceCheckboxState": [Function],
-                                "advanceTodoState": [Function],
-                                "applyOpennessState": [Function],
-                                "clearPendingCapture": [Function],
-                                "displayFile": [Function],
-                                "enterEditMode": [Function],
-                                "exitEditMode": [Function],
-                                "focusHeader": [Function],
-                                "insertCapture": [Function],
-                                "insertPendingCapture": [Function],
-                                "moveHeaderDown": [Function],
-                                "moveHeaderLeft": [Function],
-                                "moveHeaderRight": [Function],
-                                "moveHeaderUp": [Function],
-                                "moveSubtreeLeft": [Function],
-                                "moveSubtreeRight": [Function],
-                                "moveTableColumnLeft": [Function],
-                                "moveTableColumnRight": [Function],
-                                "moveTableRowDown": [Function],
-                                "moveTableRowUp": [Function],
-                                "noOp": [Function],
-                                "openHeader": [Function],
-                                "removeHeader": [Function],
-                                "removeTableColumn": [Function],
-                                "removeTableRow": [Function],
-                                "reorderPropertyList": [Function],
-                                "reorderTags": [Function],
-                                "selectHeader": [Function],
-                                "selectHeaderAndOpenParents": [Function],
-                                "selectNextSiblingHeader": [Function],
-                                "selectNextVisibleHeader": [Function],
-                                "selectPreviousVisibleHeader": [Function],
-                                "setDirty": [Function],
-                                "setHeaderTags": [Function],
-                                "setLastSyncAt": [Function],
-                                "setOrgFileErrorMessage": [Function],
-                                "setSelectedTableCellId": [Function],
-                                "stopDisplayingFile": [Function],
-                                "sync": [Function],
-                                "toggleHeaderOpened": [Function],
-                                "unfocusHeader": [Function],
-                                "updateHeaderDescription": [Function],
-                                "updateHeaderTitle": [Function],
-                                "updatePlanningItemTimestamp": [Function],
-                                "updatePropertyListItems": [Function],
-                                "updateTableCellValue": [Function],
-                                "updateTimestampWithId": [Function],
-                              }
-                            }
-                          >
-                            <Motion
-                              onRest={[Function]}
-                              style={
-                                Object {
-                                  "heightFactor": 1,
-                                  "marginLeft": Object {
-                                    "damping": 26,
-                                    "precision": 0.01,
-                                    "stiffness": 300,
-                                    "val": 0,
-                                  },
-                                  "paddingLeft": 20,
-                                }
-                              }
-                            >
-                              <div
-                                className="header"
-                                onClick={[Function]}
-                                onMouseDown={[Function]}
-                                onMouseMove={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseUp={[Function]}
-                                onTouchCancel={[Function]}
-                                onTouchEnd={[Function]}
-                                onTouchMove={[Function]}
-                                onTouchStart={[Function]}
-                                style={
-                                  Object {
-                                    "marginLeft": 0,
-                                    "paddingLeft": 20,
-                                  }
-                                }
-                              >
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": 0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="left-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": 0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": -0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="right-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": -0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <div
-                                  className="header__bullet"
-                                  style={
-                                    Object {
-                                      "color": "rgba(38, 143, 214, 1)",
-                                      "marginLeft": -16,
-                                    }
-                                  }
-                                >
-                                  *
-                                </div>
-                                <Connect(TitleLine)
-                                  color="rgba(38, 143, 214, 1)"
-                                  hasContent={false}
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "A header with ",
-                                          },
-                                          Immutable.Map {
-                                            "id": 41,
-                                            "type": "link",
-                                            "contents": Immutable.Map {
-                                              "uri": "https://google.com",
-                                              "title": "a link",
-                                            },
-                                          },
-                                        ],
-                                        "rawTitle": "A header with [[https://google.com][a link]]",
-                                        "todoKeyword": undefined,
-                                        "tags": Immutable.List [],
-                                      },
-                                      "rawDescription": "",
-                                      "description": Immutable.List [],
-                                      "opened": false,
-                                      "id": 42,
-                                      "nestingLevel": 1,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                  isSelected={false}
-                                >
-                                  <TitleLine
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    color="rgba(38, 143, 214, 1)"
-                                    hasContent={false}
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "A header with ",
-                                            },
-                                            Immutable.Map {
-                                              "id": 41,
-                                              "type": "link",
-                                              "contents": Immutable.Map {
-                                                "uri": "https://google.com",
-                                                "title": "a link",
-                                              },
-                                            },
-                                          ],
-                                          "rawTitle": "A header with [[https://google.com][a link]]",
-                                          "todoKeyword": undefined,
-                                          "tags": Immutable.List [],
-                                        },
-                                        "rawDescription": "",
-                                        "description": Immutable.List [],
-                                        "opened": false,
-                                        "id": 42,
-                                        "nestingLevel": 1,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                  >
-                                    <div
-                                      className="title-line"
-                                      onClick={[Function]}
-                                      style={
-                                        Object {
-                                          "width": 0,
-                                        }
-                                      }
-                                    >
-                                      <div>
-                                        <span
-                                          style={
-                                            Object {
-                                              "color": "rgba(38, 143, 214, 1)",
-                                              "wordBreak": "break-word",
-                                            }
-                                          }
-                                        >
-                                          <_default
-                                            parts={
-                                              Immutable.List [
-                                                Immutable.Map {
-                                                  "type": "text",
-                                                  "contents": "A header with ",
-                                                },
-                                                Immutable.Map {
-                                                  "id": 41,
-                                                  "type": "link",
-                                                  "contents": Immutable.Map {
-                                                    "uri": "https://google.com",
-                                                    "title": "a link",
-                                                  },
-                                                },
-                                              ]
-                                            }
-                                            subPartDataAndHandlers={
-                                              Object {
-                                                "onTimestampClick": [Function],
-                                                "shouldDisableActions": undefined,
-                                              }
-                                            }
-                                          >
-                                            <span>
-                                              A header with 
-                                              <a
-                                                href="https://google.com"
-                                                key="41"
-                                                rel="noopener noreferrer"
-                                                target="_blank"
-                                              >
-                                                a link
-                                              </a>
-                                            </span>
-                                          </_default>
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </TitleLine>
-                                </Connect(TitleLine)>
-                                <UnmountClosed
-                                  isOpened={false}
-                                  springConfig={
-                                    Object {
-                                      "stiffness": 300,
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "marginRight": -0,
-                                    }
-                                  }
-                                />
-                                <Connect(HeaderContent)
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "A header with ",
-                                          },
-                                          Immutable.Map {
-                                            "id": 41,
-                                            "type": "link",
-                                            "contents": Immutable.Map {
-                                              "uri": "https://google.com",
-                                              "title": "a link",
-                                            },
-                                          },
-                                        ],
-                                        "rawTitle": "A header with [[https://google.com][a link]]",
-                                        "todoKeyword": undefined,
-                                        "tags": Immutable.List [],
-                                      },
-                                      "rawDescription": "",
-                                      "description": Immutable.List [],
-                                      "opened": false,
-                                      "id": 42,
-                                      "nestingLevel": 1,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                >
-                                  <HeaderContent
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "A header with ",
-                                            },
-                                            Immutable.Map {
-                                              "id": 41,
-                                              "type": "link",
-                                              "contents": Immutable.Map {
-                                                "uri": "https://google.com",
-                                                "title": "a link",
-                                              },
-                                            },
-                                          ],
-                                          "rawTitle": "A header with [[https://google.com][a link]]",
-                                          "todoKeyword": undefined,
-                                          "tags": Immutable.List [],
-                                        },
-                                        "rawDescription": "",
-                                        "description": Immutable.List [],
-                                        "opened": false,
-                                        "id": 42,
-                                        "nestingLevel": 1,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    inTableEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                    selectedTableCellId={null}
-                                  >
-                                    <div />
-                                  </HeaderContent>
-                                </Connect(HeaderContent)>
-                              </div>
-                            </Motion>
-                          </Header>
-                        </Connect(Header)>
-                      </div>
-                    </HeaderList>
-                  </Connect(HeaderList)>
-                  <Connect(ActionDrawer)>
-                    <ActionDrawer
-                      base={
-                        Object {
-                          "activatePopup": [Function],
-                          "clearModalStack": [Function],
-                          "closePopup": [Function],
-                          "hideLoadingMessage": [Function],
-                          "loadStaticFile": [Function],
-                          "popModalPage": [Function],
-                          "pushModalPage": [Function],
-                          "restoreBaseSettings": [Function],
-                          "setAgendaDefaultDeadlineDelayUnit": [Function],
-                          "setAgendaDefaultDeadlineDelayValue": [Function],
-                          "setBulletStyle": [Function],
-                          "setCustomKeybinding": [Function],
-                          "setDisappearingLoadingMessage": [Function],
-                          "setFontSize": [Function],
-                          "setHasUnseenChangelog": [Function],
-                          "setIsLoading": [Function],
-                          "setLastSeenChangelogHeader": [Function],
-                          "setLastViewedFile": [Function],
-                          "setLoadingMessage": [Function],
-                          "setShouldLiveSync": [Function],
-                          "setShouldStoreSettingsInSyncBackend": [Function],
-                          "setShouldTapTodoToAdvance": [Function],
-                          "unloadStaticFile": [Function],
-                        }
-                      }
-                      capture={
-                        Object {
-                          "addNewEmptyCaptureTemplate": [Function],
-                          "addNewTemplateHeaderPath": [Function],
-                          "addNewTemplateOrgFileAvailability": [Function],
-                          "deleteTemplate": [Function],
-                          "removeTemplateHeaderPath": [Function],
-                          "removeTemplateOrgFileAvailability": [Function],
-                          "reorderCaptureTemplate": [Function],
-                          "restoreCaptureSettings": [Function],
-                          "updateTemplateFieldPathValue": [Function],
-                        }
-                      }
-                      captureTemplates={Array []}
-                      inEditMode={false}
-                      isFocusedHeaderActive={false}
-                      org={
-                        Object {
-                          "addHeader": [Function],
-                          "addHeaderAndEdit": [Function],
-                          "addNewPlanningItem": [Function],
-                          "addNewTableColumn": [Function],
-                          "addNewTableRow": [Function],
-                          "advanceCheckboxState": [Function],
-                          "advanceTodoState": [Function],
-                          "applyOpennessState": [Function],
-                          "clearPendingCapture": [Function],
-                          "displayFile": [Function],
-                          "enterEditMode": [Function],
-                          "exitEditMode": [Function],
-                          "focusHeader": [Function],
-                          "insertCapture": [Function],
-                          "insertPendingCapture": [Function],
-                          "moveHeaderDown": [Function],
-                          "moveHeaderLeft": [Function],
-                          "moveHeaderRight": [Function],
-                          "moveHeaderUp": [Function],
-                          "moveSubtreeLeft": [Function],
-                          "moveSubtreeRight": [Function],
-                          "moveTableColumnLeft": [Function],
-                          "moveTableColumnRight": [Function],
-                          "moveTableRowDown": [Function],
-                          "moveTableRowUp": [Function],
-                          "noOp": [Function],
-                          "openHeader": [Function],
-                          "removeHeader": [Function],
-                          "removeTableColumn": [Function],
-                          "removeTableRow": [Function],
-                          "reorderPropertyList": [Function],
-                          "reorderTags": [Function],
-                          "selectHeader": [Function],
-                          "selectHeaderAndOpenParents": [Function],
-                          "selectNextSiblingHeader": [Function],
-                          "selectNextVisibleHeader": [Function],
-                          "selectPreviousVisibleHeader": [Function],
-                          "setDirty": [Function],
-                          "setHeaderTags": [Function],
-                          "setLastSyncAt": [Function],
-                          "setOrgFileErrorMessage": [Function],
-                          "setSelectedTableCellId": [Function],
-                          "stopDisplayingFile": [Function],
-                          "sync": [Function],
-                          "toggleHeaderOpened": [Function],
-                          "unfocusHeader": [Function],
-                          "updateHeaderDescription": [Function],
-                          "updateHeaderTitle": [Function],
-                          "updatePlanningItemTimestamp": [Function],
-                          "updatePropertyListItems": [Function],
-                          "updateTableCellValue": [Function],
-                          "updateTimestampWithId": [Function],
-                        }
-                      }
-                      path="/some/test/file"
-                      selectedHeaderId={35}
-                      selectedTableCellId={null}
-                    >
-                      <div
-                        className="action-drawer-container nice-scroll"
-                      >
-                        <ActionButton
-                          iconName="cloud"
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "opacity": 1,
-                            }
-                          }
-                          subIconName="sync-alt"
-                          tooltip="Sync changes"
-                        >
-                          <button
-                            className="btn btn--circle action-drawer__btn fas fa-lg fa-cloud action-drawer__btn--with-sub-icon"
-                            onClick={[Function]}
-                            style={
-                              Object {
-                                "opacity": 1,
-                              }
-                            }
-                            title="Sync changes"
-                          >
-                            <i
-                              className="fas fa-xs fa-sync-alt action-drawer__btn__sub-icon"
-                            />
-                          </button>
-                        </ActionButton>
-                        <Motion
-                          style={
-                            Object {
-                              "bottomRowYOffset": Object {
-                                "damping": 26,
-                                "precision": 0.01,
-                                "stiffness": 300,
-                                "val": 0,
-                              },
-                              "centerXOffset": Object {
-                                "damping": 26,
-                                "precision": 0.01,
-                                "stiffness": 300,
-                                "val": 0,
-                              },
-                              "firstColumnXOffset": Object {
-                                "damping": 26,
-                                "precision": 0.01,
-                                "stiffness": 300,
-                                "val": 0,
-                              },
-                              "secondColumnXOffset": Object {
-                                "damping": 26,
-                                "precision": 0.01,
-                                "stiffness": 300,
-                                "val": 0,
-                              },
-                              "topRowYOffset": Object {
-                                "damping": 26,
-                                "precision": 0.01,
-                                "stiffness": 300,
-                                "val": 0,
-                              },
-                            }
-                          }
-                        >
-                          <div
-                            className="action-drawer__arrow-buttons-container"
-                            style={
-                              Object {
-                                "left": 0,
-                              }
-                            }
-                          >
-                            <ActionButton
-                              additionalClassName="action-drawer__arrow-button"
-                              iconName="arrow-up"
-                              isDisabled={false}
-                              onClick={[Function]}
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "boxShadow": "none",
-                                  "opacity": 1,
-                                }
-                              }
-                              subIconName={null}
-                              tooltip="Move header up"
-                            >
-                              <button
-                                className="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-arrow-up"
-                                onClick={[Function]}
-                                style={
-                                  Object {
-                                    "bottom": 0,
-                                    "boxShadow": "none",
-                                    "opacity": 1,
-                                  }
-                                }
-                                title="Move header up"
-                              />
-                            </ActionButton>
-                            <ActionButton
-                              additionalClassName="action-drawer__arrow-button"
-                              iconName="arrow-down"
-                              isDisabled={false}
-                              onClick={[Function]}
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "boxShadow": "none",
-                                  "opacity": 1,
-                                }
-                              }
-                              subIconName={null}
-                              tooltip="Move header down"
-                            >
-                              <button
-                                className="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-arrow-down"
-                                onClick={[Function]}
-                                style={
-                                  Object {
-                                    "bottom": 0,
-                                    "boxShadow": "none",
-                                    "opacity": 1,
-                                  }
-                                }
-                                title="Move header down"
-                              />
-                            </ActionButton>
-                            <ActionButton
-                              additionalClassName="action-drawer__arrow-button"
-                              iconName="arrow-left"
-                              isDisabled={false}
-                              onClick={[Function]}
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "boxShadow": "none",
-                                  "opacity": 1,
-                                  "right": 0,
-                                }
-                              }
-                              subIconName={null}
-                              tooltip="Move header left"
-                            >
-                              <button
-                                className="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-arrow-left"
-                                onClick={[Function]}
-                                style={
-                                  Object {
-                                    "bottom": 0,
-                                    "boxShadow": "none",
-                                    "opacity": 1,
-                                    "right": 0,
-                                  }
-                                }
-                                title="Move header left"
-                              />
-                            </ActionButton>
-                            <ActionButton
-                              additionalClassName="action-drawer__arrow-button"
-                              iconName="arrow-right"
-                              isDisabled={false}
-                              onClick={[Function]}
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "boxShadow": "none",
-                                  "left": 0,
-                                  "opacity": 1,
-                                }
-                              }
-                              subIconName={null}
-                              tooltip="Move header right"
-                            >
-                              <button
-                                className="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-arrow-right"
-                                onClick={[Function]}
-                                style={
-                                  Object {
-                                    "bottom": 0,
-                                    "boxShadow": "none",
-                                    "left": 0,
-                                    "opacity": 1,
-                                  }
-                                }
-                                title="Move header right"
-                              />
-                            </ActionButton>
-                            <ActionButton
-                              additionalClassName="action-drawer__arrow-button"
-                              iconName="chevron-left"
-                              isDisabled={false}
-                              onClick={[Function]}
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "boxShadow": "none",
-                                  "opacity": 1,
-                                  "right": 0,
-                                }
-                              }
-                              tooltip="Move entire subtree left"
-                            >
-                              <button
-                                className="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-chevron-left"
-                                onClick={[Function]}
-                                style={
-                                  Object {
-                                    "bottom": 0,
-                                    "boxShadow": "none",
-                                    "opacity": 1,
-                                    "right": 0,
-                                  }
-                                }
-                                title="Move entire subtree left"
-                              />
-                            </ActionButton>
-                            <ActionButton
-                              additionalClassName="action-drawer__arrow-button"
-                              iconName="chevron-right"
-                              isDisabled={false}
-                              onClick={[Function]}
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "boxShadow": "none",
-                                  "left": 0,
-                                  "opacity": 1,
-                                }
-                              }
-                              tooltip="Move entire subtree right"
-                            >
-                              <button
-                                className="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-chevron-right"
-                                onClick={[Function]}
-                                style={
-                                  Object {
-                                    "bottom": 0,
-                                    "boxShadow": "none",
-                                    "left": 0,
-                                    "opacity": 1,
-                                  }
-                                }
-                                title="Move entire subtree right"
-                              />
-                            </ActionButton>
-                            <ActionButton
-                              additionalClassName="action-drawer__main-arrow-button"
-                              iconName="arrows-alt"
-                              isDisabled={false}
-                              onClick={[Function]}
-                              onRef={
-                                Object {
-                                  "current": <button
-                                    class="btn btn--circle action-drawer__btn action-drawer__main-arrow-button fas fa-lg fa-arrows-alt"
-                                    style="opacity: 1;"
-                                    title="Show movement buttons"
-                                  />,
-                                }
-                              }
-                              style={
-                                Object {
-                                  "opacity": 1,
-                                }
-                              }
-                              subIconName={null}
-                              tooltip="Show movement buttons"
-                            >
-                              <button
-                                className="btn btn--circle action-drawer__btn action-drawer__main-arrow-button fas fa-lg fa-arrows-alt"
-                                onClick={[Function]}
-                                style={
-                                  Object {
-                                    "opacity": 1,
-                                  }
-                                }
-                                title="Show movement buttons"
-                              />
-                            </ActionButton>
-                          </div>
-                        </Motion>
-                        <ActionButton
-                          iconName="calendar-alt"
-                          isDisabled={false}
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "opacity": 1,
-                            }
-                          }
-                          tooltip="Show agenda"
-                        >
-                          <button
-                            className="btn btn--circle action-drawer__btn fas fa-lg fa-calendar-alt"
-                            onClick={[Function]}
-                            style={
-                              Object {
-                                "opacity": 1,
-                              }
-                            }
-                            title="Show agenda"
-                          />
-                        </ActionButton>
-                        <Motion
-                          style={
-                            Object {
-                              "bottom": Object {
-                                "damping": 26,
-                                "precision": 0.01,
-                                "stiffness": 300,
-                                "val": 0,
-                              },
-                            }
-                          }
-                        >
-                          <div
-                            className="action-drawer__capture-buttons-container"
-                          >
-                            <ActionButton
-                              iconName="list-ul"
-                              isDisabled={false}
-                              onClick={[Function]}
-                              style={
-                                Object {
-                                  "opacity": 1,
-                                  "position": "relative",
-                                  "zIndex": 1,
-                                }
-                              }
-                              tooltip="Show capture templates"
-                            >
-                              <button
-                                className="btn btn--circle action-drawer__btn fas fa-lg fa-list-ul"
-                                onClick={[Function]}
-                                style={
-                                  Object {
-                                    "opacity": 1,
-                                    "position": "relative",
-                                    "zIndex": 1,
-                                  }
-                                }
-                                title="Show capture templates"
-                              />
-                            </ActionButton>
-                          </div>
-                        </Motion>
-                      </div>
-                    </ActionDrawer>
-                  </Connect(ActionDrawer)>
+                  <div
+                    class="header-action-drawer__ff-click-catcher-container"
+                  >
+                    <div
+                      class="header-action-drawer__ff-click-catcher"
+                    />
+                    <i
+                      class="fas fa-pencil-alt fa-lg"
+                    />
+                  </div>
+                  <span
+                    class="header-action-drawer__separator"
+                  />
+                  <div
+                    class="header-action-drawer__ff-click-catcher-container"
+                  >
+                    <div
+                      class="header-action-drawer__ff-click-catcher"
+                    />
+                    <i
+                      class="fas fa-edit fa-lg"
+                    />
+                  </div>
+                  <span
+                    class="header-action-drawer__separator"
+                  />
+                  <div
+                    class="header-action-drawer__ff-click-catcher-container"
+                  >
+                    <div
+                      class="header-action-drawer__ff-click-catcher"
+                    />
+                    <i
+                      class="fas fa-tags fa-lg"
+                    />
+                  </div>
+                  <span
+                    class="header-action-drawer__separator"
+                  />
+                  <div
+                    class="header-action-drawer__ff-click-catcher-container"
+                  >
+                    <div
+                      class="header-action-drawer__ff-click-catcher"
+                    />
+                    <i
+                      class="fas fa-compress fa-lg"
+                    />
+                  </div>
+                  <span
+                    class="header-action-drawer__separator"
+                  />
+                  <div
+                    class="header-action-drawer__ff-click-catcher-container"
+                  >
+                    <div
+                      class="header-action-drawer__ff-click-catcher"
+                    />
+                    <i
+                      class="fas fa-plus fa-lg"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="header-action-drawer__row"
+                >
+                  <div
+                    class="header-action-drawer__deadline-scheduled-button"
+                  >
+                    Deadline
+                  </div>
+                  <span
+                    class="header-action-drawer__separator"
+                  />
+                  <div
+                    class="header-action-drawer__deadline-scheduled-button"
+                  >
+                    Scheduled
+                  </div>
                 </div>
               </div>
-            </FocusTrap>
-          </HotKeys>
-        </OrgFile>
-      </Connect(OrgFile)>
-    </Provider>
-  </Router>
-</MemoryRouter>
+            </div>
+          </div>
+          <div
+            class="header-content-container nice-scroll"
+            style="width: 0px;"
+          >
+            <span />
+          </div>
+        </div>
+        <div
+          class="header"
+          style="padding-left: 40px; margin-left: 0px;"
+        >
+          <div
+            class="left-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="right-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="header__bullet"
+            style="margin-left: -16px;"
+          >
+            *
+          </div>
+          <div
+            class="title-line"
+            style="width: 0px;"
+          >
+            
+            <div>
+              <span
+                style="word-break: break-word;"
+              >
+                <span>
+                  A nested header
+                </span>
+                
+              </span>
+            </div>
+          </div>
+          <div />
+        </div>
+        <div
+          class="header"
+          style="padding-left: 40px; margin-left: 0px;"
+        >
+          <div
+            class="left-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="right-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="header__bullet"
+            style="margin-left: -16px;"
+          >
+            *
+          </div>
+          <div
+            class="title-line"
+            style="width: 0px;"
+          >
+            <span
+              class="todo-keyword todo-keyword--todo"
+            >
+              TODO
+            </span>
+            <div>
+              <span
+                style="word-break: break-word;"
+              >
+                <span>
+                  A todo item
+                </span>
+                
+              </span>
+            </div>
+          </div>
+          <div />
+        </div>
+        <div
+          class="header"
+          style="padding-left: 40px; margin-left: 0px;"
+        >
+          <div
+            class="left-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="right-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="header__bullet"
+            style="margin-left: -16px;"
+          >
+            *
+          </div>
+          <div
+            class="title-line"
+            style="width: 0px;"
+          >
+            <span
+              class="todo-keyword todo-keyword--done"
+            >
+              DONE
+            </span>
+            <div>
+              <span
+                style="word-break: break-word;"
+              >
+                <span>
+                  A finished todo item
+                </span>
+                
+              </span>
+            </div>
+          </div>
+          <div />
+        </div>
+        <div
+          class="header"
+          style="padding-left: 20px; margin-left: 0px;"
+        >
+          <div
+            class="left-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="right-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="header__bullet"
+            style="margin-left: -16px;"
+          >
+            *
+          </div>
+          <div
+            class="title-line"
+            style="width: 0px;"
+          >
+            
+            <div>
+              <span
+                style="word-break: break-word;"
+              >
+                <span>
+                  Another top level header
+                </span>
+                ...
+              </span>
+            </div>
+          </div>
+          <div />
+        </div>
+        <div
+          class="header"
+          style="padding-left: 20px; margin-left: 0px;"
+        >
+          <div
+            class="left-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="right-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="header__bullet"
+            style="margin-left: -16px;"
+          >
+            *
+          </div>
+          <div
+            class="title-line"
+            style="width: 0px;"
+          >
+            
+            <div>
+              <span
+                style="word-break: break-word;"
+              >
+                <span>
+                  A header with tags                                              
+                </span>
+                
+              </span>
+              <div>
+                <div
+                  class="header-tag"
+                >
+                  tag1
+                </div>
+                <div
+                  class="header-tag"
+                >
+                  tag2
+                </div>
+              </div>
+            </div>
+          </div>
+          <div />
+        </div>
+        <div
+          class="header"
+          style="padding-left: 20px; margin-left: 0px;"
+        >
+          <div
+            class="left-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="right-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="header__bullet"
+            style="margin-left: -16px;"
+          >
+            *
+          </div>
+          <div
+            class="title-line"
+            style="width: 0px;"
+          >
+            
+            <div>
+              <span
+                style="word-break: break-word;"
+              >
+                <span>
+                  A header with 
+                  <a
+                    href="https://google.com"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    a link
+                  </a>
+                </span>
+                
+              </span>
+            </div>
+          </div>
+          <div />
+        </div>
+      </div>
+      <div
+        class="action-drawer-container nice-scroll"
+      >
+        <button
+          class="btn btn--circle action-drawer__btn fas fa-lg fa-cloud action-drawer__btn--with-sub-icon"
+          style="opacity: 1;"
+          title="Sync changes"
+        >
+          <i
+            class="fas fa-xs fa-sync-alt action-drawer__btn__sub-icon"
+          />
+        </button>
+        <div
+          class="action-drawer__arrow-buttons-container"
+          style="left: 0px;"
+        >
+          <button
+            class="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-arrow-up"
+            style="opacity: 1; box-shadow: none; bottom: 0px;"
+            title="Move header up"
+          />
+          <button
+            class="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-arrow-down"
+            style="opacity: 1; box-shadow: none; bottom: 0px;"
+            title="Move header down"
+          />
+          <button
+            class="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-arrow-left"
+            style="opacity: 1; box-shadow: none; bottom: 0px; right: 0px;"
+            title="Move header left"
+          />
+          <button
+            class="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-arrow-right"
+            style="opacity: 1; box-shadow: none; bottom: 0px; left: 0px;"
+            title="Move header right"
+          />
+          <button
+            class="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-chevron-left"
+            style="opacity: 1; box-shadow: none; bottom: 0px; right: 0px;"
+            title="Move entire subtree left"
+          />
+          <button
+            class="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-chevron-right"
+            style="opacity: 1; box-shadow: none; bottom: 0px; left: 0px;"
+            title="Move entire subtree right"
+          />
+          <button
+            class="btn btn--circle action-drawer__btn action-drawer__main-arrow-button fas fa-lg fa-arrows-alt"
+            style="opacity: 1;"
+            title="Show movement buttons"
+          />
+        </div>
+        <button
+          class="btn btn--circle action-drawer__btn fas fa-lg fa-calendar-alt"
+          style="opacity: 1;"
+          title="Show agenda"
+        />
+        <div
+          class="action-drawer__capture-buttons-container"
+        >
+          <button
+            class="btn btn--circle action-drawer__btn fas fa-lg fa-list-ul"
+            style="opacity: 1; position: relative; z-index: 1;"
+            title="Show capture templates"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 `;
 
 exports[`Rendering an org file Can select a header in an org file 1`] = `
-<MemoryRouter
-  keyLength={0}
->
-  <Router
-    history={
-      Object {
-        "action": "POP",
-        "block": [Function],
-        "canGo": [Function],
-        "createHref": [Function],
-        "entries": Array [
-          Object {
-            "hash": "",
-            "pathname": "/",
-            "search": "",
-            "state": undefined,
-          },
-        ],
-        "go": [Function],
-        "goBack": [Function],
-        "goForward": [Function],
-        "index": 0,
-        "length": 1,
-        "listen": [Function],
-        "location": Object {
-          "hash": "",
-          "pathname": "/",
-          "search": "",
-          "state": undefined,
-        },
-        "push": [Function],
-        "replace": [Function],
-      }
-    }
+<div>
+  <div
+    tabindex="-1"
   >
-    <Provider
-      store={
-        Object {
-          "dispatch": [Function],
-          "getState": [Function],
-          "replaceReducer": [Function],
-          "subscribe": [Function],
-          Symbol(observable): [Function],
-        }
-      }
+    <div
+      class="org-file-container"
+      tabindex="-1"
     >
-      <Connect(OrgFile)
-        path="/some/test/file"
+      <div
+        class="header-list-container"
       >
-        <OrgFile
-          activePopupData={null}
-          activePopupType={null}
-          base={
-            Object {
-              "activatePopup": [Function],
-              "clearModalStack": [Function],
-              "closePopup": [Function],
-              "hideLoadingMessage": [Function],
-              "loadStaticFile": [Function],
-              "popModalPage": [Function],
-              "pushModalPage": [Function],
-              "restoreBaseSettings": [Function],
-              "setAgendaDefaultDeadlineDelayUnit": [Function],
-              "setAgendaDefaultDeadlineDelayValue": [Function],
-              "setBulletStyle": [Function],
-              "setCustomKeybinding": [Function],
-              "setDisappearingLoadingMessage": [Function],
-              "setFontSize": [Function],
-              "setHasUnseenChangelog": [Function],
-              "setIsLoading": [Function],
-              "setLastSeenChangelogHeader": [Function],
-              "setLastViewedFile": [Function],
-              "setLoadingMessage": [Function],
-              "setShouldLiveSync": [Function],
-              "setShouldStoreSettingsInSyncBackend": [Function],
-              "setShouldSyncOnBecomingVisibile": [Function],
-              "setShouldTapTodoToAdvance": [Function],
-              "unloadStaticFile": [Function],
-            }
-          }
-          capture={
-            Object {
-              "addNewEmptyCaptureTemplate": [Function],
-              "addNewTemplateHeaderPath": [Function],
-              "addNewTemplateOrgFileAvailability": [Function],
-              "deleteTemplate": [Function],
-              "removeTemplateHeaderPath": [Function],
-              "removeTemplateOrgFileAvailability": [Function],
-              "reorderCaptureTemplate": [Function],
-              "restoreCaptureSettings": [Function],
-              "updateTemplateFieldPathValue": [Function],
-            }
-          }
-          captureTemplates={
-            Array [
-              Immutable.List [
-                Immutable.Map {
-                  "headerPaths": Immutable.List [
-                    "Capture",
-                    "Groceries",
-                  ],
-                  "iconName": "lemon",
-                  "letter": "",
-                  "isAvailableInAllOrgFiles": false,
-                  "isSample": true,
-                  "orgFilesWhereAvailable": Immutable.List [],
-                  "template": "* TODO %?",
-                  "id": 1,
-                  "shouldPrepend": false,
-                  "description": "Groceries",
-                },
-                Immutable.Map {
-                  "headerPaths": Immutable.List [
-                    "Capture",
-                    "Deeply",
-                    "Nested",
-                    "Headers",
-                    "Work",
-                    "Too!",
-                  ],
-                  "iconName": "fighter-jet",
-                  "letter": "",
-                  "isAvailableInAllOrgFiles": false,
-                  "isSample": true,
-                  "orgFilesWhereAvailable": Immutable.List [],
-                  "template": "* You can insert timestamps too! %T %?",
-                  "id": 2,
-                  "shouldPrepend": true,
-                  "description": "Deeply nested header",
-                },
-              ],
-            ]
-          }
-          customKeybindings={Immutable.Map {}}
-          headers={
-            Immutable.List [
-              Immutable.Map {
-                "titleLine": Immutable.Map {
-                  "title": Immutable.List [
-                    Immutable.Map {
-                      "type": "text",
-                      "contents": "Top level header",
-                    },
-                  ],
-                  "rawTitle": "Top level header",
-                  "todoKeyword": undefined,
-                  "tags": Immutable.List [],
-                },
-                "rawDescription": "",
-                "description": Immutable.List [],
-                "opened": true,
-                                        "id": 27,
-                "nestingLevel": 1,
-                "planningItems": Immutable.List [],
-                "propertyListItems": Immutable.List [],
-              },
-              Immutable.Map {
-                "titleLine": Immutable.Map {
-                  "title": Immutable.List [
-                    Immutable.Map {
-                      "type": "text",
-                      "contents": "A nested header",
-                    },
-                  ],
-                  "rawTitle": "A nested header",
-                  "todoKeyword": undefined,
-                  "tags": Immutable.List [],
-                },
-                "rawDescription": "",
-                "description": Immutable.List [],
-                "opened": false,
-                                        "id": 28,
-                "nestingLevel": 2,
-                "planningItems": Immutable.List [],
-                "propertyListItems": Immutable.List [],
-              },
-              Immutable.Map {
-                "titleLine": Immutable.Map {
-                  "title": Immutable.List [
-                    Immutable.Map {
-                      "type": "text",
-                      "contents": "A todo item",
-                    },
-                  ],
-                  "rawTitle": "A todo item",
-                  "todoKeyword": "TODO",
-                  "tags": Immutable.List [],
-                },
-                "rawDescription": "",
-                "description": Immutable.List [],
-                "opened": false,
-                                        "id": 29,
-                "nestingLevel": 2,
-                "planningItems": Immutable.List [],
-                "propertyListItems": Immutable.List [],
-              },
-              Immutable.Map {
-                "titleLine": Immutable.Map {
-                  "title": Immutable.List [
-                    Immutable.Map {
-                      "type": "text",
-                      "contents": "A finished todo item",
-                    },
-                  ],
-                  "rawTitle": "A finished todo item",
-                  "todoKeyword": "DONE",
-                  "tags": Immutable.List [],
-                },
-                "rawDescription": "",
-                "description": Immutable.List [],
-                "opened": false,
-                                        "id": 30,
-                "nestingLevel": 2,
-                "planningItems": Immutable.List [],
-                "propertyListItems": Immutable.List [],
-              },
-              Immutable.Map {
-                "titleLine": Immutable.Map {
-                  "title": Immutable.List [
-                    Immutable.Map {
-                      "type": "text",
-                      "contents": "Another top level header",
-                    },
-                  ],
-                  "rawTitle": "Another top level header",
-                  "todoKeyword": undefined,
-                  "tags": Immutable.List [],
-                },
-                "rawDescription": "Some description content",
-                "description": Immutable.List [
-                  Immutable.Map {
-                    "type": "text",
-                    "contents": "Some description content",
-                  },
-                ],
-                "opened": false,
-                                        "id": 31,
-                "nestingLevel": 1,
-                "planningItems": Immutable.List [],
-                "propertyListItems": Immutable.List [],
-              },
-              Immutable.Map {
-                "titleLine": Immutable.Map {
-                  "title": Immutable.List [
-                    Immutable.Map {
-                      "type": "text",
-                      "contents": "A header with tags                                              ",
-                    },
-                  ],
-                  "rawTitle": "A header with tags                                              ",
-                  "todoKeyword": undefined,
-                  "tags": Immutable.List [
-                    "tag1",
-                    "tag2",
-                  ],
-                },
-                "rawDescription": "",
-                "description": Immutable.List [],
-                "opened": false,
-                "id": 8,
-                "nestingLevel": 1,
-                "planningItems": Immutable.List [],
-                "propertyListItems": Immutable.List [],
-              },
-              Immutable.Map {
-                "titleLine": Immutable.Map {
-                  "title": Immutable.List [
-                    Immutable.Map {
-                      "type": "text",
-                      "contents": "A header with ",
-                    },
-                    Immutable.Map {
-                                              "id": 33,
-                      "type": "link",
-                      "contents": Immutable.Map {
-                        "uri": "https://google.com",
-                        "title": "a link",
-                      },
-                    },
-                  ],
-                  "rawTitle": "A header with [[https://google.com][a link]]",
-                  "todoKeyword": undefined,
-                  "tags": Immutable.List [],
-                },
-                "rawDescription": "",
-                "description": Immutable.List [],
-                "opened": false,
-                "id": 10,
-                "nestingLevel": 1,
-                "planningItems": Immutable.List [],
-                "propertyListItems": Immutable.List [],
-              },
-            ]
-          }
-          inEditMode={false}
-          loadedPath="/some/test/file"
-          org={
-            Object {
-              "addHeader": [Function],
-              "addHeaderAndEdit": [Function],
-              "addNewPlanningItem": [Function],
-              "addNewTableColumn": [Function],
-              "addNewTableRow": [Function],
-              "advanceCheckboxState": [Function],
-              "advanceTodoState": [Function],
-              "applyOpennessState": [Function],
-              "clearPendingCapture": [Function],
-              "displayFile": [Function],
-              "enterEditMode": [Function],
-              "exitEditMode": [Function],
-              "focusHeader": [Function],
-              "insertCapture": [Function],
-              "insertPendingCapture": [Function],
-              "moveHeaderDown": [Function],
-              "moveHeaderLeft": [Function],
-              "moveHeaderRight": [Function],
-              "moveHeaderUp": [Function],
-              "moveSubtreeLeft": [Function],
-              "moveSubtreeRight": [Function],
-              "moveTableColumnLeft": [Function],
-              "moveTableColumnRight": [Function],
-              "moveTableRowDown": [Function],
-              "moveTableRowUp": [Function],
-              "noOp": [Function],
-              "openHeader": [Function],
-              "removeHeader": [Function],
-              "removeTableColumn": [Function],
-              "removeTableRow": [Function],
-              "reorderPropertyList": [Function],
-              "reorderTags": [Function],
-              "selectHeader": [Function],
-              "selectHeaderAndOpenParents": [Function],
-              "selectNextSiblingHeader": [Function],
-              "selectNextVisibleHeader": [Function],
-              "selectPreviousVisibleHeader": [Function],
-              "setDirty": [Function],
-              "setHeaderTags": [Function],
-              "setLastSyncAt": [Function],
-              "setOrgFileErrorMessage": [Function],
-              "setSelectedTableCellId": [Function],
-              "stopDisplayingFile": [Function],
-              "sync": [Function],
-              "toggleHeaderOpened": [Function],
-              "unfocusHeader": [Function],
-              "updateHeaderDescription": [Function],
-              "updateHeaderTitle": [Function],
-              "updatePlanningItemTimestamp": [Function],
-              "updatePropertyListItems": [Function],
-              "updateTableCellValue": [Function],
-              "updateTimestampWithId": [Function],
-            }
-          }
-          path="/some/test/file"
-          selectedHeader={
-            Immutable.Map {
-              "titleLine": Immutable.Map {
-                "title": Immutable.List [
-                  Immutable.Map {
-                    "type": "text",
-                    "contents": "Top level header",
-                  },
-                ],
-                "rawTitle": "Top level header",
-                "todoKeyword": undefined,
-                "tags": Immutable.List [],
-              },
-              "rawDescription": "",
-              "description": Immutable.List [],
-              "opened": true,
-              "id": 27,
-              "nestingLevel": 1,
-              "planningItems": Immutable.List [],
-              "propertyListItems": Immutable.List [],
-            }
-          }
-          selectedHeaderId={27}
-          syncBackend={
-            Object {
-              "downloadFile": [Function],
-              "getDirectoryListing": [Function],
-              "loadMoreDirectoryListing": [Function],
-              "pushBackup": [Function],
-              "setCurrentFileBrowserDirectoryListing": [Function],
-              "setIsLoadingMoreDirectoryListing": [Function],
-              "signOut": [Function],
-            }
-          }
-          undo={
-            Object {
-              "clearHistory": [Function],
-              "jump": [Function],
-              "jumpToFuture": [Function],
-              "jumpToPast": [Function],
-              "redo": [Function],
-              "undo": [Function],
-            }
-          }
+        <div
+          class="header"
+          style="padding-left: 20px; margin-left: 0px;"
         >
-          <HotKeys
-            handlers={
-              Object {
-                "addHeader": [Function],
-                "advanceTodo": [Function],
-                "editDescription": [Function],
-                "editTitle": [Function],
-                "exitEditMode": [Function],
-                "moveHeaderDown": [Function],
-                "moveHeaderLeft": [Function],
-                "moveHeaderRight": [Function],
-                "moveHeaderUp": [Function],
-                "removeHeader": [Function],
-                "selectNextVisibleHeader": [Function],
-                "selectPreviousVisibleHeader": [Function],
-                "toggleHeaderOpened": [Function],
-                "undo": [Function],
-              }
-            }
-            keyMap={
-              Object {
-                "addHeader": "ctrl+enter",
-                "advanceTodo": "ctrl+t",
-                "editDescription": "ctrl+d",
-                "editTitle": "ctrl+h",
-                "exitEditMode": "command+enter",
-                "moveHeaderDown": "ctrl+command+n",
-                "moveHeaderLeft": "ctrl+command+b",
-                "moveHeaderRight": "ctrl+command+f",
-                "moveHeaderUp": "ctrl+command+p",
-                "removeHeader": "backspace",
-                "selectNextVisibleHeader": "ctrl+n",
-                "selectPreviousVisibleHeader": "ctrl+p",
-                "toggleHeaderOpened": "tab",
-                "undo": "ctrl+shift+-",
-              }
-            }
+          <div
+            class="left-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
           >
-            <FocusTrap
-              component="div"
-              onBlur={[Function]}
-              onFocus={[Function]}
-            >
-              <div
-                onBlur={[Function]}
-                onFocus={[Function]}
-                tabIndex="-1"
+            <i
+              class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="right-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="header__bullet"
+            style="margin-left: -16px;"
+          >
+            *
+          </div>
+          <div
+            class="title-line"
+            style="width: 0px;"
+          >
+            
+            <div>
+              <span
+                style="word-break: break-word;"
               >
+                <span>
+                  Top level header
+                </span>
+                ...
+              </span>
+            </div>
+          </div>
+          <div />
+        </div>
+        <div
+          class="header"
+          style="padding-left: 20px; margin-left: 0px;"
+        >
+          <div
+            class="left-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="right-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="header__bullet"
+            style="margin-left: -16px;"
+          >
+            *
+          </div>
+          <div
+            class="title-line"
+            style="width: 0px;"
+          >
+            
+            <div>
+              <span
+                style="word-break: break-word;"
+              >
+                <span>
+                  Another top level header
+                </span>
+                ...
+              </span>
+            </div>
+          </div>
+          <div />
+        </div>
+        <div
+          class="header"
+          style="padding-left: 20px; margin-left: 0px;"
+        >
+          <div
+            class="left-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="right-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="header__bullet"
+            style="margin-left: -16px;"
+          >
+            *
+          </div>
+          <div
+            class="title-line"
+            style="width: 0px;"
+          >
+            
+            <div>
+              <span
+                style="word-break: break-word;"
+              >
+                <span>
+                  A header with tags                                              
+                </span>
+                
+              </span>
+              <div>
                 <div
-                  className="org-file-container"
-                  tabIndex="-1"
+                  class="header-tag"
                 >
-                  <Connect(HeaderList)>
-                    <HeaderList
-                      headers={
-                        Immutable.List [
-                          Immutable.Map {
-                            "titleLine": Immutable.Map {
-                              "title": Immutable.List [
-                                Immutable.Map {
-                                  "type": "text",
-                                  "contents": "Top level header",
-                                },
-                              ],
-                              "rawTitle": "Top level header",
-                              "todoKeyword": undefined,
-                              "tags": Immutable.List [],
-                            },
-                            "rawDescription": "",
-                            "description": Immutable.List [],
-                            "opened": true,
-                                      "id": 27,
-                            "nestingLevel": 1,
-                            "planningItems": Immutable.List [],
-                            "propertyListItems": Immutable.List [],
-                          },
-                          Immutable.Map {
-                            "titleLine": Immutable.Map {
-                              "title": Immutable.List [
-                                Immutable.Map {
-                                  "type": "text",
-                                  "contents": "A nested header",
-                                },
-                              ],
-                              "rawTitle": "A nested header",
-                              "todoKeyword": undefined,
-                              "tags": Immutable.List [],
-                            },
-                            "rawDescription": "",
-                            "description": Immutable.List [],
-                            "opened": false,
-                                      "id": 28,
-                            "nestingLevel": 2,
-                            "planningItems": Immutable.List [],
-                            "propertyListItems": Immutable.List [],
-                          },
-                          Immutable.Map {
-                            "titleLine": Immutable.Map {
-                              "title": Immutable.List [
-                                Immutable.Map {
-                                  "type": "text",
-                                  "contents": "A todo item",
-                                },
-                              ],
-                              "rawTitle": "A todo item",
-                              "todoKeyword": "TODO",
-                              "tags": Immutable.List [],
-                            },
-                            "rawDescription": "",
-                            "description": Immutable.List [],
-                            "opened": false,
-                                      "id": 29,
-                            "nestingLevel": 2,
-                            "planningItems": Immutable.List [],
-                            "propertyListItems": Immutable.List [],
-                          },
-                          Immutable.Map {
-                            "titleLine": Immutable.Map {
-                              "title": Immutable.List [
-                                Immutable.Map {
-                                  "type": "text",
-                                  "contents": "A finished todo item",
-                                },
-                              ],
-                              "rawTitle": "A finished todo item",
-                              "todoKeyword": "DONE",
-                              "tags": Immutable.List [],
-                            },
-                            "rawDescription": "",
-                            "description": Immutable.List [],
-                            "opened": false,
-                                      "id": 30,
-                            "nestingLevel": 2,
-                            "planningItems": Immutable.List [],
-                            "propertyListItems": Immutable.List [],
-                          },
-                          Immutable.Map {
-                            "titleLine": Immutable.Map {
-                              "title": Immutable.List [
-                                Immutable.Map {
-                                  "type": "text",
-                                  "contents": "Another top level header",
-                                },
-                              ],
-                              "rawTitle": "Another top level header",
-                              "todoKeyword": undefined,
-                              "tags": Immutable.List [],
-                            },
-                            "rawDescription": "Some description content",
-                            "description": Immutable.List [
-                              Immutable.Map {
-                                "type": "text",
-                                "contents": "Some description content",
-                              },
-                            ],
-                            "opened": false,
-                                      "id": 31,
-                            "nestingLevel": 1,
-                            "planningItems": Immutable.List [],
-                            "propertyListItems": Immutable.List [],
-                          },
-                          Immutable.Map {
-                            "titleLine": Immutable.Map {
-                              "title": Immutable.List [
-                                Immutable.Map {
-                                  "type": "text",
-                                  "contents": "A header with tags                                              ",
-                                },
-                              ],
-                              "rawTitle": "A header with tags                                              ",
-                              "todoKeyword": undefined,
-                              "tags": Immutable.List [
-                                "tag1",
-                                "tag2",
-                              ],
-                            },
-                            "rawDescription": "",
-                            "description": Immutable.List [],
-                            "opened": false,
-                                        "id": 32,
-                            "nestingLevel": 1,
-                            "planningItems": Immutable.List [],
-                            "propertyListItems": Immutable.List [],
-                          },
-                          Immutable.Map {
-                            "titleLine": Immutable.Map {
-                              "title": Immutable.List [
-                                Immutable.Map {
-                                  "type": "text",
-                                  "contents": "A header with ",
-                                },
-                                Immutable.Map {
-                                            "id": 33,
-                                  "type": "link",
-                                  "contents": Immutable.Map {
-                                    "uri": "https://google.com",
-                                    "title": "a link",
-                                  },
-                                },
-                              ],
-                              "rawTitle": "A header with [[https://google.com][a link]]",
-                              "todoKeyword": undefined,
-                              "tags": Immutable.List [],
-                            },
-                            "rawDescription": "",
-                            "description": Immutable.List [],
-                            "opened": false,
-                            "id": 34,
-                            "nestingLevel": 1,
-                            "planningItems": Immutable.List [],
-                            "propertyListItems": Immutable.List [],
-                          },
-                        ]
-                      }
-                      selectedHeaderId={27}
-                    >
-                      <div
-                        className="header-list-container"
-                      >
-                        <Connect(Header)
-                          color="rgba(38, 143, 214, 1)"
-                          hasContent={true}
-                          header={
-                            Immutable.Map {
-                              "titleLine": Immutable.Map {
-                                "title": Immutable.List [
-                                  Immutable.Map {
-                                    "type": "text",
-                                    "contents": "Top level header",
-                                  },
-                                ],
-                                "rawTitle": "Top level header",
-                                "todoKeyword": undefined,
-                                "tags": Immutable.List [],
-                              },
-                              "rawDescription": "",
-                              "description": Immutable.List [],
-                              "opened": true,
-                              "id": 27,
-                              "nestingLevel": 1,
-                              "planningItems": Immutable.List [],
-                              "propertyListItems": Immutable.List [],
-                            }
-                          }
-                          isSelected={true}
-                          key="27"
-                          onRef={[Function]}
-                        >
-                          <Header
-                            base={
-                              Object {
-                                "activatePopup": [Function],
-                                "clearModalStack": [Function],
-                                "closePopup": [Function],
-                                "hideLoadingMessage": [Function],
-                                "loadStaticFile": [Function],
-                                "popModalPage": [Function],
-                                "pushModalPage": [Function],
-                                "restoreBaseSettings": [Function],
-                                "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                "setAgendaDefaultDeadlineDelayValue": [Function],
-                                "setBulletStyle": [Function],
-                                "setCustomKeybinding": [Function],
-                                "setDisappearingLoadingMessage": [Function],
-                                "setFontSize": [Function],
-                                "setHasUnseenChangelog": [Function],
-                                "setIsLoading": [Function],
-                                "setLastSeenChangelogHeader": [Function],
-                                "setLastViewedFile": [Function],
-                                "setLoadingMessage": [Function],
-                                "setShouldLiveSync": [Function],
-                                "setShouldStoreSettingsInSyncBackend": [Function],
-                                "setShouldTapTodoToAdvance": [Function],
-                                "unloadStaticFile": [Function],
-                              }
-                            }
-                            color="rgba(38, 143, 214, 1)"
-                            focusedHeader={null}
-                            hasContent={true}
-                            header={
-                              Immutable.Map {
-                                "titleLine": Immutable.Map {
-                                  "title": Immutable.List [
-                                    Immutable.Map {
-                                      "type": "text",
-                                      "contents": "Top level header",
-                                    },
-                                  ],
-                                  "rawTitle": "Top level header",
-                                  "todoKeyword": undefined,
-                                  "tags": Immutable.List [],
-                                },
-                                "rawDescription": "",
-                                "description": Immutable.List [],
-                                "opened": true,
-                                        "id": 27,
-                                "nestingLevel": 1,
-                                "planningItems": Immutable.List [],
-                                "propertyListItems": Immutable.List [],
-                              }
-                            }
-                            inEditMode={false}
-                            isFocused={false}
-                            isSelected={true}
-                            onRef={[Function]}
-                            org={
-                              Object {
-                                "addHeader": [Function],
-                                "addHeaderAndEdit": [Function],
-                                "addNewPlanningItem": [Function],
-                                "addNewTableColumn": [Function],
-                                "addNewTableRow": [Function],
-                                "advanceCheckboxState": [Function],
-                                "advanceTodoState": [Function],
-                                "applyOpennessState": [Function],
-                                "clearPendingCapture": [Function],
-                                "displayFile": [Function],
-                                "enterEditMode": [Function],
-                                "exitEditMode": [Function],
-                                "focusHeader": [Function],
-                                "insertCapture": [Function],
-                                "insertPendingCapture": [Function],
-                                "moveHeaderDown": [Function],
-                                "moveHeaderLeft": [Function],
-                                "moveHeaderRight": [Function],
-                                "moveHeaderUp": [Function],
-                                "moveSubtreeLeft": [Function],
-                                "moveSubtreeRight": [Function],
-                                "moveTableColumnLeft": [Function],
-                                "moveTableColumnRight": [Function],
-                                "moveTableRowDown": [Function],
-                                "moveTableRowUp": [Function],
-                                "noOp": [Function],
-                                "openHeader": [Function],
-                                "removeHeader": [Function],
-                                "removeTableColumn": [Function],
-                                "removeTableRow": [Function],
-                                "reorderPropertyList": [Function],
-                                "reorderTags": [Function],
-                                "selectHeader": [Function],
-                                "selectHeaderAndOpenParents": [Function],
-                                "selectNextSiblingHeader": [Function],
-                                "selectNextVisibleHeader": [Function],
-                                "selectPreviousVisibleHeader": [Function],
-                                "setDirty": [Function],
-                                "setHeaderTags": [Function],
-                                "setLastSyncAt": [Function],
-                                "setOrgFileErrorMessage": [Function],
-                                "setSelectedTableCellId": [Function],
-                                "stopDisplayingFile": [Function],
-                                "sync": [Function],
-                                "toggleHeaderOpened": [Function],
-                                "unfocusHeader": [Function],
-                                "updateHeaderDescription": [Function],
-                                "updateHeaderTitle": [Function],
-                                "updatePlanningItemTimestamp": [Function],
-                                "updatePropertyListItems": [Function],
-                                "updateTableCellValue": [Function],
-                                "updateTimestampWithId": [Function],
-                              }
-                            }
-                          >
-                            <Motion
-                              onRest={[Function]}
-                              style={
-                                Object {
-                                  "heightFactor": 1,
-                                  "marginLeft": Object {
-                                    "damping": 26,
-                                    "precision": 0.01,
-                                    "stiffness": 300,
-                                    "val": 0,
-                                  },
-                                  "paddingLeft": 20,
-                                }
-                              }
-                            >
-                              <div
-                                className="header header--selected"
-                                onClick={[Function]}
-                                onMouseDown={[Function]}
-                                onMouseMove={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseUp={[Function]}
-                                onTouchCancel={[Function]}
-                                onTouchEnd={[Function]}
-                                onTouchMove={[Function]}
-                                onTouchStart={[Function]}
-                                style={
-                                  Object {
-                                    "marginLeft": 0,
-                                    "paddingLeft": 20,
-                                  }
-                                }
-                              >
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": 0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="left-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": 0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": -0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="right-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": -0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <div
-                                  className="header__bullet"
-                                  style={
-                                    Object {
-                                      "color": "rgba(38, 143, 214, 1)",
-                                      "marginLeft": -16,
-                                    }
-                                  }
-                                >
-                                  *
-                                </div>
-                                <Connect(TitleLine)
-                                  color="rgba(38, 143, 214, 1)"
-                                  hasContent={true}
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "Top level header",
-                                          },
-                                        ],
-                                        "rawTitle": "Top level header",
-                                        "todoKeyword": undefined,
-                                        "tags": Immutable.List [],
-                                      },
-                                      "rawDescription": "",
-                                      "description": Immutable.List [],
-                                      "opened": true,
-                                      "id": 27,
-                                      "nestingLevel": 1,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                  isSelected={true}
-                                >
-                                  <TitleLine
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    color="rgba(38, 143, 214, 1)"
-                                    hasContent={true}
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "Top level header",
-                                            },
-                                          ],
-                                          "rawTitle": "Top level header",
-                                          "todoKeyword": undefined,
-                                          "tags": Immutable.List [],
-                                        },
-                                        "rawDescription": "",
-                                        "description": Immutable.List [],
-                                        "opened": true,
-                                "id": 27,
-                                        "nestingLevel": 1,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    isSelected={true}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                  >
-                                    <div
-                                      className="title-line"
-                                      onClick={[Function]}
-                                      style={
-                                        Object {
-                                          "width": 0,
-                                        }
-                                      }
-                                    >
-                                      <div>
-                                        <span
-                                          style={
-                                            Object {
-                                              "color": "rgba(38, 143, 214, 1)",
-                                              "wordBreak": "break-word",
-                                            }
-                                          }
-                                        >
-                                          <_default
-                                            parts={
-                                              Immutable.List [
-                                                Immutable.Map {
-                                                  "type": "text",
-                                                  "contents": "Top level header",
-                                                },
-                                              ]
-                                            }
-                                            subPartDataAndHandlers={
-                                              Object {
-                                                "onTimestampClick": [Function],
-                                                "shouldDisableActions": undefined,
-                                              }
-                                            }
-                                          >
-                                            <span>
-                                              Top level header
-                                            </span>
-                                          </_default>
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </TitleLine>
-                                </Connect(TitleLine)>
-                                <UnmountClosed
-                                  isOpened={true}
-                                  springConfig={
-                                    Object {
-                                      "stiffness": 300,
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "marginRight": -0,
-                                    }
-                                  }
-                                >
-                                  <Collapse
-                                    fixedHeight={-1}
-                                    forceInitialAnimation={true}
-                                    hasNestedCollapse={false}
-                                    isOpened={true}
-                                    onMeasure={[Function]}
-                                    onRender={[Function]}
-                                    onRest={[Function]}
-                                    springConfig={
-                                      Object {
-                                        "stiffness": 300,
-                                      }
-                                    }
-                                    style={
-                                      Object {
-                                        "marginRight": -0,
-                                      }
-                                    }
-                                    theme={
-                                      Object {
-                                        "collapse": "ReactCollapse--collapse",
-                                        "content": "ReactCollapse--content",
-                                      }
-                                    }
-                                  >
-                                    <Motion
-                                      defaultStyle={
-                                        Object {
-                                          "height": 0,
-                                        }
-                                      }
-                                      onRest={[Function]}
-                                      style={
-                                        Object {
-                                          "height": Object {
-                                            "damping": 26,
-                                            "precision": 1,
-                                            "stiffness": 300,
-                                            "val": 0,
-                                          },
-                                        }
-                                      }
-                                    >
-                                      <div
-                                        className="ReactCollapse--collapse"
-                                        style={
-                                          Object {
-                                            "height": 0,
-                                            "marginRight": -0,
-                                            "overflow": "hidden",
-                                          }
-                                        }
-                                      >
-                                        <div
-                                          className="ReactCollapse--content"
-                                        >
-                                          <HeaderActionDrawer
-                                            isFocused={false}
-                                            onAddNewHeader={[Function]}
-                                            onDeadlineClick={[Function]}
-                                            onEnterDescriptionEditMode={[Function]}
-                                            onEnterTitleEditMode={[Function]}
-                                            onFocus={[Function]}
-                                            onScheduledClick={[Function]}
-                                            onTagsClick={[Function]}
-                                            onUnfocus={[Function]}
-                                          >
-                                            <div
-                                              className="header-action-drawer-container"
-                                            >
-                                              <div
-                                                className="header-action-drawer__row"
-                                              >
-                                                <div
-                                                  className="header-action-drawer__ff-click-catcher-container"
-                                                  onClick={[Function]}
-                                                >
-                                                  <div
-                                                    className="header-action-drawer__ff-click-catcher"
-                                                  />
-                                                  <i
-                                                    className="fas fa-pencil-alt fa-lg"
-                                                  />
-                                                </div>
-                                                <span
-                                                  className="header-action-drawer__separator"
-                                                />
-                                                <div
-                                                  className="header-action-drawer__ff-click-catcher-container"
-                                                  onClick={[Function]}
-                                                >
-                                                  <div
-                                                    className="header-action-drawer__ff-click-catcher"
-                                                  />
-                                                  <i
-                                                    className="fas fa-edit fa-lg"
-                                                  />
-                                                </div>
-                                                <span
-                                                  className="header-action-drawer__separator"
-                                                />
-                                                <div
-                                                  className="header-action-drawer__ff-click-catcher-container"
-                                                  onClick={[Function]}
-                                                >
-                                                  <div
-                                                    className="header-action-drawer__ff-click-catcher"
-                                                  />
-                                                  <i
-                                                    className="fas fa-tags fa-lg"
-                                                  />
-                                                </div>
-                                                <span
-                                                  className="header-action-drawer__separator"
-                                                />
-                                                <div
-                                                  className="header-action-drawer__ff-click-catcher-container"
-                                                  onClick={[Function]}
-                                                >
-                                                  <div
-                                                    className="header-action-drawer__ff-click-catcher"
-                                                  />
-                                                  <i
-                                                    className="fas fa-compress fa-lg"
-                                                  />
-                                                </div>
-                                                <span
-                                                  className="header-action-drawer__separator"
-                                                />
-                                                <div
-                                                  className="header-action-drawer__ff-click-catcher-container"
-                                                  onClick={[Function]}
-                                                >
-                                                  <div
-                                                    className="header-action-drawer__ff-click-catcher"
-                                                  />
-                                                  <i
-                                                    className="fas fa-plus fa-lg"
-                                                  />
-                                                </div>
-                                              </div>
-                                              <div
-                                                className="header-action-drawer__row"
-                                              >
-                                                <div
-                                                  className="header-action-drawer__deadline-scheduled-button"
-                                                  onClick={[Function]}
-                                                >
-                                                  Deadline
-                                                </div>
-                                                <span
-                                                  className="header-action-drawer__separator"
-                                                />
-                                                <div
-                                                  className="header-action-drawer__deadline-scheduled-button"
-                                                  onClick={[Function]}
-                                                >
-                                                  Scheduled
-                                                </div>
-                                              </div>
-                                            </div>
-                                          </HeaderActionDrawer>
-                                        </div>
-                                      </div>
-                                    </Motion>
-                                  </Collapse>
-                                </UnmountClosed>
-                                <Connect(HeaderContent)
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "Top level header",
-                                          },
-                                        ],
-                                        "rawTitle": "Top level header",
-                                        "todoKeyword": undefined,
-                                        "tags": Immutable.List [],
-                                      },
-                                      "rawDescription": "",
-                                      "description": Immutable.List [],
-                                      "opened": true,
-                            "id": 27,
-                                      "nestingLevel": 1,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                >
-                                  <HeaderContent
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldSyncOnBecomingVisibile": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "Top level header",
-                                            },
-                                          ],
-                                          "rawTitle": "Top level header",
-                                          "todoKeyword": undefined,
-                                          "tags": Immutable.List [],
-                                        },
-                                        "rawDescription": "",
-                                        "description": Immutable.List [],
-                                        "opened": true,
-                "id": 27,
-                                        "nestingLevel": 1,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    inTableEditMode={false}
-                                    isSelected={true}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                    selectedTableCellId={null}
-                                  >
-                                    <div
-                                      className="header-content-container nice-scroll"
-                                      style={
-                                        Object {
-                                          "width": 0,
-                                        }
-                                      }
-                                    >
-                                      <PlanningItems
-                                        onClick={[Function]}
-                                        planningItems={Immutable.List []}
-                                      />
-                                      <_default
-                                        onEdit={[Function]}
-                                        onTimestampClick={[Function]}
-                                        propertyListItems={Immutable.List []}
-                                      />
-                                      <_default
-                                        parts={Immutable.List []}
-                                        subPartDataAndHandlers={
-                                          Object {
-                                            "inTableEditMode": false,
-                                            "onAddNewTableColumn": [Function],
-                                            "onAddNewTableRow": [Function],
-                                            "onCheckboxClick": [Function],
-                                            "onEnterTableEditMode": [Function],
-                                            "onExitTableEditMode": [Function],
-                                            "onRemoveTableColumn": [Function],
-                                            "onRemoveTableRow": [Function],
-                                            "onTableCellSelect": [Function],
-                                            "onTableCellValueUpdate": [Function],
-                                            "onTimestampClick": [Function],
-                                            "selectedTableCellId": null,
-                                            "shouldDisableActions": undefined,
-                                          }
-                                        }
-                                      >
-                                        <span>
-                                          <Component />
-                                        </span>
-                                      </_default>
-                                    </div>
-                                  </HeaderContent>
-                                </Connect(HeaderContent)>
-                              </div>
-                            </Motion>
-                          </Header>
-                        </Connect(Header)>
-                        <Connect(Header)
-                          color="rgba(42, 164, 168, 1)"
-                          hasContent={false}
-                          header={
-                            Immutable.Map {
-                              "titleLine": Immutable.Map {
-                                "title": Immutable.List [
-                                  Immutable.Map {
-                                    "type": "text",
-                                    "contents": "A nested header",
-                                  },
-                                ],
-                                "rawTitle": "A nested header",
-                                "todoKeyword": undefined,
-                                "tags": Immutable.List [],
-                              },
-                              "rawDescription": "",
-                              "description": Immutable.List [],
-                              "opened": false,
-                              "id": 28,
-                              "nestingLevel": 2,
-                              "planningItems": Immutable.List [],
-                              "propertyListItems": Immutable.List [],
-                            }
-                          }
-                          isSelected={false}
-                          key="28"
-                          onRef={[Function]}
-                        >
-                          <Header
-                            base={
-                              Object {
-                                "activatePopup": [Function],
-                                "clearModalStack": [Function],
-                                "closePopup": [Function],
-                                "hideLoadingMessage": [Function],
-                                "loadStaticFile": [Function],
-                                "popModalPage": [Function],
-                                "pushModalPage": [Function],
-                                "restoreBaseSettings": [Function],
-                                "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                "setAgendaDefaultDeadlineDelayValue": [Function],
-                                "setBulletStyle": [Function],
-                                "setCustomKeybinding": [Function],
-                                "setDisappearingLoadingMessage": [Function],
-                                "setFontSize": [Function],
-                                "setHasUnseenChangelog": [Function],
-                                "setIsLoading": [Function],
-                                "setLastSeenChangelogHeader": [Function],
-                                "setLastViewedFile": [Function],
-                                "setLoadingMessage": [Function],
-                                "setShouldLiveSync": [Function],
-                                "setShouldStoreSettingsInSyncBackend": [Function],
-                                "setShouldTapTodoToAdvance": [Function],
-                                "unloadStaticFile": [Function],
-                              }
-                            }
-                            color="rgba(42, 164, 168, 1)"
-                            focusedHeader={null}
-                            hasContent={false}
-                            header={
-                              Immutable.Map {
-                                "titleLine": Immutable.Map {
-                                  "title": Immutable.List [
-                                    Immutable.Map {
-                                      "type": "text",
-                                      "contents": "A nested header",
-                                    },
-                                  ],
-                                  "rawTitle": "A nested header",
-                                  "todoKeyword": undefined,
-                                  "tags": Immutable.List [],
-                                },
-                                "rawDescription": "",
-                                "description": Immutable.List [],
-                                "opened": false,
-                                        "id": 28,
-                                "nestingLevel": 2,
-                                "planningItems": Immutable.List [],
-                                "propertyListItems": Immutable.List [],
-                              }
-                            }
-                            inEditMode={false}
-                            isFocused={false}
-                            isSelected={false}
-                            onRef={[Function]}
-                            org={
-                              Object {
-                                "addHeader": [Function],
-                                "addHeaderAndEdit": [Function],
-                                "addNewPlanningItem": [Function],
-                                "addNewTableColumn": [Function],
-                                "addNewTableRow": [Function],
-                                "advanceCheckboxState": [Function],
-                                "advanceTodoState": [Function],
-                                "applyOpennessState": [Function],
-                                "clearPendingCapture": [Function],
-                                "displayFile": [Function],
-                                "enterEditMode": [Function],
-                                "exitEditMode": [Function],
-                                "focusHeader": [Function],
-                                "insertCapture": [Function],
-                                "insertPendingCapture": [Function],
-                                "moveHeaderDown": [Function],
-                                "moveHeaderLeft": [Function],
-                                "moveHeaderRight": [Function],
-                                "moveHeaderUp": [Function],
-                                "moveSubtreeLeft": [Function],
-                                "moveSubtreeRight": [Function],
-                                "moveTableColumnLeft": [Function],
-                                "moveTableColumnRight": [Function],
-                                "moveTableRowDown": [Function],
-                                "moveTableRowUp": [Function],
-                                "noOp": [Function],
-                                "openHeader": [Function],
-                                "removeHeader": [Function],
-                                "removeTableColumn": [Function],
-                                "removeTableRow": [Function],
-                                "reorderPropertyList": [Function],
-                                "reorderTags": [Function],
-                                "selectHeader": [Function],
-                                "selectHeaderAndOpenParents": [Function],
-                                "selectNextSiblingHeader": [Function],
-                                "selectNextVisibleHeader": [Function],
-                                "selectPreviousVisibleHeader": [Function],
-                                "setDirty": [Function],
-                                "setHeaderTags": [Function],
-                                "setLastSyncAt": [Function],
-                                "setOrgFileErrorMessage": [Function],
-                                "setSelectedTableCellId": [Function],
-                                "stopDisplayingFile": [Function],
-                                "sync": [Function],
-                                "toggleHeaderOpened": [Function],
-                                "unfocusHeader": [Function],
-                                "updateHeaderDescription": [Function],
-                                "updateHeaderTitle": [Function],
-                                "updatePlanningItemTimestamp": [Function],
-                                "updatePropertyListItems": [Function],
-                                "updateTableCellValue": [Function],
-                                "updateTimestampWithId": [Function],
-                              }
-                            }
-                          >
-                            <Motion
-                              onRest={[Function]}
-                              style={
-                                Object {
-                                  "heightFactor": 1,
-                                  "marginLeft": Object {
-                                    "damping": 26,
-                                    "precision": 0.01,
-                                    "stiffness": 300,
-                                    "val": 0,
-                                  },
-                                  "paddingLeft": 40,
-                                }
-                              }
-                            >
-                              <div
-                                className="header"
-                                onClick={[Function]}
-                                onMouseDown={[Function]}
-                                onMouseMove={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseUp={[Function]}
-                                onTouchCancel={[Function]}
-                                onTouchEnd={[Function]}
-                                onTouchMove={[Function]}
-                                onTouchStart={[Function]}
-                                style={
-                                  Object {
-                                    "marginLeft": 0,
-                                    "paddingLeft": 40,
-                                  }
-                                }
-                              >
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": 0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="left-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": 0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": -0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="right-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": -0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <div
-                                  className="header__bullet"
-                                  style={
-                                    Object {
-                                      "color": "rgba(42, 164, 168, 1)",
-                                      "marginLeft": -16,
-                                    }
-                                  }
-                                >
-                                  *
-                                </div>
-                                <Connect(TitleLine)
-                                  color="rgba(42, 164, 168, 1)"
-                                  hasContent={false}
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "A nested header",
-                                          },
-                                        ],
-                                        "rawTitle": "A nested header",
-                                        "todoKeyword": undefined,
-                                        "tags": Immutable.List [],
-                                      },
-                                      "rawDescription": "",
-                                      "description": Immutable.List [],
-                                      "opened": false,
-                                      "id": 28,
-                                      "nestingLevel": 2,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                  isSelected={false}
-                                >
-                                  <TitleLine
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    color="rgba(42, 164, 168, 1)"
-                                    hasContent={false}
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "A nested header",
-                                            },
-                                          ],
-                                          "rawTitle": "A nested header",
-                                          "todoKeyword": undefined,
-                                          "tags": Immutable.List [],
-                                        },
-                                        "rawDescription": "",
-                                        "description": Immutable.List [],
-                                        "opened": false,
-                                "id": 28,
-                                        "nestingLevel": 2,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                  >
-                                    <div
-                                      className="title-line"
-                                      onClick={[Function]}
-                                      style={
-                                        Object {
-                                          "width": 0,
-                                        }
-                                      }
-                                    >
-                                      <div>
-                                        <span
-                                          style={
-                                            Object {
-                                              "color": "rgba(42, 164, 168, 1)",
-                                              "wordBreak": "break-word",
-                                            }
-                                          }
-                                        >
-                                          <_default
-                                            parts={
-                                              Immutable.List [
-                                                Immutable.Map {
-                                                  "type": "text",
-                                                  "contents": "A nested header",
-                                                },
-                                              ]
-                                            }
-                                            subPartDataAndHandlers={
-                                              Object {
-                                                "onTimestampClick": [Function],
-                                                "shouldDisableActions": undefined,
-                                              }
-                                            }
-                                          >
-                                            <span>
-                                              A nested header
-                                            </span>
-                                          </_default>
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </TitleLine>
-                                </Connect(TitleLine)>
-                                <UnmountClosed
-                                  isOpened={false}
-                                  springConfig={
-                                    Object {
-                                      "stiffness": 300,
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "marginRight": -0,
-                                    }
-                                  }
-                                />
-                                <Connect(HeaderContent)
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "A nested header",
-                                          },
-                                        ],
-                                        "rawTitle": "A nested header",
-                                        "todoKeyword": undefined,
-                                        "tags": Immutable.List [],
-                                      },
-                                      "rawDescription": "",
-                                      "description": Immutable.List [],
-                                      "opened": false,
-                            "id": 28,
-                                      "nestingLevel": 2,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                >
-                                  <HeaderContent
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "A nested header",
-                                            },
-                                          ],
-                                          "rawTitle": "A nested header",
-                                          "todoKeyword": undefined,
-                                          "tags": Immutable.List [],
-                                        },
-                                        "rawDescription": "",
-                                        "description": Immutable.List [],
-                                        "opened": false,
-                "id": 28,
-                                        "nestingLevel": 2,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    inTableEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                    selectedTableCellId={null}
-                                  >
-                                    <div />
-                                  </HeaderContent>
-                                </Connect(HeaderContent)>
-                              </div>
-                            </Motion>
-                          </Header>
-                        </Connect(Header)>
-                        <Connect(Header)
-                          color="rgba(42, 164, 168, 1)"
-                          hasContent={false}
-                          header={
-                            Immutable.Map {
-                              "titleLine": Immutable.Map {
-                                "title": Immutable.List [
-                                  Immutable.Map {
-                                    "type": "text",
-                                    "contents": "A todo item",
-                                  },
-                                ],
-                                "rawTitle": "A todo item",
-                                "todoKeyword": "TODO",
-                                "tags": Immutable.List [],
-                              },
-                              "rawDescription": "",
-                              "description": Immutable.List [],
-                              "opened": false,
-                              "id": 29,
-                              "nestingLevel": 2,
-                              "planningItems": Immutable.List [],
-                              "propertyListItems": Immutable.List [],
-                            }
-                          }
-                          isSelected={false}
-                          key="29"
-                          onRef={[Function]}
-                        >
-                          <Header
-                            base={
-                              Object {
-                                "activatePopup": [Function],
-                                "clearModalStack": [Function],
-                                "closePopup": [Function],
-                                "hideLoadingMessage": [Function],
-                                "loadStaticFile": [Function],
-                                "popModalPage": [Function],
-                                "pushModalPage": [Function],
-                                "restoreBaseSettings": [Function],
-                                "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                "setAgendaDefaultDeadlineDelayValue": [Function],
-                                "setBulletStyle": [Function],
-                                "setCustomKeybinding": [Function],
-                                "setDisappearingLoadingMessage": [Function],
-                                "setFontSize": [Function],
-                                "setHasUnseenChangelog": [Function],
-                                "setIsLoading": [Function],
-                                "setLastSeenChangelogHeader": [Function],
-                                "setLastViewedFile": [Function],
-                                "setLoadingMessage": [Function],
-                                "setShouldLiveSync": [Function],
-                                "setShouldStoreSettingsInSyncBackend": [Function],
-                                "setShouldTapTodoToAdvance": [Function],
-                                "unloadStaticFile": [Function],
-                              }
-                            }
-                            color="rgba(42, 164, 168, 1)"
-                            focusedHeader={null}
-                            hasContent={false}
-                            header={
-                              Immutable.Map {
-                                "titleLine": Immutable.Map {
-                                  "title": Immutable.List [
-                                    Immutable.Map {
-                                      "type": "text",
-                                      "contents": "A todo item",
-                                    },
-                                  ],
-                                  "rawTitle": "A todo item",
-                                  "todoKeyword": "TODO",
-                                  "tags": Immutable.List [],
-                                },
-                                "rawDescription": "",
-                                "description": Immutable.List [],
-                                "opened": false,
-                                        "id": 29,
-                                "nestingLevel": 2,
-                                "planningItems": Immutable.List [],
-                                "propertyListItems": Immutable.List [],
-                              }
-                            }
-                            inEditMode={false}
-                            isFocused={false}
-                            isSelected={false}
-                            onRef={[Function]}
-                            org={
-                              Object {
-                                "addHeader": [Function],
-                                "addHeaderAndEdit": [Function],
-                                "addNewPlanningItem": [Function],
-                                "addNewTableColumn": [Function],
-                                "addNewTableRow": [Function],
-                                "advanceCheckboxState": [Function],
-                                "advanceTodoState": [Function],
-                                "applyOpennessState": [Function],
-                                "clearPendingCapture": [Function],
-                                "displayFile": [Function],
-                                "enterEditMode": [Function],
-                                "exitEditMode": [Function],
-                                "focusHeader": [Function],
-                                "insertCapture": [Function],
-                                "insertPendingCapture": [Function],
-                                "moveHeaderDown": [Function],
-                                "moveHeaderLeft": [Function],
-                                "moveHeaderRight": [Function],
-                                "moveHeaderUp": [Function],
-                                "moveSubtreeLeft": [Function],
-                                "moveSubtreeRight": [Function],
-                                "moveTableColumnLeft": [Function],
-                                "moveTableColumnRight": [Function],
-                                "moveTableRowDown": [Function],
-                                "moveTableRowUp": [Function],
-                                "noOp": [Function],
-                                "openHeader": [Function],
-                                "removeHeader": [Function],
-                                "removeTableColumn": [Function],
-                                "removeTableRow": [Function],
-                                "reorderPropertyList": [Function],
-                                "reorderTags": [Function],
-                                "selectHeader": [Function],
-                                "selectHeaderAndOpenParents": [Function],
-                                "selectNextSiblingHeader": [Function],
-                                "selectNextVisibleHeader": [Function],
-                                "selectPreviousVisibleHeader": [Function],
-                                "setDirty": [Function],
-                                "setHeaderTags": [Function],
-                                "setLastSyncAt": [Function],
-                                "setOrgFileErrorMessage": [Function],
-                                "setSelectedTableCellId": [Function],
-                                "stopDisplayingFile": [Function],
-                                "sync": [Function],
-                                "toggleHeaderOpened": [Function],
-                                "unfocusHeader": [Function],
-                                "updateHeaderDescription": [Function],
-                                "updateHeaderTitle": [Function],
-                                "updatePlanningItemTimestamp": [Function],
-                                "updatePropertyListItems": [Function],
-                                "updateTableCellValue": [Function],
-                                "updateTimestampWithId": [Function],
-                              }
-                            }
-                          >
-                            <Motion
-                              onRest={[Function]}
-                              style={
-                                Object {
-                                  "heightFactor": 1,
-                                  "marginLeft": Object {
-                                    "damping": 26,
-                                    "precision": 0.01,
-                                    "stiffness": 300,
-                                    "val": 0,
-                                  },
-                                  "paddingLeft": 40,
-                                }
-                              }
-                            >
-                              <div
-                                className="header"
-                                onClick={[Function]}
-                                onMouseDown={[Function]}
-                                onMouseMove={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseUp={[Function]}
-                                onTouchCancel={[Function]}
-                                onTouchEnd={[Function]}
-                                onTouchMove={[Function]}
-                                onTouchStart={[Function]}
-                                style={
-                                  Object {
-                                    "marginLeft": 0,
-                                    "paddingLeft": 40,
-                                  }
-                                }
-                              >
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": 0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="left-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": 0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": -0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="right-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": -0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <div
-                                  className="header__bullet"
-                                  style={
-                                    Object {
-                                      "color": "rgba(42, 164, 168, 1)",
-                                      "marginLeft": -16,
-                                    }
-                                  }
-                                >
-                                  *
-                                </div>
-                                <Connect(TitleLine)
-                                  color="rgba(42, 164, 168, 1)"
-                                  hasContent={false}
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "A todo item",
-                                          },
-                                        ],
-                                        "rawTitle": "A todo item",
-                                        "todoKeyword": "TODO",
-                                        "tags": Immutable.List [],
-                                      },
-                                      "rawDescription": "",
-                                      "description": Immutable.List [],
-                                      "opened": false,
-                                      "id": 29,
-                                      "nestingLevel": 2,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                  isSelected={false}
-                                >
-                                  <TitleLine
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    color="rgba(42, 164, 168, 1)"
-                                    hasContent={false}
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "A todo item",
-                                            },
-                                          ],
-                                          "rawTitle": "A todo item",
-                                          "todoKeyword": "TODO",
-                                          "tags": Immutable.List [],
-                                        },
-                                        "rawDescription": "",
-                                        "description": Immutable.List [],
-                                        "opened": false,
-                                "id": 29,
-                                        "nestingLevel": 2,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                  >
-                                    <div
-                                      className="title-line"
-                                      onClick={[Function]}
-                                      style={
-                                        Object {
-                                          "width": 0,
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="todo-keyword todo-keyword--todo"
-                                        onClick={[Function]}
-                                      >
-                                        TODO
-                                      </span>
-                                      <div>
-                                        <span
-                                          style={
-                                            Object {
-                                              "color": "rgba(42, 164, 168, 1)",
-                                              "wordBreak": "break-word",
-                                            }
-                                          }
-                                        >
-                                          <_default
-                                            parts={
-                                              Immutable.List [
-                                                Immutable.Map {
-                                                  "type": "text",
-                                                  "contents": "A todo item",
-                                                },
-                                              ]
-                                            }
-                                            subPartDataAndHandlers={
-                                              Object {
-                                                "onTimestampClick": [Function],
-                                                "shouldDisableActions": undefined,
-                                              }
-                                            }
-                                          >
-                                            <span>
-                                              A todo item
-                                            </span>
-                                          </_default>
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </TitleLine>
-                                </Connect(TitleLine)>
-                                <UnmountClosed
-                                  isOpened={false}
-                                  springConfig={
-                                    Object {
-                                      "stiffness": 300,
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "marginRight": -0,
-                                    }
-                                  }
-                                />
-                                <Connect(HeaderContent)
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "A todo item",
-                                          },
-                                        ],
-                                        "rawTitle": "A todo item",
-                                        "todoKeyword": "TODO",
-                                        "tags": Immutable.List [],
-                                      },
-                                      "rawDescription": "",
-                                      "description": Immutable.List [],
-                                      "opened": false,
-                            "id": 29,
-                                      "nestingLevel": 2,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                >
-                                  <HeaderContent
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "A todo item",
-                                            },
-                                          ],
-                                          "rawTitle": "A todo item",
-                                          "todoKeyword": "TODO",
-                                          "tags": Immutable.List [],
-                                        },
-                                        "rawDescription": "",
-                                        "description": Immutable.List [],
-                                        "opened": false,
-                "id": 29,
-                                        "nestingLevel": 2,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    inTableEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                    selectedTableCellId={null}
-                                  >
-                                    <div />
-                                  </HeaderContent>
-                                </Connect(HeaderContent)>
-                              </div>
-                            </Motion>
-                          </Header>
-                        </Connect(Header)>
-                        <Connect(Header)
-                          color="rgba(42, 164, 168, 1)"
-                          hasContent={false}
-                          header={
-                            Immutable.Map {
-                              "titleLine": Immutable.Map {
-                                "title": Immutable.List [
-                                  Immutable.Map {
-                                    "type": "text",
-                                    "contents": "A finished todo item",
-                                  },
-                                ],
-                                "rawTitle": "A finished todo item",
-                                "todoKeyword": "DONE",
-                                "tags": Immutable.List [],
-                              },
-                              "rawDescription": "",
-                              "description": Immutable.List [],
-                              "opened": false,
-                              "id": 30,
-                              "nestingLevel": 2,
-                              "planningItems": Immutable.List [],
-                              "propertyListItems": Immutable.List [],
-                            }
-                          }
-                          isSelected={false}
-                          key="30"
-                          onRef={[Function]}
-                        >
-                          <Header
-                            base={
-                              Object {
-                                "activatePopup": [Function],
-                                "clearModalStack": [Function],
-                                "closePopup": [Function],
-                                "hideLoadingMessage": [Function],
-                                "loadStaticFile": [Function],
-                                "popModalPage": [Function],
-                                "pushModalPage": [Function],
-                                "restoreBaseSettings": [Function],
-                                "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                "setAgendaDefaultDeadlineDelayValue": [Function],
-                                "setBulletStyle": [Function],
-                                "setCustomKeybinding": [Function],
-                                "setDisappearingLoadingMessage": [Function],
-                                "setFontSize": [Function],
-                                "setHasUnseenChangelog": [Function],
-                                "setIsLoading": [Function],
-                                "setLastSeenChangelogHeader": [Function],
-                                "setLastViewedFile": [Function],
-                                "setLoadingMessage": [Function],
-                                "setShouldLiveSync": [Function],
-                                "setShouldStoreSettingsInSyncBackend": [Function],
-                                "setShouldTapTodoToAdvance": [Function],
-                                "unloadStaticFile": [Function],
-                              }
-                            }
-                            color="rgba(42, 164, 168, 1)"
-                            focusedHeader={null}
-                            hasContent={false}
-                            header={
-                              Immutable.Map {
-                                "titleLine": Immutable.Map {
-                                  "title": Immutable.List [
-                                    Immutable.Map {
-                                      "type": "text",
-                                      "contents": "A finished todo item",
-                                    },
-                                  ],
-                                  "rawTitle": "A finished todo item",
-                                  "todoKeyword": "DONE",
-                                  "tags": Immutable.List [],
-                                },
-                                "rawDescription": "",
-                                "description": Immutable.List [],
-                                "opened": false,
-                                        "id": 30,
-                                "nestingLevel": 2,
-                                "planningItems": Immutable.List [],
-                                "propertyListItems": Immutable.List [],
-                              }
-                            }
-                            inEditMode={false}
-                            isFocused={false}
-                            isSelected={false}
-                            onRef={[Function]}
-                            org={
-                              Object {
-                                "addHeader": [Function],
-                                "addHeaderAndEdit": [Function],
-                                "addNewPlanningItem": [Function],
-                                "addNewTableColumn": [Function],
-                                "addNewTableRow": [Function],
-                                "advanceCheckboxState": [Function],
-                                "advanceTodoState": [Function],
-                                "applyOpennessState": [Function],
-                                "clearPendingCapture": [Function],
-                                "displayFile": [Function],
-                                "enterEditMode": [Function],
-                                "exitEditMode": [Function],
-                                "focusHeader": [Function],
-                                "insertCapture": [Function],
-                                "insertPendingCapture": [Function],
-                                "moveHeaderDown": [Function],
-                                "moveHeaderLeft": [Function],
-                                "moveHeaderRight": [Function],
-                                "moveHeaderUp": [Function],
-                                "moveSubtreeLeft": [Function],
-                                "moveSubtreeRight": [Function],
-                                "moveTableColumnLeft": [Function],
-                                "moveTableColumnRight": [Function],
-                                "moveTableRowDown": [Function],
-                                "moveTableRowUp": [Function],
-                                "noOp": [Function],
-                                "openHeader": [Function],
-                                "removeHeader": [Function],
-                                "removeTableColumn": [Function],
-                                "removeTableRow": [Function],
-                                "reorderPropertyList": [Function],
-                                "reorderTags": [Function],
-                                "selectHeader": [Function],
-                                "selectHeaderAndOpenParents": [Function],
-                                "selectNextSiblingHeader": [Function],
-                                "selectNextVisibleHeader": [Function],
-                                "selectPreviousVisibleHeader": [Function],
-                                "setDirty": [Function],
-                                "setHeaderTags": [Function],
-                                "setLastSyncAt": [Function],
-                                "setOrgFileErrorMessage": [Function],
-                                "setSelectedTableCellId": [Function],
-                                "stopDisplayingFile": [Function],
-                                "sync": [Function],
-                                "toggleHeaderOpened": [Function],
-                                "unfocusHeader": [Function],
-                                "updateHeaderDescription": [Function],
-                                "updateHeaderTitle": [Function],
-                                "updatePlanningItemTimestamp": [Function],
-                                "updatePropertyListItems": [Function],
-                                "updateTableCellValue": [Function],
-                                "updateTimestampWithId": [Function],
-                              }
-                            }
-                          >
-                            <Motion
-                              onRest={[Function]}
-                              style={
-                                Object {
-                                  "heightFactor": 1,
-                                  "marginLeft": Object {
-                                    "damping": 26,
-                                    "precision": 0.01,
-                                    "stiffness": 300,
-                                    "val": 0,
-                                  },
-                                  "paddingLeft": 40,
-                                }
-                              }
-                            >
-                              <div
-                                className="header"
-                                onClick={[Function]}
-                                onMouseDown={[Function]}
-                                onMouseMove={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseUp={[Function]}
-                                onTouchCancel={[Function]}
-                                onTouchEnd={[Function]}
-                                onTouchMove={[Function]}
-                                onTouchStart={[Function]}
-                                style={
-                                  Object {
-                                    "marginLeft": 0,
-                                    "paddingLeft": 40,
-                                  }
-                                }
-                              >
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": 0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="left-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": 0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": -0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="right-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": -0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <div
-                                  className="header__bullet"
-                                  style={
-                                    Object {
-                                      "color": "rgba(42, 164, 168, 1)",
-                                      "marginLeft": -16,
-                                    }
-                                  }
-                                >
-                                  *
-                                </div>
-                                <Connect(TitleLine)
-                                  color="rgba(42, 164, 168, 1)"
-                                  hasContent={false}
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "A finished todo item",
-                                          },
-                                        ],
-                                        "rawTitle": "A finished todo item",
-                                        "todoKeyword": "DONE",
-                                        "tags": Immutable.List [],
-                                      },
-                                      "rawDescription": "",
-                                      "description": Immutable.List [],
-                                      "opened": false,
-                                      "id": 30,
-                                      "nestingLevel": 2,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                  isSelected={false}
-                                >
-                                  <TitleLine
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    color="rgba(42, 164, 168, 1)"
-                                    hasContent={false}
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "A finished todo item",
-                                            },
-                                          ],
-                                          "rawTitle": "A finished todo item",
-                                          "todoKeyword": "DONE",
-                                          "tags": Immutable.List [],
-                                        },
-                                        "rawDescription": "",
-                                        "description": Immutable.List [],
-                                        "opened": false,
-                                "id": 30,
-                                        "nestingLevel": 2,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                  >
-                                    <div
-                                      className="title-line"
-                                      onClick={[Function]}
-                                      style={
-                                        Object {
-                                          "width": 0,
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="todo-keyword todo-keyword--done"
-                                        onClick={[Function]}
-                                      >
-                                        DONE
-                                      </span>
-                                      <div>
-                                        <span
-                                          style={
-                                            Object {
-                                              "color": "rgba(42, 164, 168, 1)",
-                                              "wordBreak": "break-word",
-                                            }
-                                          }
-                                        >
-                                          <_default
-                                            parts={
-                                              Immutable.List [
-                                                Immutable.Map {
-                                                  "type": "text",
-                                                  "contents": "A finished todo item",
-                                                },
-                                              ]
-                                            }
-                                            subPartDataAndHandlers={
-                                              Object {
-                                                "onTimestampClick": [Function],
-                                                "shouldDisableActions": undefined,
-                                              }
-                                            }
-                                          >
-                                            <span>
-                                              A finished todo item
-                                            </span>
-                                          </_default>
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </TitleLine>
-                                </Connect(TitleLine)>
-                                <UnmountClosed
-                                  isOpened={false}
-                                  springConfig={
-                                    Object {
-                                      "stiffness": 300,
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "marginRight": -0,
-                                    }
-                                  }
-                                />
-                                <Connect(HeaderContent)
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "A finished todo item",
-                                          },
-                                        ],
-                                        "rawTitle": "A finished todo item",
-                                        "todoKeyword": "DONE",
-                                        "tags": Immutable.List [],
-                                      },
-                                      "rawDescription": "",
-                                      "description": Immutable.List [],
-                                      "opened": false,
-                            "id": 30,
-                                      "nestingLevel": 2,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                >
-                                  <HeaderContent
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "A finished todo item",
-                                            },
-                                          ],
-                                          "rawTitle": "A finished todo item",
-                                          "todoKeyword": "DONE",
-                                          "tags": Immutable.List [],
-                                        },
-                                        "rawDescription": "",
-                                        "description": Immutable.List [],
-                                        "opened": false,
-                "id": 30,
-                                        "nestingLevel": 2,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    inTableEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                    selectedTableCellId={null}
-                                  >
-                                    <div />
-                                  </HeaderContent>
-                                </Connect(HeaderContent)>
-                              </div>
-                            </Motion>
-                          </Header>
-                        </Connect(Header)>
-                        <Connect(Header)
-                          color="rgba(38, 143, 214, 1)"
-                          hasContent={true}
-                          header={
-                            Immutable.Map {
-                              "titleLine": Immutable.Map {
-                                "title": Immutable.List [
-                                  Immutable.Map {
-                                    "type": "text",
-                                    "contents": "Another top level header",
-                                  },
-                                ],
-                                "rawTitle": "Another top level header",
-                                "todoKeyword": undefined,
-                                "tags": Immutable.List [],
-                              },
-                              "rawDescription": "Some description content",
-                              "description": Immutable.List [
-                                Immutable.Map {
-                                  "type": "text",
-                                  "contents": "Some description content",
-                                },
-                              ],
-                              "opened": false,
-                              "id": 31,
-                              "nestingLevel": 1,
-                              "planningItems": Immutable.List [],
-                              "propertyListItems": Immutable.List [],
-                            }
-                          }
-                          isSelected={false}
-                          key="31"
-                          onRef={[Function]}
-                        >
-                          <Header
-                            base={
-                              Object {
-                                "activatePopup": [Function],
-                                "clearModalStack": [Function],
-                                "closePopup": [Function],
-                                "hideLoadingMessage": [Function],
-                                "loadStaticFile": [Function],
-                                "popModalPage": [Function],
-                                "pushModalPage": [Function],
-                                "restoreBaseSettings": [Function],
-                                "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                "setAgendaDefaultDeadlineDelayValue": [Function],
-                                "setBulletStyle": [Function],
-                                "setCustomKeybinding": [Function],
-                                "setDisappearingLoadingMessage": [Function],
-                                "setFontSize": [Function],
-                                "setHasUnseenChangelog": [Function],
-                                "setIsLoading": [Function],
-                                "setLastSeenChangelogHeader": [Function],
-                                "setLastViewedFile": [Function],
-                                "setLoadingMessage": [Function],
-                                "setShouldLiveSync": [Function],
-                                "setShouldStoreSettingsInSyncBackend": [Function],
-                                "setShouldTapTodoToAdvance": [Function],
-                                "unloadStaticFile": [Function],
-                              }
-                            }
-                            color="rgba(38, 143, 214, 1)"
-                            focusedHeader={null}
-                            hasContent={true}
-                            header={
-                              Immutable.Map {
-                                "titleLine": Immutable.Map {
-                                  "title": Immutable.List [
-                                    Immutable.Map {
-                                      "type": "text",
-                                      "contents": "Another top level header",
-                                    },
-                                  ],
-                                  "rawTitle": "Another top level header",
-                                  "todoKeyword": undefined,
-                                  "tags": Immutable.List [],
-                                },
-                                "rawDescription": "Some description content",
-                                "description": Immutable.List [
-                                  Immutable.Map {
-                                    "type": "text",
-                                    "contents": "Some description content",
-                                  },
-                                ],
-                                "opened": false,
-                                        "id": 31,
-                                "nestingLevel": 1,
-                                "planningItems": Immutable.List [],
-                                "propertyListItems": Immutable.List [],
-                              }
-                            }
-                            inEditMode={false}
-                            isFocused={false}
-                            isSelected={false}
-                            onRef={[Function]}
-                            org={
-                              Object {
-                                "addHeader": [Function],
-                                "addHeaderAndEdit": [Function],
-                                "addNewPlanningItem": [Function],
-                                "addNewTableColumn": [Function],
-                                "addNewTableRow": [Function],
-                                "advanceCheckboxState": [Function],
-                                "advanceTodoState": [Function],
-                                "applyOpennessState": [Function],
-                                "clearPendingCapture": [Function],
-                                "displayFile": [Function],
-                                "enterEditMode": [Function],
-                                "exitEditMode": [Function],
-                                "focusHeader": [Function],
-                                "insertCapture": [Function],
-                                "insertPendingCapture": [Function],
-                                "moveHeaderDown": [Function],
-                                "moveHeaderLeft": [Function],
-                                "moveHeaderRight": [Function],
-                                "moveHeaderUp": [Function],
-                                "moveSubtreeLeft": [Function],
-                                "moveSubtreeRight": [Function],
-                                "moveTableColumnLeft": [Function],
-                                "moveTableColumnRight": [Function],
-                                "moveTableRowDown": [Function],
-                                "moveTableRowUp": [Function],
-                                "noOp": [Function],
-                                "openHeader": [Function],
-                                "removeHeader": [Function],
-                                "removeTableColumn": [Function],
-                                "removeTableRow": [Function],
-                                "reorderPropertyList": [Function],
-                                "reorderTags": [Function],
-                                "selectHeader": [Function],
-                                "selectHeaderAndOpenParents": [Function],
-                                "selectNextSiblingHeader": [Function],
-                                "selectNextVisibleHeader": [Function],
-                                "selectPreviousVisibleHeader": [Function],
-                                "setDirty": [Function],
-                                "setHeaderTags": [Function],
-                                "setLastSyncAt": [Function],
-                                "setOrgFileErrorMessage": [Function],
-                                "setSelectedTableCellId": [Function],
-                                "stopDisplayingFile": [Function],
-                                "sync": [Function],
-                                "toggleHeaderOpened": [Function],
-                                "unfocusHeader": [Function],
-                                "updateHeaderDescription": [Function],
-                                "updateHeaderTitle": [Function],
-                                "updatePlanningItemTimestamp": [Function],
-                                "updatePropertyListItems": [Function],
-                                "updateTableCellValue": [Function],
-                                "updateTimestampWithId": [Function],
-                              }
-                            }
-                          >
-                            <Motion
-                              onRest={[Function]}
-                              style={
-                                Object {
-                                  "heightFactor": 1,
-                                  "marginLeft": Object {
-                                    "damping": 26,
-                                    "precision": 0.01,
-                                    "stiffness": 300,
-                                    "val": 0,
-                                  },
-                                  "paddingLeft": 20,
-                                }
-                              }
-                            >
-                              <div
-                                className="header"
-                                onClick={[Function]}
-                                onMouseDown={[Function]}
-                                onMouseMove={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseUp={[Function]}
-                                onTouchCancel={[Function]}
-                                onTouchEnd={[Function]}
-                                onTouchMove={[Function]}
-                                onTouchStart={[Function]}
-                                style={
-                                  Object {
-                                    "marginLeft": 0,
-                                    "paddingLeft": 20,
-                                  }
-                                }
-                              >
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": 0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="left-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": 0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": -0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="right-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": -0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <div
-                                  className="header__bullet"
-                                  style={
-                                    Object {
-                                      "color": "rgba(38, 143, 214, 1)",
-                                      "marginLeft": -16,
-                                    }
-                                  }
-                                >
-                                  *
-                                </div>
-                                <Connect(TitleLine)
-                                  color="rgba(38, 143, 214, 1)"
-                                  hasContent={true}
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "Another top level header",
-                                          },
-                                        ],
-                                        "rawTitle": "Another top level header",
-                                        "todoKeyword": undefined,
-                                        "tags": Immutable.List [],
-                                      },
-                                      "rawDescription": "Some description content",
-                                      "description": Immutable.List [
-                                        Immutable.Map {
-                                          "type": "text",
-                                          "contents": "Some description content",
-                                        },
-                                      ],
-                                      "opened": false,
-                "id": 31,
-                                      "nestingLevel": 1,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                  isSelected={false}
-                                >
-                                  <TitleLine
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    color="rgba(38, 143, 214, 1)"
-                                    hasContent={true}
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "Another top level header",
-                                            },
-                                          ],
-                                          "rawTitle": "Another top level header",
-                                          "todoKeyword": undefined,
-                                          "tags": Immutable.List [],
-                                        },
-                                        "rawDescription": "Some description content",
-                                        "description": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "Some description content",
-                                          },
-                                        ],
-                                        "opened": false,
-                                      "id": 31,
-                                        "nestingLevel": 1,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                  >
-                                    <div
-                                      className="title-line"
-                                      onClick={[Function]}
-                                      style={
-                                        Object {
-                                          "width": 0,
-                                        }
-                                      }
-                                    >
-                                      <div>
-                                        <span
-                                          style={
-                                            Object {
-                                              "color": "rgba(38, 143, 214, 1)",
-                                              "wordBreak": "break-word",
-                                            }
-                                          }
-                                        >
-                                          <_default
-                                            parts={
-                                              Immutable.List [
-                                                Immutable.Map {
-                                                  "type": "text",
-                                                  "contents": "Another top level header",
-                                                },
-                                              ]
-                                            }
-                                            subPartDataAndHandlers={
-                                              Object {
-                                                "onTimestampClick": [Function],
-                                                "shouldDisableActions": undefined,
-                                              }
-                                            }
-                                          >
-                                            <span>
-                                              Another top level header
-                                            </span>
-                                          </_default>
-                                          ...
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </TitleLine>
-                                </Connect(TitleLine)>
-                                <UnmountClosed
-                                  isOpened={false}
-                                  springConfig={
-                                    Object {
-                                      "stiffness": 300,
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "marginRight": -0,
-                                    }
-                                  }
-                                />
-                                <Connect(HeaderContent)
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "Another top level header",
-                                          },
-                                        ],
-                                        "rawTitle": "Another top level header",
-                                        "todoKeyword": undefined,
-                                        "tags": Immutable.List [],
-                                      },
-                                      "rawDescription": "Some description content",
-                                      "description": Immutable.List [
-                                        Immutable.Map {
-                                          "type": "text",
-                                          "contents": "Some description content",
-                                        },
-                                      ],
-                                      "opened": false,
-                                "id": 31,
-                                      "nestingLevel": 1,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                >
-                                  <HeaderContent
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "Another top level header",
-                                            },
-                                          ],
-                                          "rawTitle": "Another top level header",
-                                          "todoKeyword": undefined,
-                                          "tags": Immutable.List [],
-                                        },
-                                        "rawDescription": "Some description content",
-                                        "description": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "Some description content",
-                                          },
-                                        ],
-                                        "opened": false,
-                            "id": 31,
-                                        "nestingLevel": 1,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    inTableEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                    selectedTableCellId={null}
-                                  >
-                                    <div />
-                                  </HeaderContent>
-                                </Connect(HeaderContent)>
-                              </div>
-                            </Motion>
-                          </Header>
-                        </Connect(Header)>
-                        <Connect(Header)
-                          color="rgba(38, 143, 214, 1)"
-                          hasContent={false}
-                          header={
-                            Immutable.Map {
-                              "titleLine": Immutable.Map {
-                                "title": Immutable.List [
-                                  Immutable.Map {
-                                    "type": "text",
-                                    "contents": "A header with tags                                              ",
-                                  },
-                                ],
-                                "rawTitle": "A header with tags                                              ",
-                                "todoKeyword": undefined,
-                                "tags": Immutable.List [
-                                  "tag1",
-                                  "tag2",
-                                ],
-                              },
-                              "rawDescription": "",
-                              "description": Immutable.List [],
-                              "opened": false,
-                "id": 32,
-                              "nestingLevel": 1,
-                              "planningItems": Immutable.List [],
-                              "propertyListItems": Immutable.List [],
-                            }
-                          }
-                          isSelected={false}
-                          key="8"
-                          onRef={[Function]}
-                        >
-                          <Header
-                            base={
-                              Object {
-                                "activatePopup": [Function],
-                                "clearModalStack": [Function],
-                                "closePopup": [Function],
-                                "hideLoadingMessage": [Function],
-                                "loadStaticFile": [Function],
-                                "popModalPage": [Function],
-                                "pushModalPage": [Function],
-                                "restoreBaseSettings": [Function],
-                                "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                "setAgendaDefaultDeadlineDelayValue": [Function],
-                                "setBulletStyle": [Function],
-                                "setCustomKeybinding": [Function],
-                                "setDisappearingLoadingMessage": [Function],
-                                "setFontSize": [Function],
-                                "setHasUnseenChangelog": [Function],
-                                "setIsLoading": [Function],
-                                "setLastSeenChangelogHeader": [Function],
-                                "setLastViewedFile": [Function],
-                                "setLoadingMessage": [Function],
-                                "setShouldLiveSync": [Function],
-                                "setShouldStoreSettingsInSyncBackend": [Function],
-                                "setShouldTapTodoToAdvance": [Function],
-                                "unloadStaticFile": [Function],
-                              }
-                            }
-                            color="rgba(38, 143, 214, 1)"
-                            focusedHeader={null}
-                            hasContent={false}
-                            header={
-                              Immutable.Map {
-                                "titleLine": Immutable.Map {
-                                  "title": Immutable.List [
-                                    Immutable.Map {
-                                      "type": "text",
-                                      "contents": "A header with tags                                              ",
-                                    },
-                                  ],
-                                  "rawTitle": "A header with tags                                              ",
-                                  "todoKeyword": undefined,
-                                  "tags": Immutable.List [
-                                    "tag1",
-                                    "tag2",
-                                  ],
-                                },
-                                "rawDescription": "",
-                                "description": Immutable.List [],
-                                "opened": false,
-                            "id": 32,
-                                "nestingLevel": 1,
-                                "planningItems": Immutable.List [],
-                                "propertyListItems": Immutable.List [],
-                              }
-                            }
-                            inEditMode={false}
-                            isFocused={false}
-                            isSelected={false}
-                            onRef={[Function]}
-                            org={
-                              Object {
-                                "addHeader": [Function],
-                                "addHeaderAndEdit": [Function],
-                                "addNewPlanningItem": [Function],
-                                "addNewTableColumn": [Function],
-                                "addNewTableRow": [Function],
-                                "advanceCheckboxState": [Function],
-                                "advanceTodoState": [Function],
-                                "applyOpennessState": [Function],
-                                "clearPendingCapture": [Function],
-                                "displayFile": [Function],
-                                "enterEditMode": [Function],
-                                "exitEditMode": [Function],
-                                "focusHeader": [Function],
-                                "insertCapture": [Function],
-                                "insertPendingCapture": [Function],
-                                "moveHeaderDown": [Function],
-                                "moveHeaderLeft": [Function],
-                                "moveHeaderRight": [Function],
-                                "moveHeaderUp": [Function],
-                                "moveSubtreeLeft": [Function],
-                                "moveSubtreeRight": [Function],
-                                "moveTableColumnLeft": [Function],
-                                "moveTableColumnRight": [Function],
-                                "moveTableRowDown": [Function],
-                                "moveTableRowUp": [Function],
-                                "noOp": [Function],
-                                "openHeader": [Function],
-                                "removeHeader": [Function],
-                                "removeTableColumn": [Function],
-                                "removeTableRow": [Function],
-                                "reorderPropertyList": [Function],
-                                "reorderTags": [Function],
-                                "selectHeader": [Function],
-                                "selectHeaderAndOpenParents": [Function],
-                                "selectNextSiblingHeader": [Function],
-                                "selectNextVisibleHeader": [Function],
-                                "selectPreviousVisibleHeader": [Function],
-                                "setDirty": [Function],
-                                "setHeaderTags": [Function],
-                                "setLastSyncAt": [Function],
-                                "setOrgFileErrorMessage": [Function],
-                                "setSelectedTableCellId": [Function],
-                                "stopDisplayingFile": [Function],
-                                "sync": [Function],
-                                "toggleHeaderOpened": [Function],
-                                "unfocusHeader": [Function],
-                                "updateHeaderDescription": [Function],
-                                "updateHeaderTitle": [Function],
-                                "updatePlanningItemTimestamp": [Function],
-                                "updatePropertyListItems": [Function],
-                                "updateTableCellValue": [Function],
-                                "updateTimestampWithId": [Function],
-                              }
-                            }
-                          >
-                            <Motion
-                              onRest={[Function]}
-                              style={
-                                Object {
-                                  "heightFactor": 1,
-                                  "marginLeft": Object {
-                                    "damping": 26,
-                                    "precision": 0.01,
-                                    "stiffness": 300,
-                                    "val": 0,
-                                  },
-                                  "paddingLeft": 20,
-                                }
-                              }
-                            >
-                              <div
-                                className="header"
-                                onClick={[Function]}
-                                onMouseDown={[Function]}
-                                onMouseMove={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseUp={[Function]}
-                                onTouchCancel={[Function]}
-                                onTouchEnd={[Function]}
-                                onTouchMove={[Function]}
-                                onTouchStart={[Function]}
-                                style={
-                                  Object {
-                                    "marginLeft": 0,
-                                    "paddingLeft": 20,
-                                  }
-                                }
-                              >
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": 0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="left-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": 0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": -0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="right-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": -0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <div
-                                  className="header__bullet"
-                                  style={
-                                    Object {
-                                      "color": "rgba(38, 143, 214, 1)",
-                                      "marginLeft": -16,
-                                    }
-                                  }
-                                >
-                                  *
-                                </div>
-                                <Connect(TitleLine)
-                                  color="rgba(38, 143, 214, 1)"
-                                  hasContent={false}
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "A header with tags                                              ",
-                                          },
-                                        ],
-                                        "rawTitle": "A header with tags                                              ",
-                                        "todoKeyword": undefined,
-                                        "tags": Immutable.List [
-                                          "tag1",
-                                          "tag2",
-                                        ],
-                                      },
-                                      "rawDescription": "",
-                                      "description": Immutable.List [],
-                                      "opened": false,
-                                      "id": 32,
-                                      "nestingLevel": 1,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                  isSelected={false}
-                                >
-                                  <TitleLine
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    color="rgba(38, 143, 214, 1)"
-                                    hasContent={false}
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "A header with tags                                              ",
-                                            },
-                                          ],
-                                          "rawTitle": "A header with tags                                              ",
-                                          "todoKeyword": undefined,
-                                          "tags": Immutable.List [
-                                            "tag1",
-                                            "tag2",
-                                          ],
-                                        },
-                                        "rawDescription": "",
-                                        "description": Immutable.List [],
-                                        "opened": false,
-                                        "id": 32,
-                                        "nestingLevel": 1,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                  >
-                                    <div
-                                      className="title-line"
-                                      onClick={[Function]}
-                                      style={
-                                        Object {
-                                          "width": 0,
-                                        }
-                                      }
-                                    >
-                                      <div>
-                                        <span
-                                          style={
-                                            Object {
-                                              "color": "rgba(38, 143, 214, 1)",
-                                              "wordBreak": "break-word",
-                                            }
-                                          }
-                                        >
-                                          <_default
-                                            parts={
-                                              Immutable.List [
-                                                Immutable.Map {
-                                                  "type": "text",
-                                                  "contents": "A header with tags                                              ",
-                                                },
-                                              ]
-                                            }
-                                            subPartDataAndHandlers={
-                                              Object {
-                                                "onTimestampClick": [Function],
-                                                "shouldDisableActions": undefined,
-                                              }
-                                            }
-                                          >
-                                            <span>
-                                              A header with tags                                              
-                                            </span>
-                                          </_default>
-                                        </span>
-                                        <div>
-                                          <div
-                                            className="header-tag"
-                                            key="tag1"
-                                          >
-                                            tag1
-                                          </div>
-                                          <div
-                                            className="header-tag"
-                                            key="tag2"
-                                          >
-                                            tag2
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </TitleLine>
-                                </Connect(TitleLine)>
-                                <UnmountClosed
-                                  isOpened={false}
-                                  springConfig={
-                                    Object {
-                                      "stiffness": 300,
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "marginRight": -0,
-                                    }
-                                  }
-                                />
-                                <Connect(HeaderContent)
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "A header with tags                                              ",
-                                          },
-                                        ],
-                                        "rawTitle": "A header with tags                                              ",
-                                        "todoKeyword": undefined,
-                                        "tags": Immutable.List [
-                                          "tag1",
-                                          "tag2",
-                                        ],
-                                      },
-                                      "rawDescription": "",
-                                      "description": Immutable.List [],
-                                      "opened": false,
-                                      "id": 32,
-                                      "nestingLevel": 1,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                >
-                                  <HeaderContent
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "A header with tags                                              ",
-                                            },
-                                          ],
-                                          "rawTitle": "A header with tags                                              ",
-                                          "todoKeyword": undefined,
-                                          "tags": Immutable.List [
-                                            "tag1",
-                                            "tag2",
-                                          ],
-                                        },
-                                        "rawDescription": "",
-                                        "description": Immutable.List [],
-                                        "opened": false,
-                                "id": 32,
-                                        "nestingLevel": 1,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    inTableEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                    selectedTableCellId={null}
-                                  >
-                                    <div />
-                                  </HeaderContent>
-                                </Connect(HeaderContent)>
-                              </div>
-                            </Motion>
-                          </Header>
-                        </Connect(Header)>
-                        <Connect(Header)
-                          color="rgba(38, 143, 214, 1)"
-                          hasContent={false}
-                          header={
-                            Immutable.Map {
-                              "titleLine": Immutable.Map {
-                                "title": Immutable.List [
-                                  Immutable.Map {
-                                    "type": "text",
-                                    "contents": "A header with ",
-                                  },
-                                  Immutable.Map {
-                      "id": 33,
-                                    "type": "link",
-                                    "contents": Immutable.Map {
-                                      "uri": "https://google.com",
-                                      "title": "a link",
-                                    },
-                                  },
-                                ],
-                                "rawTitle": "A header with [[https://google.com][a link]]",
-                                "todoKeyword": undefined,
-                                "tags": Immutable.List [],
-                              },
-                              "rawDescription": "",
-                              "description": Immutable.List [],
-                              "opened": false,
-                "id": 34,
-                              "nestingLevel": 1,
-                              "planningItems": Immutable.List [],
-                              "propertyListItems": Immutable.List [],
-                            }
-                          }
-                          isSelected={false}
-                          key="10"
-                          onRef={[Function]}
-                        >
-                          <Header
-                            base={
-                              Object {
-                                "activatePopup": [Function],
-                                "clearModalStack": [Function],
-                                "closePopup": [Function],
-                                "hideLoadingMessage": [Function],
-                                "loadStaticFile": [Function],
-                                "popModalPage": [Function],
-                                "pushModalPage": [Function],
-                                "restoreBaseSettings": [Function],
-                                "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                "setAgendaDefaultDeadlineDelayValue": [Function],
-                                "setBulletStyle": [Function],
-                                "setCustomKeybinding": [Function],
-                                "setDisappearingLoadingMessage": [Function],
-                                "setFontSize": [Function],
-                                "setHasUnseenChangelog": [Function],
-                                "setIsLoading": [Function],
-                                "setLastSeenChangelogHeader": [Function],
-                                "setLastViewedFile": [Function],
-                                "setLoadingMessage": [Function],
-                                "setShouldLiveSync": [Function],
-                                "setShouldStoreSettingsInSyncBackend": [Function],
-                                "setShouldTapTodoToAdvance": [Function],
-                                "unloadStaticFile": [Function],
-                              }
-                            }
-                            color="var(--blue)"
-                            focusedHeader={null}
-                            hasContent={false}
-                            header={
-                              Immutable.Map {
-                                "titleLine": Immutable.Map {
-                                  "title": Immutable.List [
-                                    Immutable.Map {
-                                      "type": "text",
-                                      "contents": "A header with ",
-                                    },
-                                    Immutable.Map {
-                                  "id": 33,
-                                      "type": "link",
-                                      "contents": Immutable.Map {
-                                        "uri": "https://google.com",
-                                        "title": "a link",
-                                      },
-                                    },
-                                  ],
-                                  "rawTitle": "A header with [[https://google.com][a link]]",
-                                  "todoKeyword": undefined,
-                                  "tags": Immutable.List [],
-                                },
-                                "rawDescription": "",
-                                "description": Immutable.List [],
-                                "opened": false,
-                                        "id": 34,
-                                "nestingLevel": 1,
-                                "planningItems": Immutable.List [],
-                                "propertyListItems": Immutable.List [],
-                              }
-                            }
-                            inEditMode={false}
-                            isFocused={false}
-                            isSelected={false}
-                            onRef={[Function]}
-                            org={
-                              Object {
-                                "addHeader": [Function],
-                                "addHeaderAndEdit": [Function],
-                                "addNewPlanningItem": [Function],
-                                "addNewTableColumn": [Function],
-                                "addNewTableRow": [Function],
-                                "advanceCheckboxState": [Function],
-                                "advanceTodoState": [Function],
-                                "applyOpennessState": [Function],
-                                "clearPendingCapture": [Function],
-                                "displayFile": [Function],
-                                "enterEditMode": [Function],
-                                "exitEditMode": [Function],
-                                "focusHeader": [Function],
-                                "insertCapture": [Function],
-                                "insertPendingCapture": [Function],
-                                "moveHeaderDown": [Function],
-                                "moveHeaderLeft": [Function],
-                                "moveHeaderRight": [Function],
-                                "moveHeaderUp": [Function],
-                                "moveSubtreeLeft": [Function],
-                                "moveSubtreeRight": [Function],
-                                "moveTableColumnLeft": [Function],
-                                "moveTableColumnRight": [Function],
-                                "moveTableRowDown": [Function],
-                                "moveTableRowUp": [Function],
-                                "noOp": [Function],
-                                "openHeader": [Function],
-                                "removeHeader": [Function],
-                                "removeTableColumn": [Function],
-                                "removeTableRow": [Function],
-                                "reorderPropertyList": [Function],
-                                "reorderTags": [Function],
-                                "selectHeader": [Function],
-                                "selectHeaderAndOpenParents": [Function],
-                                "selectNextSiblingHeader": [Function],
-                                "selectNextVisibleHeader": [Function],
-                                "selectPreviousVisibleHeader": [Function],
-                                "setDirty": [Function],
-                                "setHeaderTags": [Function],
-                                "setLastSyncAt": [Function],
-                                "setOrgFileErrorMessage": [Function],
-                                "setSelectedTableCellId": [Function],
-                                "stopDisplayingFile": [Function],
-                                "sync": [Function],
-                                "toggleHeaderOpened": [Function],
-                                "unfocusHeader": [Function],
-                                "updateHeaderDescription": [Function],
-                                "updateHeaderTitle": [Function],
-                                "updatePlanningItemTimestamp": [Function],
-                                "updatePropertyListItems": [Function],
-                                "updateTableCellValue": [Function],
-                                "updateTimestampWithId": [Function],
-                              }
-                            }
-                          >
-                            <Motion
-                              onRest={[Function]}
-                              style={
-                                Object {
-                                  "heightFactor": 1,
-                                  "marginLeft": Object {
-                                    "damping": 26,
-                                    "precision": 0.01,
-                                    "stiffness": 300,
-                                    "val": 0,
-                                  },
-                                  "paddingLeft": 20,
-                                }
-                              }
-                            >
-                              <div
-                                className="header"
-                                onClick={[Function]}
-                                onMouseDown={[Function]}
-                                onMouseMove={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseUp={[Function]}
-                                onTouchCancel={[Function]}
-                                onTouchEnd={[Function]}
-                                onTouchMove={[Function]}
-                                onTouchStart={[Function]}
-                                style={
-                                  Object {
-                                    "marginLeft": 0,
-                                    "paddingLeft": 20,
-                                  }
-                                }
-                              >
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": 0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="left-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": 0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <Motion
-                                  style={
-                                    Object {
-                                      "backgroundColorFactor": Object {
-                                        "damping": 26,
-                                        "precision": 0.01,
-                                        "stiffness": 300,
-                                        "val": 0,
-                                      },
-                                      "width": -0,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="right-swipe-action-container"
-                                    style={
-                                      Object {
-                                        "backgroundColor": "rgba(211, 211, 211, 1)",
-                                        "width": -0,
-                                      }
-                                    }
-                                  >
-                                    <i
-                                      className="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
-                                      style={
-                                        Object {
-                                          "display": "none",
-                                        }
-                                      }
-                                    />
-                                  </div>
-                                </Motion>
-                                <div
-                                  className="header__bullet"
-                                  style={
-                                    Object {
-                                      "color": "rgba(38, 143, 214, 1)",
-                                      "marginLeft": -16,
-                                    }
-                                  }
-                                >
-                                  *
-                                </div>
-                                <Connect(TitleLine)
-                                  color="rgba(38, 143, 214, 1)"
-                                  hasContent={false}
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "A header with ",
-                                          },
-                                          Immutable.Map {
-                                                  "id": 33,
-                                            "type": "link",
-                                            "contents": Immutable.Map {
-                                              "uri": "https://google.com",
-                                              "title": "a link",
-                                            },
-                                          },
-                                        ],
-                                        "rawTitle": "A header with [[https://google.com][a link]]",
-                                        "todoKeyword": undefined,
-                                        "tags": Immutable.List [],
-                                      },
-                                      "rawDescription": "",
-                                      "description": Immutable.List [],
-                                      "opened": false,
-                                      "id": 34,
-                                      "nestingLevel": 1,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                  isSelected={false}
-                                >
-                                  <TitleLine
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    color="var(--blue)"
-                                    hasContent={false}
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "A header with ",
-                                            },
-                                            Immutable.Map {
-                                              "id": 33,
-                                              "type": "link",
-                                              "contents": Immutable.Map {
-                                                "uri": "https://google.com",
-                                                "title": "a link",
-                                              },
-                                            },
-                                          ],
-                                          "rawTitle": "A header with [[https://google.com][a link]]",
-                                          "todoKeyword": undefined,
-                                          "tags": Immutable.List [],
-                                        },
-                                        "rawDescription": "",
-                                        "description": Immutable.List [],
-                                        "opened": false,
-                                        "id": 34,
-                                        "nestingLevel": 1,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                  >
-                                    <div
-                                      className="title-line"
-                                      onClick={[Function]}
-                                      style={
-                                        Object {
-                                          "width": 0,
-                                        }
-                                      }
-                                    >
-                                      <div>
-                                        <span
-                                          style={
-                                            Object {
-                                              "color": "rgba(38, 143, 214, 1)",
-                                              "wordBreak": "break-word",
-                                            }
-                                          }
-                                        >
-                                          <_default
-                                            parts={
-                                              Immutable.List [
-                                                Immutable.Map {
-                                                  "type": "text",
-                                                  "contents": "A header with ",
-                                                },
-                                                Immutable.Map {
-                                            "id": 33,
-                                                  "type": "link",
-                                                  "contents": Immutable.Map {
-                                                    "uri": "https://google.com",
-                                                    "title": "a link",
-                                                  },
-                                                },
-                                              ]
-                                            }
-                                            subPartDataAndHandlers={
-                                              Object {
-                                                "onTimestampClick": [Function],
-                                                "shouldDisableActions": undefined,
-                                              }
-                                            }
-                                          >
-                                            <span>
-                                              A header with 
-                                              <a
-                                                href="https://google.com"
-                                                key="33"
-                                                rel="noopener noreferrer"
-                                                target="_blank"
-                                              >
-                                                a link
-                                              </a>
-                                            </span>
-                                          </_default>
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </TitleLine>
-                                </Connect(TitleLine)>
-                                <UnmountClosed
-                                  isOpened={false}
-                                  springConfig={
-                                    Object {
-                                      "stiffness": 300,
-                                    }
-                                  }
-                                  style={
-                                    Object {
-                                      "marginRight": -0,
-                                    }
-                                  }
-                                />
-                                <Connect(HeaderContent)
-                                  header={
-                                    Immutable.Map {
-                                      "titleLine": Immutable.Map {
-                                        "title": Immutable.List [
-                                          Immutable.Map {
-                                            "type": "text",
-                                            "contents": "A header with ",
-                                          },
-                                          Immutable.Map {
-                                      "id": 33,
-                                            "type": "link",
-                                            "contents": Immutable.Map {
-                                              "uri": "https://google.com",
-                                              "title": "a link",
-                                            },
-                                          },
-                                        ],
-                                        "rawTitle": "A header with [[https://google.com][a link]]",
-                                        "todoKeyword": undefined,
-                                        "tags": Immutable.List [],
-                                      },
-                                      "rawDescription": "",
-                                      "description": Immutable.List [],
-                                      "opened": false,
-                                      "id": 34,
-                                      "nestingLevel": 1,
-                                      "planningItems": Immutable.List [],
-                                      "propertyListItems": Immutable.List [],
-                                    }
-                                  }
-                                >
-                                  <HeaderContent
-                                    base={
-                                      Object {
-                                        "activatePopup": [Function],
-                                        "clearModalStack": [Function],
-                                        "closePopup": [Function],
-                                        "hideLoadingMessage": [Function],
-                                        "loadStaticFile": [Function],
-                                        "popModalPage": [Function],
-                                        "pushModalPage": [Function],
-                                        "restoreBaseSettings": [Function],
-                                        "setAgendaDefaultDeadlineDelayUnit": [Function],
-                                        "setAgendaDefaultDeadlineDelayValue": [Function],
-                                        "setBulletStyle": [Function],
-                                        "setCustomKeybinding": [Function],
-                                        "setDisappearingLoadingMessage": [Function],
-                                        "setFontSize": [Function],
-                                        "setHasUnseenChangelog": [Function],
-                                        "setIsLoading": [Function],
-                                        "setLastSeenChangelogHeader": [Function],
-                                        "setLastViewedFile": [Function],
-                                        "setLoadingMessage": [Function],
-                                        "setShouldLiveSync": [Function],
-                                        "setShouldStoreSettingsInSyncBackend": [Function],
-                                        "setShouldTapTodoToAdvance": [Function],
-                                        "unloadStaticFile": [Function],
-                                      }
-                                    }
-                                    header={
-                                      Immutable.Map {
-                                        "titleLine": Immutable.Map {
-                                          "title": Immutable.List [
-                                            Immutable.Map {
-                                              "type": "text",
-                                              "contents": "A header with ",
-                                            },
-                                            Immutable.Map {
-                                    "id": 33,
-                                              "type": "link",
-                                              "contents": Immutable.Map {
-                                                "uri": "https://google.com",
-                                                "title": "a link",
-                                              },
-                                            },
-                                          ],
-                                          "rawTitle": "A header with [[https://google.com][a link]]",
-                                          "todoKeyword": undefined,
-                                          "tags": Immutable.List [],
-                                        },
-                                        "rawDescription": "",
-                                        "description": Immutable.List [],
-                                        "opened": false,
-                                "id": 34,
-                                        "nestingLevel": 1,
-                                        "planningItems": Immutable.List [],
-                                        "propertyListItems": Immutable.List [],
-                                      }
-                                    }
-                                    inEditMode={false}
-                                    inTableEditMode={false}
-                                    isSelected={false}
-                                    org={
-                                      Object {
-                                        "addHeader": [Function],
-                                        "addHeaderAndEdit": [Function],
-                                        "addNewPlanningItem": [Function],
-                                        "addNewTableColumn": [Function],
-                                        "addNewTableRow": [Function],
-                                        "advanceCheckboxState": [Function],
-                                        "advanceTodoState": [Function],
-                                        "applyOpennessState": [Function],
-                                        "clearPendingCapture": [Function],
-                                        "displayFile": [Function],
-                                        "enterEditMode": [Function],
-                                        "exitEditMode": [Function],
-                                        "focusHeader": [Function],
-                                        "insertCapture": [Function],
-                                        "insertPendingCapture": [Function],
-                                        "moveHeaderDown": [Function],
-                                        "moveHeaderLeft": [Function],
-                                        "moveHeaderRight": [Function],
-                                        "moveHeaderUp": [Function],
-                                        "moveSubtreeLeft": [Function],
-                                        "moveSubtreeRight": [Function],
-                                        "moveTableColumnLeft": [Function],
-                                        "moveTableColumnRight": [Function],
-                                        "moveTableRowDown": [Function],
-                                        "moveTableRowUp": [Function],
-                                        "noOp": [Function],
-                                        "openHeader": [Function],
-                                        "removeHeader": [Function],
-                                        "removeTableColumn": [Function],
-                                        "removeTableRow": [Function],
-                                        "reorderPropertyList": [Function],
-                                        "reorderTags": [Function],
-                                        "selectHeader": [Function],
-                                        "selectHeaderAndOpenParents": [Function],
-                                        "selectNextSiblingHeader": [Function],
-                                        "selectNextVisibleHeader": [Function],
-                                        "selectPreviousVisibleHeader": [Function],
-                                        "setDirty": [Function],
-                                        "setHeaderTags": [Function],
-                                        "setLastSyncAt": [Function],
-                                        "setOrgFileErrorMessage": [Function],
-                                        "setSelectedTableCellId": [Function],
-                                        "stopDisplayingFile": [Function],
-                                        "sync": [Function],
-                                        "toggleHeaderOpened": [Function],
-                                        "unfocusHeader": [Function],
-                                        "updateHeaderDescription": [Function],
-                                        "updateHeaderTitle": [Function],
-                                        "updatePlanningItemTimestamp": [Function],
-                                        "updatePropertyListItems": [Function],
-                                        "updateTableCellValue": [Function],
-                                        "updateTimestampWithId": [Function],
-                                      }
-                                    }
-                                    selectedTableCellId={null}
-                                  >
-                                    <div />
-                                  </HeaderContent>
-                                </Connect(HeaderContent)>
-                              </div>
-                            </Motion>
-                          </Header>
-                        </Connect(Header)>
-                      </div>
-                    </HeaderList>
-                  </Connect(HeaderList)>
-                  <Connect(ActionDrawer)>
-                    <ActionDrawer
-                      base={
-                        Object {
-                          "activatePopup": [Function],
-                          "clearModalStack": [Function],
-                          "closePopup": [Function],
-                          "hideLoadingMessage": [Function],
-                          "loadStaticFile": [Function],
-                          "popModalPage": [Function],
-                          "pushModalPage": [Function],
-                          "restoreBaseSettings": [Function],
-                          "setAgendaDefaultDeadlineDelayUnit": [Function],
-                          "setAgendaDefaultDeadlineDelayValue": [Function],
-                          "setBulletStyle": [Function],
-                          "setCustomKeybinding": [Function],
-                          "setDisappearingLoadingMessage": [Function],
-                          "setFontSize": [Function],
-                          "setHasUnseenChangelog": [Function],
-                          "setIsLoading": [Function],
-                          "setLastSeenChangelogHeader": [Function],
-                          "setLastViewedFile": [Function],
-                          "setLoadingMessage": [Function],
-                          "setShouldLiveSync": [Function],
-                          "setShouldStoreSettingsInSyncBackend": [Function],
-                          "setShouldTapTodoToAdvance": [Function],
-                          "unloadStaticFile": [Function],
-                        }
-                      }
-                      capture={
-                        Object {
-                          "addNewEmptyCaptureTemplate": [Function],
-                          "addNewTemplateHeaderPath": [Function],
-                          "addNewTemplateOrgFileAvailability": [Function],
-                          "deleteTemplate": [Function],
-                          "removeTemplateHeaderPath": [Function],
-                          "removeTemplateOrgFileAvailability": [Function],
-                          "reorderCaptureTemplate": [Function],
-                          "restoreCaptureSettings": [Function],
-                          "updateTemplateFieldPathValue": [Function],
-                        }
-                      }
-                      captureTemplates={Array []}
-                      inEditMode={false}
-                      isFocusedHeaderActive={false}
-                      org={
-                        Object {
-                          "addHeader": [Function],
-                          "addHeaderAndEdit": [Function],
-                          "addNewPlanningItem": [Function],
-                          "addNewTableColumn": [Function],
-                          "addNewTableRow": [Function],
-                          "advanceCheckboxState": [Function],
-                          "advanceTodoState": [Function],
-                          "applyOpennessState": [Function],
-                          "clearPendingCapture": [Function],
-                          "displayFile": [Function],
-                          "enterEditMode": [Function],
-                          "exitEditMode": [Function],
-                          "focusHeader": [Function],
-                          "insertCapture": [Function],
-                          "insertPendingCapture": [Function],
-                          "moveHeaderDown": [Function],
-                          "moveHeaderLeft": [Function],
-                          "moveHeaderRight": [Function],
-                          "moveHeaderUp": [Function],
-                          "moveSubtreeLeft": [Function],
-                          "moveSubtreeRight": [Function],
-                          "moveTableColumnLeft": [Function],
-                          "moveTableColumnRight": [Function],
-                          "moveTableRowDown": [Function],
-                          "moveTableRowUp": [Function],
-                          "noOp": [Function],
-                          "openHeader": [Function],
-                          "removeHeader": [Function],
-                          "removeTableColumn": [Function],
-                          "removeTableRow": [Function],
-                          "reorderPropertyList": [Function],
-                          "reorderTags": [Function],
-                          "selectHeader": [Function],
-                          "selectHeaderAndOpenParents": [Function],
-                          "selectNextSiblingHeader": [Function],
-                          "selectNextVisibleHeader": [Function],
-                          "selectPreviousVisibleHeader": [Function],
-                          "setDirty": [Function],
-                          "setHeaderTags": [Function],
-                          "setLastSyncAt": [Function],
-                          "setOrgFileErrorMessage": [Function],
-                          "setSelectedTableCellId": [Function],
-                          "stopDisplayingFile": [Function],
-                          "sync": [Function],
-                          "toggleHeaderOpened": [Function],
-                          "unfocusHeader": [Function],
-                          "updateHeaderDescription": [Function],
-                          "updateHeaderTitle": [Function],
-                          "updatePlanningItemTimestamp": [Function],
-                          "updatePropertyListItems": [Function],
-                          "updateTableCellValue": [Function],
-                          "updateTimestampWithId": [Function],
-                        }
-                      }
-                      path="/some/test/file"
-                      selectedHeaderId={27}
-                      selectedTableCellId={null}
-                    >
-                      <div
-                        className="action-drawer-container nice-scroll"
-                      >
-                        <ActionButton
-                          iconName="cloud"
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "opacity": 1,
-                            }
-                          }
-                          subIconName="sync-alt"
-                          tooltip="Sync changes"
-                        >
-                          <button
-                            className="btn btn--circle action-drawer__btn fas fa-lg fa-cloud action-drawer__btn--with-sub-icon"
-                            onClick={[Function]}
-                            style={
-                              Object {
-                                "opacity": 1,
-                              }
-                            }
-                            title="Sync changes"
-                          >
-                            <i
-                              className="fas fa-xs fa-sync-alt action-drawer__btn__sub-icon"
-                            />
-                          </button>
-                        </ActionButton>
-                        <Motion
-                          style={
-                            Object {
-                              "bottomRowYOffset": Object {
-                                "damping": 26,
-                                "precision": 0.01,
-                                "stiffness": 300,
-                                "val": 0,
-                              },
-                              "centerXOffset": Object {
-                                "damping": 26,
-                                "precision": 0.01,
-                                "stiffness": 300,
-                                "val": 0,
-                              },
-                              "firstColumnXOffset": Object {
-                                "damping": 26,
-                                "precision": 0.01,
-                                "stiffness": 300,
-                                "val": 0,
-                              },
-                              "secondColumnXOffset": Object {
-                                "damping": 26,
-                                "precision": 0.01,
-                                "stiffness": 300,
-                                "val": 0,
-                              },
-                              "topRowYOffset": Object {
-                                "damping": 26,
-                                "precision": 0.01,
-                                "stiffness": 300,
-                                "val": 0,
-                              },
-                            }
-                          }
-                        >
-                          <div
-                            className="action-drawer__arrow-buttons-container"
-                            style={
-                              Object {
-                                "left": 0,
-                              }
-                            }
-                          >
-                            <ActionButton
-                              additionalClassName="action-drawer__arrow-button"
-                              iconName="arrow-up"
-                              isDisabled={false}
-                              onClick={[Function]}
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "boxShadow": "none",
-                                  "opacity": 1,
-                                }
-                              }
-                              subIconName={null}
-                              tooltip="Move header up"
-                            >
-                              <button
-                                className="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-arrow-up"
-                                onClick={[Function]}
-                                style={
-                                  Object {
-                                    "bottom": 0,
-                                    "boxShadow": "none",
-                                    "opacity": 1,
-                                  }
-                                }
-                                title="Move header up"
-                              />
-                            </ActionButton>
-                            <ActionButton
-                              additionalClassName="action-drawer__arrow-button"
-                              iconName="arrow-down"
-                              isDisabled={false}
-                              onClick={[Function]}
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "boxShadow": "none",
-                                  "opacity": 1,
-                                }
-                              }
-                              subIconName={null}
-                              tooltip="Move header down"
-                            >
-                              <button
-                                className="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-arrow-down"
-                                onClick={[Function]}
-                                style={
-                                  Object {
-                                    "bottom": 0,
-                                    "boxShadow": "none",
-                                    "opacity": 1,
-                                  }
-                                }
-                                title="Move header down"
-                              />
-                            </ActionButton>
-                            <ActionButton
-                              additionalClassName="action-drawer__arrow-button"
-                              iconName="arrow-left"
-                              isDisabled={false}
-                              onClick={[Function]}
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "boxShadow": "none",
-                                  "opacity": 1,
-                                  "right": 0,
-                                }
-                              }
-                              subIconName={null}
-                              tooltip="Move header left"
-                            >
-                              <button
-                                className="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-arrow-left"
-                                onClick={[Function]}
-                                style={
-                                  Object {
-                                    "bottom": 0,
-                                    "boxShadow": "none",
-                                    "opacity": 1,
-                                    "right": 0,
-                                  }
-                                }
-                                title="Move header left"
-                              />
-                            </ActionButton>
-                            <ActionButton
-                              additionalClassName="action-drawer__arrow-button"
-                              iconName="arrow-right"
-                              isDisabled={false}
-                              onClick={[Function]}
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "boxShadow": "none",
-                                  "left": 0,
-                                  "opacity": 1,
-                                }
-                              }
-                              subIconName={null}
-                              tooltip="Move header right"
-                            >
-                              <button
-                                className="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-arrow-right"
-                                onClick={[Function]}
-                                style={
-                                  Object {
-                                    "bottom": 0,
-                                    "boxShadow": "none",
-                                    "left": 0,
-                                    "opacity": 1,
-                                  }
-                                }
-                                title="Move header right"
-                              />
-                            </ActionButton>
-                            <ActionButton
-                              additionalClassName="action-drawer__arrow-button"
-                              iconName="chevron-left"
-                              isDisabled={false}
-                              onClick={[Function]}
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "boxShadow": "none",
-                                  "opacity": 1,
-                                  "right": 0,
-                                }
-                              }
-                              tooltip="Move entire subtree left"
-                            >
-                              <button
-                                className="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-chevron-left"
-                                onClick={[Function]}
-                                style={
-                                  Object {
-                                    "bottom": 0,
-                                    "boxShadow": "none",
-                                    "opacity": 1,
-                                    "right": 0,
-                                  }
-                                }
-                                title="Move entire subtree left"
-                              />
-                            </ActionButton>
-                            <ActionButton
-                              additionalClassName="action-drawer__arrow-button"
-                              iconName="chevron-right"
-                              isDisabled={false}
-                              onClick={[Function]}
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "boxShadow": "none",
-                                  "left": 0,
-                                  "opacity": 1,
-                                }
-                              }
-                              tooltip="Move entire subtree right"
-                            >
-                              <button
-                                className="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-chevron-right"
-                                onClick={[Function]}
-                                style={
-                                  Object {
-                                    "bottom": 0,
-                                    "boxShadow": "none",
-                                    "left": 0,
-                                    "opacity": 1,
-                                  }
-                                }
-                                title="Move entire subtree right"
-                              />
-                            </ActionButton>
-                            <ActionButton
-                              additionalClassName="action-drawer__main-arrow-button"
-                              iconName="arrows-alt"
-                              isDisabled={false}
-                              onClick={[Function]}
-                              onRef={
-                                Object {
-                                  "current": <button
-                                    class="btn btn--circle action-drawer__btn action-drawer__main-arrow-button fas fa-lg fa-arrows-alt"
-                                    style="opacity: 1;"
-                                    title="Show movement buttons"
-                                  />,
-                                }
-                              }
-                              style={
-                                Object {
-                                  "opacity": 1,
-                                }
-                              }
-                              subIconName={null}
-                              tooltip="Show movement buttons"
-                            >
-                              <button
-                                className="btn btn--circle action-drawer__btn action-drawer__main-arrow-button fas fa-lg fa-arrows-alt"
-                                onClick={[Function]}
-                                style={
-                                  Object {
-                                    "opacity": 1,
-                                  }
-                                }
-                                title="Show movement buttons"
-                              />
-                            </ActionButton>
-                          </div>
-                        </Motion>
-                        <ActionButton
-                          iconName="calendar-alt"
-                          isDisabled={false}
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "opacity": 1,
-                            }
-                          }
-                          tooltip="Show agenda"
-                        >
-                          <button
-                            className="btn btn--circle action-drawer__btn fas fa-lg fa-calendar-alt"
-                            onClick={[Function]}
-                            style={
-                              Object {
-                                "opacity": 1,
-                              }
-                            }
-                            title="Show agenda"
-                          />
-                        </ActionButton>
-                        <Motion
-                          style={
-                            Object {
-                              "bottom": Object {
-                                "damping": 26,
-                                "precision": 0.01,
-                                "stiffness": 300,
-                                "val": 0,
-                              },
-                            }
-                          }
-                        >
-                          <div
-                            className="action-drawer__capture-buttons-container"
-                          >
-                            <ActionButton
-                              iconName="list-ul"
-                              isDisabled={false}
-                              onClick={[Function]}
-                              style={
-                                Object {
-                                  "opacity": 1,
-                                  "position": "relative",
-                                  "zIndex": 1,
-                                }
-                              }
-                              tooltip="Show capture templates"
-                            >
-                              <button
-                                className="btn btn--circle action-drawer__btn fas fa-lg fa-list-ul"
-                                onClick={[Function]}
-                                style={
-                                  Object {
-                                    "opacity": 1,
-                                    "position": "relative",
-                                    "zIndex": 1,
-                                  }
-                                }
-                                title="Show capture templates"
-                              />
-                            </ActionButton>
-                          </div>
-                        </Motion>
-                      </div>
-                    </ActionDrawer>
-                  </Connect(ActionDrawer)>
+                  tag1
+                </div>
+                <div
+                  class="header-tag"
+                >
+                  tag2
                 </div>
               </div>
-            </FocusTrap>
-          </HotKeys>
-        </OrgFile>
-      </Connect(OrgFile)>
-    </Provider>
-  </Router>
-</MemoryRouter>
+            </div>
+          </div>
+          <div />
+        </div>
+        <div
+          class="header"
+          style="padding-left: 20px; margin-left: 0px;"
+        >
+          <div
+            class="left-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="right-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="header__bullet"
+            style="margin-left: -16px;"
+          >
+            *
+          </div>
+          <div
+            class="title-line"
+            style="width: 0px;"
+          >
+            
+            <div>
+              <span
+                style="word-break: break-word;"
+              >
+                <span>
+                  A header with 
+                  <a
+                    href="https://google.com"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    a link
+                  </a>
+                </span>
+                
+              </span>
+            </div>
+          </div>
+          <div />
+        </div>
+      </div>
+      <div
+        class="action-drawer-container nice-scroll"
+      >
+        <button
+          class="btn btn--circle action-drawer__btn fas fa-lg fa-cloud action-drawer__btn--with-sub-icon"
+          style="opacity: 1;"
+          title="Sync changes"
+        >
+          <i
+            class="fas fa-xs fa-sync-alt action-drawer__btn__sub-icon"
+          />
+        </button>
+        <div
+          class="action-drawer__arrow-buttons-container"
+          style="left: 0px;"
+        >
+          <button
+            class="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-arrow-up"
+            style="opacity: 1; box-shadow: none; bottom: 0px;"
+            title="Move header up"
+          />
+          <button
+            class="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-arrow-down"
+            style="opacity: 1; box-shadow: none; bottom: 0px;"
+            title="Move header down"
+          />
+          <button
+            class="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-arrow-left"
+            style="opacity: 1; box-shadow: none; bottom: 0px; right: 0px;"
+            title="Move header left"
+          />
+          <button
+            class="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-arrow-right"
+            style="opacity: 1; box-shadow: none; bottom: 0px; left: 0px;"
+            title="Move header right"
+          />
+          <button
+            class="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-chevron-left"
+            style="opacity: 1; box-shadow: none; bottom: 0px; right: 0px;"
+            title="Move entire subtree left"
+          />
+          <button
+            class="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-chevron-right"
+            style="opacity: 1; box-shadow: none; bottom: 0px; left: 0px;"
+            title="Move entire subtree right"
+          />
+          <button
+            class="btn btn--circle action-drawer__btn action-drawer__main-arrow-button fas fa-lg fa-arrows-alt"
+            style="opacity: 1;"
+            title="Show movement buttons"
+          />
+        </div>
+        <button
+          class="btn btn--circle action-drawer__btn fas fa-lg fa-calendar-alt"
+          style="opacity: 1;"
+          title="Show agenda"
+        />
+        <div
+          class="action-drawer__capture-buttons-container"
+        >
+          <button
+            class="btn btn--circle action-drawer__btn fas fa-lg fa-list-ul"
+            style="opacity: 1; position: relative; z-index: 1;"
+            title="Show capture templates"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Rendering an org file Can select a header in an org file 2`] = `
+<div>
+  <div
+    tabindex="-1"
+  >
+    <div
+      class="org-file-container"
+      tabindex="-1"
+    >
+      <div
+        class="header-list-container"
+      >
+        <div
+          class="header header--selected"
+          style="padding-left: 20px; margin-left: 0px;"
+        >
+          <div
+            class="left-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="right-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="header__bullet"
+            style="margin-left: -16px;"
+          >
+            *
+          </div>
+          <div
+            class="title-line"
+            style="width: 0px;"
+          >
+            
+            <div>
+              <span
+                style="word-break: break-word;"
+              >
+                <span>
+                  Top level header
+                </span>
+                
+              </span>
+            </div>
+          </div>
+          <div
+            class="ReactCollapse--collapse"
+            style="overflow: hidden; height: 0px; margin-right: 0px;"
+          >
+            <div
+              class="ReactCollapse--content"
+            >
+              <div
+                class="header-action-drawer-container"
+              >
+                <div
+                  class="header-action-drawer__row"
+                >
+                  <div
+                    class="header-action-drawer__ff-click-catcher-container"
+                  >
+                    <div
+                      class="header-action-drawer__ff-click-catcher"
+                    />
+                    <i
+                      class="fas fa-pencil-alt fa-lg"
+                    />
+                  </div>
+                  <span
+                    class="header-action-drawer__separator"
+                  />
+                  <div
+                    class="header-action-drawer__ff-click-catcher-container"
+                  >
+                    <div
+                      class="header-action-drawer__ff-click-catcher"
+                    />
+                    <i
+                      class="fas fa-edit fa-lg"
+                    />
+                  </div>
+                  <span
+                    class="header-action-drawer__separator"
+                  />
+                  <div
+                    class="header-action-drawer__ff-click-catcher-container"
+                  >
+                    <div
+                      class="header-action-drawer__ff-click-catcher"
+                    />
+                    <i
+                      class="fas fa-tags fa-lg"
+                    />
+                  </div>
+                  <span
+                    class="header-action-drawer__separator"
+                  />
+                  <div
+                    class="header-action-drawer__ff-click-catcher-container"
+                  >
+                    <div
+                      class="header-action-drawer__ff-click-catcher"
+                    />
+                    <i
+                      class="fas fa-compress fa-lg"
+                    />
+                  </div>
+                  <span
+                    class="header-action-drawer__separator"
+                  />
+                  <div
+                    class="header-action-drawer__ff-click-catcher-container"
+                  >
+                    <div
+                      class="header-action-drawer__ff-click-catcher"
+                    />
+                    <i
+                      class="fas fa-plus fa-lg"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="header-action-drawer__row"
+                >
+                  <div
+                    class="header-action-drawer__deadline-scheduled-button"
+                  >
+                    Deadline
+                  </div>
+                  <span
+                    class="header-action-drawer__separator"
+                  />
+                  <div
+                    class="header-action-drawer__deadline-scheduled-button"
+                  >
+                    Scheduled
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="header-content-container nice-scroll"
+            style="width: 0px;"
+          >
+            <span />
+          </div>
+        </div>
+        <div
+          class="header"
+          style="padding-left: 40px; margin-left: 0px;"
+        >
+          <div
+            class="left-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="right-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="header__bullet"
+            style="margin-left: -16px;"
+          >
+            *
+          </div>
+          <div
+            class="title-line"
+            style="width: 0px;"
+          >
+            
+            <div>
+              <span
+                style="word-break: break-word;"
+              >
+                <span>
+                  A nested header
+                </span>
+                
+              </span>
+            </div>
+          </div>
+          <div />
+        </div>
+        <div
+          class="header"
+          style="padding-left: 40px; margin-left: 0px;"
+        >
+          <div
+            class="left-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="right-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="header__bullet"
+            style="margin-left: -16px;"
+          >
+            *
+          </div>
+          <div
+            class="title-line"
+            style="width: 0px;"
+          >
+            <span
+              class="todo-keyword todo-keyword--todo"
+            >
+              TODO
+            </span>
+            <div>
+              <span
+                style="word-break: break-word;"
+              >
+                <span>
+                  A todo item
+                </span>
+                
+              </span>
+            </div>
+          </div>
+          <div />
+        </div>
+        <div
+          class="header"
+          style="padding-left: 40px; margin-left: 0px;"
+        >
+          <div
+            class="left-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="right-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="header__bullet"
+            style="margin-left: -16px;"
+          >
+            *
+          </div>
+          <div
+            class="title-line"
+            style="width: 0px;"
+          >
+            <span
+              class="todo-keyword todo-keyword--done"
+            >
+              DONE
+            </span>
+            <div>
+              <span
+                style="word-break: break-word;"
+              >
+                <span>
+                  A finished todo item
+                </span>
+                
+              </span>
+            </div>
+          </div>
+          <div />
+        </div>
+        <div
+          class="header"
+          style="padding-left: 20px; margin-left: 0px;"
+        >
+          <div
+            class="left-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="right-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="header__bullet"
+            style="margin-left: -16px;"
+          >
+            *
+          </div>
+          <div
+            class="title-line"
+            style="width: 0px;"
+          >
+            
+            <div>
+              <span
+                style="word-break: break-word;"
+              >
+                <span>
+                  Another top level header
+                </span>
+                ...
+              </span>
+            </div>
+          </div>
+          <div />
+        </div>
+        <div
+          class="header"
+          style="padding-left: 20px; margin-left: 0px;"
+        >
+          <div
+            class="left-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="right-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="header__bullet"
+            style="margin-left: -16px;"
+          >
+            *
+          </div>
+          <div
+            class="title-line"
+            style="width: 0px;"
+          >
+            
+            <div>
+              <span
+                style="word-break: break-word;"
+              >
+                <span>
+                  A header with tags                                              
+                </span>
+                
+              </span>
+              <div>
+                <div
+                  class="header-tag"
+                >
+                  tag1
+                </div>
+                <div
+                  class="header-tag"
+                >
+                  tag2
+                </div>
+              </div>
+            </div>
+          </div>
+          <div />
+        </div>
+        <div
+          class="header"
+          style="padding-left: 20px; margin-left: 0px;"
+        >
+          <div
+            class="left-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="right-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
+              style="display: none;"
+            />
+          </div>
+          <div
+            class="header__bullet"
+            style="margin-left: -16px;"
+          >
+            *
+          </div>
+          <div
+            class="title-line"
+            style="width: 0px;"
+          >
+            
+            <div>
+              <span
+                style="word-break: break-word;"
+              >
+                <span>
+                  A header with 
+                  <a
+                    href="https://google.com"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    a link
+                  </a>
+                </span>
+                
+              </span>
+            </div>
+          </div>
+          <div />
+        </div>
+      </div>
+      <div
+        class="action-drawer-container nice-scroll"
+      >
+        <button
+          class="btn btn--circle action-drawer__btn fas fa-lg fa-cloud action-drawer__btn--with-sub-icon"
+          style="opacity: 1;"
+          title="Sync changes"
+        >
+          <i
+            class="fas fa-xs fa-sync-alt action-drawer__btn__sub-icon"
+          />
+        </button>
+        <div
+          class="action-drawer__arrow-buttons-container"
+          style="left: 0px;"
+        >
+          <button
+            class="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-arrow-up"
+            style="opacity: 1; box-shadow: none; bottom: 0px;"
+            title="Move header up"
+          />
+          <button
+            class="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-arrow-down"
+            style="opacity: 1; box-shadow: none; bottom: 0px;"
+            title="Move header down"
+          />
+          <button
+            class="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-arrow-left"
+            style="opacity: 1; box-shadow: none; bottom: 0px; right: 0px;"
+            title="Move header left"
+          />
+          <button
+            class="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-arrow-right"
+            style="opacity: 1; box-shadow: none; bottom: 0px; left: 0px;"
+            title="Move header right"
+          />
+          <button
+            class="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-chevron-left"
+            style="opacity: 1; box-shadow: none; bottom: 0px; right: 0px;"
+            title="Move entire subtree left"
+          />
+          <button
+            class="btn btn--circle action-drawer__btn action-drawer__arrow-button fas fa-lg fa-chevron-right"
+            style="opacity: 1; box-shadow: none; bottom: 0px; left: 0px;"
+            title="Move entire subtree right"
+          />
+          <button
+            class="btn btn--circle action-drawer__btn action-drawer__main-arrow-button fas fa-lg fa-arrows-alt"
+            style="opacity: 1;"
+            title="Show movement buttons"
+          />
+        </div>
+        <button
+          class="btn btn--circle action-drawer__btn fas fa-lg fa-calendar-alt"
+          style="opacity: 1;"
+          title="Show agenda"
+        />
+        <div
+          class="action-drawer__capture-buttons-container"
+        >
+          <button
+            class="btn btn--circle action-drawer__btn fas fa-lg fa-list-ul"
+            style="opacity: 1; position: relative; z-index: 1;"
+            title="Show capture templates"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 `;


### PR DESCRIPTION
1. Adds ```@testing-library/react``` as a new Dev dependency.

2. Removes the ```.skip``` from OrgFile-tests and rewrites those tests using the newly added library and its guiding principles:

   1. If it relates to rendering components, then it should deal with DOM nodes rather than component instances, and it should not encourage dealing with component instances.
   2. It should be generally useful for testing the application components in the way the user would use it. We are making some trade-offs here because we're using a computer and often a simulated browser environment, but in general, utilities should encourage tests that use the components the way they're intended to be used.
    3. Utility implementations and APIs should be simple and flexible.

(copied from: https://testing-library.com/docs/guiding-principles)


In the current form this PR solves issue #43 and also #10 because I used the 3 skipped tests mentioned there as examples for writing tests using ```@testing-library/react```.