### PR TITLE
fix: Show clickable links with cursor pointer

### DIFF
--- a/src/components/HeaderBar/stylesheet.css
+++ b/src/components/HeaderBar/stylesheet.css
@@ -52,6 +52,7 @@
   margin-left: auto;
   display: flex;
   align-items: center;
+  cursor: pointer;
 
   color: var(--base01);
 }

--- a/src/components/SyncServiceSignIn/stylesheet.css
+++ b/src/components/SyncServiceSignIn/stylesheet.css
@@ -36,6 +36,7 @@
 
 .sync-service-container {
   border-bottom: 1px solid var(--base01);
+  cursor: pointer;
 
   padding: 20px 10px;
 }


### PR DESCRIPTION
Hey folks, thank you for this great project. 

I am not sure if it is a bug, since idk if we are supporting desktop users, but I missed that when first using organice. (a few seconds until I realized that I could click the dropbox logo/item in sign-in page). 

Do you think it is useful? should I create an issue for it? 