### PR TITLE
fix: Remove unneeded code that was tagged with "ridiculous hack"

### DIFF
--- a/src/components/UI/Drawer/index.js
+++ b/src/components/UI/Drawer/index.js
@@ -82,17 +82,6 @@ export default ({ children, shouldIncludeCloseButton, onClose }) => {
     }
   }, [innerContainer, dragOffsetY]);
 
-  useEffect(() => {
-    // A ridiculous hack to get around what is presumably a Mobile Safari bug in iOS 12.
-    // Without this, I can't scroll the inner container in the agenda view.
-    setTimeout(() => {
-      innerContainer.current.style.left = '0';
-      setTimeout(() => {
-        innerContainer.current.style.left = '-1px';
-      }, 0);
-    }, 0);
-  }, [children]);
-
   const outerClassName = classNames('drawer-outer-container', {
     'drawer-outer-container--visible': isVisible,
   });


### PR DESCRIPTION
Tested on iOS 12 and 13 that the presumed iOS bug does not appear after removing the code.