### PR TITLE
[WIP] Docker Support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,14 +51,28 @@ jobs:
 
       - run: yarn test
 
+  push-image:
+    machine: true
+    steps:
+      - checkout
+      - run: docker build --rm=false -t ${DOCKER_HUB_USR}/organice:${CIRCLE_SHA1} .
+      - run: docker login --username ${DOCKER_HUB_USR} --password ${DOCKER_HUB_PWD}
+      - run: docker push ${DOCKER_HUB_USR}/organice:${CIRCLE_SHA1}
+
 workflows:
   version: 2
   build-deploy:
     jobs:
-      - build
-      - deploy:
-          requires:
-            - build
-          filters:
-            branches:
-              only: master
+      # - build
+      - push-image
+          # requires:
+          #   - build
+          # filters:
+          #   branches:
+          #     only: master
+      # - deploy:
+      #     requires:
+      #       - build
+      #     filters:
+      #       branches:
+      #         only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ workflows:
       #     filters:
       #       branches:
       #         only: master
-      - push-image
+      - push-image:
           requires:
             - build  # because of tests
           # filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,9 +55,13 @@ jobs:
     machine: true
     steps:
       - checkout
+      # Build docker image and push it to DockerHub
       - run: docker build --rm=false -t ${DOCKER_HUB_USR}/organice:${CIRCLE_BUILD_NUM} .
       - run: docker login --username ${DOCKER_HUB_USR} --password ${DOCKER_HUB_PWD}
       - run: docker push ${DOCKER_HUB_USR}/organice:${CIRCLE_BUILD_NUM}
+      # Re-assign latest tag to current build
+      - run: docker tag ${DOCKER_HUB_USR}/organice:${CIRCLE_BUILD_NUM} ${DOCKER_HUB_USR}/organice:latest
+      - run: docker push ${DOCKER_HUB_USR}/organice:latest
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,9 +55,9 @@ jobs:
     machine: true
     steps:
       - checkout
-      - run: docker build --rm=false -t ${DOCKER_HUB_USR}/organice:${CIRCLE_SHA1} .
+      - run: docker build --rm=false -t ${DOCKER_HUB_USR}/organice:${CIRCLE_BUILD_NUM} .
       - run: docker login --username ${DOCKER_HUB_USR} --password ${DOCKER_HUB_PWD}
-      - run: docker push ${DOCKER_HUB_USR}/organice:${CIRCLE_SHA1}
+      - run: docker push ${DOCKER_HUB_USR}/organice:${CIRCLE_BUILD_NUM}
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,15 +68,15 @@ workflows:
   build-deploy:
     jobs:
       - build
-      # - deploy:
-      #     requires:
-      #       - build
-      #     filters:
-      #       branches:
-      #         only: master
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
       - push-image:
           requires:
             - build  # because of tests
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,16 +67,16 @@ workflows:
   version: 2
   build-deploy:
     jobs:
-      # - build
-      - push-image
-          # requires:
-          #   - build
-          # filters:
-          #   branches:
-          #     only: master
+      - build
       # - deploy:
       #     requires:
       #       - build
       #     filters:
       #       branches:
       #         only: master
+      - push-image
+          requires:
+            - build  # because of tests
+          # filters:
+          #   branches:
+          #     only: master

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN yarn install \
 
 RUN addgroup -S organice \
     && adduser -S organice -G organice
-USER organic
+USER organice
 
 ENV NODE_ENV=production
 EXPOSE 5000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM node:12.13-alpine3.9
 
+# Switch to Apline Linux Mirror of Clarkson University:
+# https://mirror.clarkson.edu/distributions.html#alpine
+# This fixes an issue with hanging fetch commands in CI, see also
+# https://github.com/gliderlabs/docker-alpine/issues/307#issuecomment-427465925
+RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/http\:\/\/mirror.clarkson.edu/g' /etc/apk/repositories
+
 RUN apk add --no-cache yarn
 
 COPY . /opt/organice
@@ -9,6 +15,8 @@ RUN yarn install \
     && yarn global add serve \
     && yarn build
 
+# No root privileges are required. Create and switch to non-root user.
+# https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
 RUN addgroup -S organice \
     && adduser -S organice -G organice
 USER organice

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ WORKDIR /opt/organice
 RUN yarn install \
     && yarn global add serve \
     && yarn build \
-    && yarn cache clean
+    && yarn cache clean \
+    && rm -rf node_modules
 
 # No root privileges are required. Create and switch to non-root user.
 # https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:12.13-alpine3.9
+
+RUN apk add --no-cache yarn
+
+COPY . /opt/organice
+WORKDIR /opt/organice
+
+RUN yarn install \
+    && yarn global add serve \
+    && yarn build
+
+RUN addgroup -S organic \
+    && adduser -S organic -G organic
+USER organic
+
+ENV NODE_ENV=production
+EXPOSE 5000
+ENTRYPOINT ["serve", "-s", "build"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN yarn install \
     && yarn global add serve \
     && yarn build
 
-RUN addgroup -S organic \
-    && adduser -S organic -G organic
+RUN addgroup -S organice \
+    && adduser -S organice -G organice
 USER organic
 
 ENV NODE_ENV=production

--- a/README.org
+++ b/README.org
@@ -306,6 +306,33 @@ RewriteRule ^ - [L]
 RewriteRule ^ /index.html [L]
 #+END_EXAMPLE
 
+  *
+*** Docker
+Organice is also available as a docker image.
+
+**** with docker-compose
+
+If [[https://docs.docker.com/compose/][docker-compose]] is installed the following command downloads and runs the
+latest image automatically.
+
+#+BEGIN_SRC shell
+docker-compose up -d
+#+END_SRC
+
+The webserver is listening on port 5000 and can be reached here:
+http://localhost:5000
+
+**** Without docker-compose
+
+If docker-compose is not installed the command looks like this:
+
+#+BEGIN_SRC shell
+docker run -p 5000:5000 -t organice twohundredok/organice:latest
+#+END_SRC
+
+Again the webserver is listening on port 5000 and can be reached here:
+http://localhost:5000
+  
 ** Capture templates
 
 organice supports capture templates by implementing a flexible

--- a/README.org
+++ b/README.org
@@ -263,6 +263,40 @@ END_SCRIPT
 exit 0
 #+END_SRC
 
+*** Docker
+
+organice is also available as a Docker image.
+
+**** With =docker-compose=
+
+If [[https://docs.docker.com/compose/][docker-compose]] is installed, the following command downloads and
+runs the latest image automatically.
+
+#+BEGIN_SRC shell
+docker-compose up -d
+#+END_SRC
+
+The webserver is listening on port 5000 and can be reached here:
+http://localhost:5000
+
+If you want to build the image yourself, use the
+=docker-compose-dev.yaml= file:
+
+#+BEGIN_SRC shell
+docker-compose -f docker-compose-dev.yaml up
+#+END_SRC
+
+**** Without docker-compose
+
+If =docker-compose= is not installed the command looks like this:
+
+#+BEGIN_SRC shell
+docker run -p 5000:5000 -t organice twohundredok/organice:latest
+#+END_SRC
+
+Again the webserver is listening on port 5000 and can be reached here:
+http://localhost:5000
+
 *** Heroku
 Assuming, you have an account and have installed the [[https://devcenter.heroku.com/articles/heroku-cli][command line
 tools]], deployment is as easy as:
@@ -306,33 +340,6 @@ RewriteRule ^ - [L]
 RewriteRule ^ /index.html [L]
 #+END_EXAMPLE
 
-  *
-*** Docker
-Organice is also available as a docker image.
-
-**** with docker-compose
-
-If [[https://docs.docker.com/compose/][docker-compose]] is installed the following command downloads and runs the
-latest image automatically.
-
-#+BEGIN_SRC shell
-docker-compose up -d
-#+END_SRC
-
-The webserver is listening on port 5000 and can be reached here:
-http://localhost:5000
-
-**** Without docker-compose
-
-If docker-compose is not installed the command looks like this:
-
-#+BEGIN_SRC shell
-docker run -p 5000:5000 -t organice twohundredok/organice:latest
-#+END_SRC
-
-Again the webserver is listening on port 5000 and can be reached here:
-http://localhost:5000
-  
 ** Capture templates
 
 organice supports capture templates by implementing a flexible

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -2,5 +2,7 @@ version: "3"
 services:
   organice:
     image: "twohundredok/organice:latest"
+    build:
+      context: .
     ports:
       - "5000:5000"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
-version: "3"
+version: '3'
 services:
   organice:
-    image: "twohundredok/organice:latest"
+    image: 'twohundredok/organice:latest'
     ports:
-      - "5000:5000"
+      - '5000:5000'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,7 @@
 version: "3"
 services:
   organice:
+    image: twohundredok/organice:latest
     build:
       context: .
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,7 @@
+version: "3"
+services:
+  organice:
+    build:
+      context: .
+    ports:
+      - "5000:5000"


### PR DESCRIPTION
This PR adds support for creating a Docker image from the source code which has  been requested in  #132. 

The Docker image makes it easier to run this service without the need to install the correct versions for `nodejs`, `yarn`, etc.
It also allows users to be able to run this service in a Kubernetes cluster or a Docker Swarm cluster.

This PR is still in progress while a pipeline has to be built around creating the Docker image and pushing it to some registry (e.g. Docker Hub).