### PR TITLE
[WIP] Failing unit tests for inline-markup

### DIFF
--- a/src/components/OrgFile/OrgFile.unit.test.js
+++ b/src/components/OrgFile/OrgFile.unit.test.js
@@ -56,6 +56,17 @@ describe('Unit Tests for Org file', () => {
       });
     });
 
+    describe('regex collisions of inline-markup and different links', () => {
+      test('Parse /italic/ followed by URL with /', () => {
+        const result = parseMarkupAndCookies('/italic/ word http://example.com/ text');
+        expect(result.length).toEqual(4);
+      });
+      test('Parse =verb= followed by URL with = in query', () => {
+        const result = parseMarkupAndCookies('=URL=: http://example.com/?a=b');
+        expect(result.length).toEqual(3);
+      });
+    });
+
     describe('HTTP URLs', () => {
       test('Parse a line containing an URL but no /italic/ text before the URL', () => {
         const testOrgFile = readFixture('url');


### PR DESCRIPTION
Previous discussion: https://github.com/200ok-ch/organice/pull/147#issuecomment-568739231

'inline-markup' is being parsed too greedy. This PR includes tests to show it. Next step: Fix the parser.