### PR TITLE
WIP Planning items with following checkmarks are parsed correctly

### DIFF
--- a/src/components/OrgFile/OrgFile.test.js
+++ b/src/components/OrgFile/OrgFile.test.js
@@ -107,6 +107,12 @@ describe('Unit Tests for org file', () => {
           expect(exportedFile).toEqual(testOrgFile.trimRight());
         });
       });
+
+      describe('Parses planning item with following checkmark', () => {
+        const testOrgFile = readFixture('planning_item_with_following_checkmark');
+        const exportedFile = parseAndExportOrgFile(testOrgFile);
+        expect(exportedFile).toEqual(testOrgFile.trimRight());
+      });
     });
   });
 });

--- a/test_helpers/fixtures/planning_item_with_following_checkmark.org
+++ b/test_helpers/fixtures/planning_item_with_following_checkmark.org
@@ -1,0 +1,3 @@
+* WAITING Proofing "Announcement für EmacsConf"
+  SCHEDULED: <2019-09-16 Mon>
+- [X] Write draft announcement


### PR DESCRIPTION
Related issue: #47 