### PR TITLE
fix: error on clearing date picker

### DIFF
--- a/src/components/OrgFile/components/TimestampEditorModal/components/TimestampEditor/index.js
+++ b/src/components/OrgFile/components/TimestampEditorModal/components/TimestampEditor/index.js
@@ -36,6 +36,8 @@ export default class TimestampEditor extends PureComponent {
   }
 
   handleDateChange(event) {
+    if (!event.target.value) return;
+
     const { onChange, timestamp } = this.props;
 
     const [newYear, newMonth, newDay, newDayName] = format(


### PR DESCRIPTION
The datepicker was throwing an error when trying to parse the date on clear. If no date is picker, do nothing.