### PR TITLE
Improve webdav url input

### DIFF
--- a/src/components/SyncServiceSignIn/index.js
+++ b/src/components/SyncServiceSignIn/index.js
@@ -44,7 +44,7 @@ function WebDAVForm() {
         <p>
           <label>Url:</label>
           <input
-            type="text"
+            type="url"
             value={url}
             className="textfield"
             onChange={e => {


### PR DESCRIPTION
This PR is just a minimal change, but it provides a better UX for mobile users. It changes the type of the URL input box from `type="text"` to `type="url"`, which enables mobile OSes to use the correct keyboard layout. See [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/url).