### PR TITLE
Keep all in-file settings and content lines from top of file

### DIFF
--- a/README.org
+++ b/README.org
@@ -36,19 +36,17 @@ great choice.
 "Current" means we're working hard on removing the following
 restrictions and expectations.
 
-- organice understands only few in-buffer settings (=#+TODO:= and
+- organice understands only a few in-buffer settings (=#+TODO:= and
   =#+TYP_TODO:=).
-  - If you have other in-buffer settings and save the file with
-    organice, they will be lost.
-- After potential in-buffer settings, your Org file _has to_ begin
-  with a headline.
-  - Meaning that a file with just some text (which would otherwise be
-    proper Org syntax) will not be parsed correctly.
-  - After that first headline, organice is actually very robust in
-    reading your Org file and _not_ breaking any of it. We've had
-    users with 10k LOC Org files with all kinds of native Org features
-    (of which organice only has partial understanding) and they just
-    work fine!
+  - Other in-buffer settings are imported and re-exported but are not
+    editable with organice.
+- Other content before the first headline is imported and re-exported,
+  but invisible and currently not editable with organice.
+- In treating all the rest of the content beyond the first headline
+  organice is actually very robust in reading and editing your Org
+  file and _not_ breaking any of it. We've had users with 10k LOC Org
+  files with all kinds of native Org features (of which organice only
+  has partial understanding) and they just work fine!
 
 Generally, when working with distributed Org files, we're recommending
 to put them under version control and to check for bugs and racing

--- a/src/actions/org.js
+++ b/src/actions/org.js
@@ -68,7 +68,9 @@ export const sync = ({
               path,
               exportOrg(
                 getState().org.present.get('headers'),
-                getState().org.present.get('todoKeywordSets')
+                getState().org.present.get('todoKeywordSets'),
+                getState().org.present.get('fileConfigLines'),
+                getState().org.present.get('linesBeforeHeadings')
               )
             )
             .then(() => {

--- a/src/components/OrgFile/OrgFile.unit.test.js
+++ b/src/components/OrgFile/OrgFile.unit.test.js
@@ -11,7 +11,9 @@ function parseAndExportOrgFile(testOrgFile) {
   const parsedFile = parseOrg(testOrgFile);
   const headers = parsedFile.get('headers');
   const todoKeywordSets = parsedFile.get('todoKeywordSets');
-  const exportedFile = exportOrg(headers, todoKeywordSets);
+  const fileConfigLines = parsedFile.get('fileConfigLines');
+  const linesBeforeHeadings = parsedFile.get('linesBeforeHeadings');
+  const exportedFile = exportOrg(headers, todoKeywordSets,fileConfigLines,linesBeforeHeadings);
   return exportedFile;
 }
 
@@ -52,6 +54,12 @@ describe('Unit Tests for org file', () => {
         const exportedFile = parseAndExportOrgFile(testOrgFile);
         expect(exportedFile).toEqual(testOrgFile);
       });
+    });
+
+	test('Config and content lines before first heading line are kept', () => {
+      const testOrgFile = readFixture('before-first-headline');
+      const exportedFile = parseAndExportOrgFile(testOrgFile);
+      expect(exportedFile).toEqual(testOrgFile);
     });
 
     describe('Planning items', () => {

--- a/src/lib/export_org.js
+++ b/src/lib/export_org.js
@@ -216,15 +216,30 @@ export const attributedStringToRawText = parts => {
     .join('');
 };
 
-export default (headers, todoKeywordSets) => {
+export default (headers, todoKeywordSets, fileConfigLines, linesBeforeHeadings) => {
   let configContent = '';
+
+  if (fileConfigLines.size > 0) {
+    configContent = fileConfigLines.join('\n') + '\n';
+  }
+
   if (!todoKeywordSets.get(0).get('default')) {
     configContent =
+      configContent +
       todoKeywordSets
         .map(todoKeywordSet => {
           return todoKeywordSet.get('configLine');
         })
-        .join('\n') + '\n\n';
+        .join('\n') +
+      '\n';
+  }
+
+  if (linesBeforeHeadings.size > 0) {
+    configContent = configContent + linesBeforeHeadings.join('\n');
+  }
+
+  if (configContent.length > 0) {
+    configContent = configContent + '\n';
   }
 
   const headerContent = headers

--- a/src/lib/parse_org.js
+++ b/src/lib/parse_org.js
@@ -607,6 +607,8 @@ export const parseOrg = fileContents => {
   const lines = fileContents.split('\n');
 
   let todoKeywordSets = new List();
+  let fileConfigLines = new List();
+  let linesBeforeHeadings = new List();
 
   lines.forEach(line => {
     // A header has to start with at least one consecutive asterisk
@@ -637,6 +639,10 @@ export const parseOrg = fileContents => {
               default: false,
             })
           );
+        } else if (line.startsWith('#+')) {
+          fileConfigLines = fileConfigLines.push(line);
+        } else {
+          linesBeforeHeadings = linesBeforeHeadings.push(line);
         }
       } else {
         headers = headers.updateIn([headers.size - 1, 'rawDescription'], rawDescription => {
@@ -678,5 +684,7 @@ export const parseOrg = fileContents => {
   return fromJS({
     headers,
     todoKeywordSets,
+    fileConfigLines,
+    linesBeforeHeadings,
   });
 };

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -41,7 +41,9 @@ const displayFile = (state, action) => {
     .set('path', action.path)
     .set('contents', action.contents)
     .set('headers', parsedFile.get('headers'))
-    .set('todoKeywordSets', parsedFile.get('todoKeywordSets'));
+    .set('todoKeywordSets', parsedFile.get('todoKeywordSets'))
+    .set('fileConfigLines', parsedFile.get('fileConfigLines'))
+    .set('linesBeforeHeadings', parsedFile.get('linesBeforeHeadings'));
 };
 
 const stopDisplayingFile = state =>
@@ -49,7 +51,9 @@ const stopDisplayingFile = state =>
     .set('path', null)
     .set('contents', null)
     .set('headers', null)
-    .set('todoKeywordSets', null);
+    .set('todoKeywordSets', null)
+    .set('fileConfigLines', null)
+    .set('linesBeforeHeadings', null);
 
 const openHeader = (state, action) => {
   const headers = state.get('headers');


### PR DESCRIPTION
They will not be visible and editable for now, but are not lost on
import and export (better than the current situation in my opinion).

This can be viewed as a temporary (perhaps not so beautiful) fix for avoiding information loss until the proper parser is completed.

----

#