### PR TITLE
Place TODO keyword of previous header in the new header

### DIFF
--- a/src/components/OrgFile/OrgFile.integration.test.js
+++ b/src/components/OrgFile/OrgFile.integration.test.js
@@ -76,96 +76,7 @@ Some description content
     store.dispatch(displayFile('fixtureTestFile.org', testOrgFile));
   });
 
-  describe('Actions within an Org file', () => {
-    test('Can select a header in an org file', () => {
-      const { getByText, queryByText } = render(
-        <MemoryRouter keyLength={0}>
-          <Provider store={store}>
-            <OrgFile path="fixtureTestFile.org" />
-          </Provider>
-        </MemoryRouter>
-      );
-
-      expect(queryByText('Scheduled')).toBeFalsy();
-      expect(queryByText('Deadline')).toBeFalsy();
-
-      fireEvent.click(getByText('Top level header'));
-
-      expect(queryByText('Scheduled')).toBeTruthy();
-      expect(queryByText('Deadline')).toBeTruthy();
-    });
-
-    // Org Mode has keywords as workflow states and can cycle through
-    // them: https://orgmode.org/manual/Workflow-states.html
-    // In organice, we can cycle through them by swiping or by clicking
-    // (if enabled). This test checks for the latter.
-    test('Can advance todo state for selected header in an org file', () => {
-      const { queryByText } = render(
-        <MemoryRouter keyLength={0}>
-          <Provider store={store}>
-            <OrgFile path="fixtureTestFile.org" />
-          </Provider>
-        </MemoryRouter>
-      );
-
-      // In the very beginning, the TODO is hidden, because the file
-      // starts folded down to the top level
-      expect(queryByText('TODO')).toBeFalsy();
-
-      // Cycle the top header (which will make the next headers
-      // [including the TODO] visible
-      fireEvent.click(queryByText('Top level header'));
-
-      // In the beginning, the TODO is not DONE
-      expect(queryByText('TODO')).toBeTruthy();
-      expect(queryByText('DONE')).toBeFalsy();
-
-      // Toggle the TODO
-      fireEvent.click(queryByText('TODO'));
-
-      // Then the TODO is DONE
-      expect(queryByText('TODO')).toBeFalsy();
-      expect(queryByText('DONE')).toBeTruthy();
-    });
-
-    test('Can clock in & out of an event', () => {
-      const { getByText, queryByText } = render(
-        <MemoryRouter keyLength={0}>
-          <Provider store={store}>
-            <OrgFile path="fixtureTestFile.org" />
-          </Provider>
-        </MemoryRouter>
-      );
-
-      expect(queryByText('Clock In')).toBeFalsy();
-      expect(queryByText('Clock Out')).toBeFalsy();
-
-      fireEvent.click(getByText('Top level header'));
-
-      expect(queryByText('Clock In')).toBeTruthy();
-      expect(queryByText('Clock Out')).toBeFalsy();
-      expect(queryByText(':LOGBOOK:...')).toBeFalsy();
-
-      fireEvent.click(getByText('Clock In'));
-
-      expect(queryByText('Clock In')).toBeFalsy();
-      expect(queryByText('Clock Out')).toBeTruthy();
-      expect(queryByText(':LOGBOOK:...')).toBeTruthy();
-
-      fireEvent.click(getByText('Clock Out'));
-
-      expect(queryByText('Clock In')).toBeTruthy();
-      expect(queryByText('Clock Out')).toBeFalsy();
-      expect(queryByText(':LOGBOOK:...')).toBeTruthy();
-
-      fireEvent.click(getByText(':LOGBOOK:...'));
-
-      expect(queryByText('CLOCK:')).toBeTruthy();
-      expect(queryByText('=> 0:00')).toBeTruthy();
-    });
-  });
-
-  describe('Renders everything starting from an Org file', () => {
+  describe('Org Functionality', () => {
     let container,
       getByText,
       getAllByText,
@@ -194,172 +105,252 @@ Some description content
       queryAllByText = res.queryAllByText;
     });
 
-    test('renders an Org file', () => {
-      expect(getAllByText(/\*/)).toHaveLength(5);
-      expect(container).toMatchSnapshot();
-    });
+    describe('Actions within an Org file', () => {
+      test('Can select a header in an org file', () => {
+        expect(queryByText('Scheduled')).toBeFalsy();
+        expect(queryByText('Deadline')).toBeFalsy();
 
-    describe('Undo / Redo', () => {
-      test('On loading an Org file, both are disabled', () => {
-        expect(getByTitle('Undo').classList.contains('header-bar__actions__item--disabled')).toBe(
-          true
-        );
-        expect(getByTitle('Redo').classList.contains('header-bar__actions__item--disabled')).toBe(
-          true
-        );
+        fireEvent.click(getByText('Top level header'));
+
+        expect(queryByText('Scheduled')).toBeTruthy();
+        expect(queryByText('Deadline')).toBeTruthy();
       });
 
-      // FIXME: Why is this test not working?
-      test.skip('Undo becomes available on interaction', () => {
-        fireEvent.click(queryByText('Top level header'));
-        fireEvent.click(queryByText('TODO'));
-        // INFO: In the real app, the class is removed now
-        expect(getByTitle('Undo').classList.contains('header-bar__actions__item--disabled')).toBe(
-          false
-        );
-      });
-
-      // FIXME: Why is this test not working?
-      test.skip('Undo and redo do their respective task', () => {
-        fireEvent.click(queryByText('Top level header'));
-        expect(queryByText('TODO')).toBeTruthy();
-        fireEvent.click(queryByText('TODO'));
+      // Org Mode has keywords as workflow states and can cycle through
+      // them: https://orgmode.org/manual/Workflow-states.html
+      // In organice, we can cycle through them by swiping or by clicking
+      // (if enabled). This test checks for the latter.
+      test('Can advance todo state for selected header in an org file', () => {
+        // In the very beginning, the TODO is hidden, because the file
+        // starts folded down to the top level
         expect(queryByText('TODO')).toBeFalsy();
 
-        // Likely this is what is not working
-        fireEvent.click(getByTitle('Undo'));
-        // INFO: This is where the test stops working
-        expect(queryByText('TODO')).toBeTruthy();
-
-        // fireEvent.click(getByTitle('Redo'));
-        // expect(queryByText('TODO')).toBeFalsy();
-      });
-    });
-
-    describe('Planning items', () => {
-      test('deletes planning items', () => {
+        // Cycle the top header (which will make the next headers
+        // [including the TODO] visible
         fireEvent.click(queryByText('Top level header'));
+
+        // In the beginning, the TODO is not DONE
+        expect(queryByText('TODO')).toBeTruthy();
+        expect(queryByText('DONE')).toBeFalsy();
+
+        // Toggle the TODO
+        fireEvent.click(queryByText('TODO'));
+
+        // Then the TODO is DONE
+        expect(queryByText('TODO')).toBeFalsy();
+        expect(queryByText('DONE')).toBeTruthy();
+      });
+
+      // Same behaviour has `S-C-RET` in Emacs Org mode.
+      test('Can create a new header with an inherited todoKeyword', () => {
+        fireEvent.click(queryByText('Top level header'));
+        // Click 'plus' on the first header which is _not_ a todoKeyword header
+        fireEvent.click(container.querySelectorAll("[data-testid='header-action-plus']")[0]);
+        expect(getByTestId('titleLineInput').value).toEqual('');
+
+        // Click 'plus' on the second header which _is_ a todoKeyword header
         fireEvent.click(queryByText('A todo item with schedule and deadline'));
-        fireEvent.click(queryByText('<2019-09-19 Thu>'));
+        fireEvent.click(container.querySelectorAll("[data-testid='header-action-plus']")[1]);
+        expect(getByTestId('titleLineInput').value).toEqual('TODO ');
+      });
 
-        expect(queryByText('SCHEDULED:')).toBeTruthy();
-        expect(queryByText('DEADLINE:')).toBeTruthy();
+      test('Can clock in & out of an event', () => {
+        expect(queryByText('Clock In')).toBeFalsy();
+        expect(queryByText('Clock Out')).toBeFalsy();
 
-        // First: Delete "Scheduled" time
+        fireEvent.click(getByText('Top level header'));
 
-        // The <input type="date"> field exposes a 'x' button to
-        // delete the time. There's no direct API to trigger it.
-        // Hence, get the element, remove the time and fire the
-        // 'change' event manually.
-        let timePicker = getByTestId('timestamp-selector');
-        timePicker.value = null;
-        fireEvent.change(timePicker);
+        expect(queryByText('Clock In')).toBeTruthy();
+        expect(queryByText('Clock Out')).toBeFalsy();
+        expect(queryByText(':LOGBOOK:...')).toBeFalsy();
 
-        expect(queryByText('SCHEDULED:')).toBeFalsy();
-        expect(queryByText('DEADLINE:')).toBeTruthy();
+        fireEvent.click(getByText('Clock In'));
 
-        // Second: Delete "Deadline" time
+        expect(queryByText('Clock In')).toBeFalsy();
+        expect(queryByText('Clock Out')).toBeTruthy();
+        expect(queryByText(':LOGBOOK:...')).toBeTruthy();
 
-        fireEvent.click(queryByText('<2018-10-05 Fri>'));
-        timePicker = getByTestId('timestamp-selector');
-        timePicker.value = null;
-        fireEvent.change(timePicker);
+        fireEvent.click(getByText('Clock Out'));
 
-        expect(queryByText('SCHEDULED:')).toBeFalsy();
-        expect(queryByText('DEADLINE:')).toBeFalsy();
+        expect(queryByText('Clock In')).toBeTruthy();
+        expect(queryByText('Clock Out')).toBeFalsy();
+        expect(queryByText(':LOGBOOK:...')).toBeTruthy();
+
+        fireEvent.click(getByText(':LOGBOOK:...'));
+
+        expect(queryByText('CLOCK:')).toBeTruthy();
+        expect(queryByText('=> 0:00')).toBeTruthy();
       });
     });
 
-    describe('Sharing', () => {
-      let windowSpy;
-      beforeEach(() => {
-        windowSpy = jest.spyOn(global, 'open');
-        windowSpy.mockImplementation(x => x);
+    describe('Renders everything starting from an Org file', () => {
+      test('renders an Org file', () => {
+        expect(getAllByText(/\*/)).toHaveLength(5);
+        expect(container).toMatchSnapshot();
       });
 
-      afterEach(() => {
-        windowSpy.mockRestore();
+      describe('Undo / Redo', () => {
+        test('On loading an Org file, both are disabled', () => {
+          expect(getByTitle('Undo').classList.contains('header-bar__actions__item--disabled')).toBe(
+            true
+          );
+          expect(getByTitle('Redo').classList.contains('header-bar__actions__item--disabled')).toBe(
+            true
+          );
+        });
+
+        // FIXME: Why is this test not working?
+        test.skip('Undo becomes available on interaction', () => {
+          fireEvent.click(queryByText('Top level header'));
+          fireEvent.click(queryByText('TODO'));
+          // INFO: In the real app, the class is removed now
+          expect(getByTitle('Undo').classList.contains('header-bar__actions__item--disabled')).toBe(
+            false
+          );
+        });
+
+        // FIXME: Why is this test not working?
+        test.skip('Undo and redo do their respective task', () => {
+          fireEvent.click(queryByText('Top level header'));
+          expect(queryByText('TODO')).toBeTruthy();
+          fireEvent.click(queryByText('TODO'));
+          expect(queryByText('TODO')).toBeFalsy();
+
+          // Likely this is what is not working
+          fireEvent.click(getByTitle('Undo'));
+          // INFO: This is where the test stops working
+          expect(queryByText('TODO')).toBeTruthy();
+
+          // fireEvent.click(getByTitle('Redo'));
+          // expect(queryByText('TODO')).toBeFalsy();
+        });
       });
 
-      test('sends the selected header and its body as an email', () => {
-        fireEvent.click(queryByText('Another top level header'));
-        fireEvent.click(getByTestId('share'));
-        expect(global.open).toBeCalledWith(
-          `mailto:?subject=${encodeURIComponent(
-            'Another top level header'
-          )}&body=${encodeURIComponent('\n\nSome description content\n')}`
-        );
-      });
-    });
+      describe('Planning items', () => {
+        test('deletes planning items', () => {
+          fireEvent.click(queryByText('Top level header'));
+          fireEvent.click(queryByText('A todo item with schedule and deadline'));
+          fireEvent.click(queryByText('<2019-09-19 Thu>'));
 
-    describe('Agenda', () => {
-      test('renders Agenda for an Org file', () => {
-        // Agenda is not visible by default
-        expect(queryByText('Agenda')).toBeFalsy();
-        expect(queryByText('Day')).toBeFalsy();
-        expect(queryByText('Month')).toBeFalsy();
-        expect(queryByText('A scheduled todo item')).toBeFalsy();
+          expect(queryByText('SCHEDULED:')).toBeTruthy();
+          expect(queryByText('DEADLINE:')).toBeTruthy();
 
-        fireEvent.click(getByTitle('Show agenda'));
+          // First: Delete "Scheduled" time
 
-        expect(queryByText('Agenda')).toBeTruthy();
-        expect(queryByText('Day')).toBeTruthy();
-        expect(queryByText('Month')).toBeTruthy();
-        expect(queryAllByText('A todo item with schedule and deadline')).toBeTruthy();
+          // The <input type="date"> field exposes a 'x' button to
+          // delete the time. There's no direct API to trigger it.
+          // Hence, get the element, remove the time and fire the
+          // 'change' event manually.
+          let timePicker = getByTestId('timestamp-selector');
+          timePicker.value = null;
+          fireEvent.change(timePicker);
+
+          expect(queryByText('SCHEDULED:')).toBeFalsy();
+          expect(queryByText('DEADLINE:')).toBeTruthy();
+
+          // Second: Delete "Deadline" time
+
+          fireEvent.click(queryByText('<2018-10-05 Fri>'));
+          timePicker = getByTestId('timestamp-selector');
+          timePicker.value = null;
+          fireEvent.change(timePicker);
+
+          expect(queryByText('SCHEDULED:')).toBeFalsy();
+          expect(queryByText('DEADLINE:')).toBeFalsy();
+        });
       });
 
-      test('Clicking a TODO within the agenda highlights it in the main view', () => {
-        fireEvent.click(getByTitle('Show agenda'));
-        fireEvent.click(queryAllByText('A todo item with schedule and deadline')[0]);
-        expect(queryByText('Agenda')).toBeFalsy();
-        expect(queryByText('A todo item with schedule and deadline')).toBeTruthy();
-        expect(queryByText('Scheduled')).toBeTruthy();
+      describe('Sharing', () => {
+        let windowSpy;
+        beforeEach(() => {
+          windowSpy = jest.spyOn(global, 'open');
+          windowSpy.mockImplementation(x => x);
+        });
+
+        afterEach(() => {
+          windowSpy.mockRestore();
+        });
+
+        test('sends the selected header and its body as an email', () => {
+          fireEvent.click(queryByText('Another top level header'));
+          fireEvent.click(getByTestId('share'));
+          expect(global.open).toBeCalledWith(
+            `mailto:?subject=${encodeURIComponent(
+              'Another top level header'
+            )}&body=${encodeURIComponent('\n\nSome description content\n')}`
+          );
+        });
       });
 
-      test('Clicking the Timestamp in a TODO within the agenda toggles from the date to the time', () => {
-        fireEvent.click(getByTitle('Show agenda'));
-        const timeSinceScheduled = formatDistanceToNow(new Date('2019-09-19'));
-        expect(queryByText(timeSinceScheduled)).toBeFalsy();
-        expect(queryByText('09/19')).toBeTruthy();
-        fireEvent.click(queryByText('09/19'));
-        expect(queryByText('09/19')).toBeFalsy();
-        expect(queryByText(`${timeSinceScheduled} ago`)).toBeTruthy();
-      });
-    });
+      describe('Agenda', () => {
+        test('renders Agenda for an Org file', () => {
+          // Agenda is not visible by default
+          expect(queryByText('Agenda')).toBeFalsy();
+          expect(queryByText('Day')).toBeFalsy();
+          expect(queryByText('Month')).toBeFalsy();
+          expect(queryByText('A scheduled todo item')).toBeFalsy();
 
-    describe('Link recognition', () => {
-      test('recognizes phone numbers', () => {
-        fireEvent.click(
-          queryByText('A header with a URL, mail address and phone number as content')
-        );
-        const elem = getAllByText('+498025123456789');
-        // There's exactly one phone number
-        expect(elem.length).toEqual(1);
-        // And it renders as such
-        expect(elem[0]).toHaveAttribute('href', 'tel:+498025123456789');
-        expect(elem[0]).toHaveTextContent('+498025123456789');
+          fireEvent.click(getByTitle('Show agenda'));
+
+          expect(queryByText('Agenda')).toBeTruthy();
+          expect(queryByText('Day')).toBeTruthy();
+          expect(queryByText('Month')).toBeTruthy();
+          expect(queryAllByText('A todo item with schedule and deadline')).toBeTruthy();
+        });
+
+        test('Clicking a TODO within the agenda highlights it in the main view', () => {
+          fireEvent.click(getByTitle('Show agenda'));
+          fireEvent.click(queryAllByText('A todo item with schedule and deadline')[0]);
+          expect(queryByText('Agenda')).toBeFalsy();
+          expect(queryByText('A todo item with schedule and deadline')).toBeTruthy();
+          expect(queryByText('Scheduled')).toBeTruthy();
+        });
+
+        test('Clicking the Timestamp in a TODO within the agenda toggles from the date to the time', () => {
+          fireEvent.click(getByTitle('Show agenda'));
+          const timeSinceScheduled = formatDistanceToNow(new Date('2019-09-19'));
+          expect(queryByText(timeSinceScheduled)).toBeFalsy();
+          expect(queryByText('09/19')).toBeTruthy();
+          fireEvent.click(queryByText('09/19'));
+          expect(queryByText('09/19')).toBeFalsy();
+          expect(queryByText(`${timeSinceScheduled} ago`)).toBeTruthy();
+        });
       });
-      test('recognizes URLs', () => {
-        fireEvent.click(
-          queryByText('A header with a URL, mail address and phone number as content')
-        );
-        const elem = getAllByText('https://foo.bar.baz/xyz?a=b&d#foo');
-        // There's exactly one such URL
-        expect(elem.length).toEqual(1);
-        // And it renders as such
-        expect(elem[0]).toHaveAttribute('href', 'https://foo.bar.baz/xyz?a=b&d#foo');
-        expect(elem[0]).toHaveTextContent('https://foo.bar.baz/xyz?a=b&d#foo');
-      });
-      test('recognizes email addresses', () => {
-        fireEvent.click(
-          queryByText('A header with a URL, mail address and phone number as content')
-        );
-        const elem = getAllByText('foo.bar@baz.org');
-        // There's exactly one such email address
-        expect(elem.length).toEqual(1);
-        // And it renders as such
-        expect(elem[0]).toHaveAttribute('href', 'mailto:foo.bar@baz.org');
-        expect(elem[0]).toHaveTextContent('foo.bar@baz.org');
+
+      describe('Link recognition', () => {
+        test('recognizes phone numbers', () => {
+          fireEvent.click(
+            queryByText('A header with a URL, mail address and phone number as content')
+          );
+          const elem = getAllByText('+498025123456789');
+          // There's exactly one phone number
+          expect(elem.length).toEqual(1);
+          // And it renders as such
+          expect(elem[0]).toHaveAttribute('href', 'tel:+498025123456789');
+          expect(elem[0]).toHaveTextContent('+498025123456789');
+        });
+        test('recognizes URLs', () => {
+          fireEvent.click(
+            queryByText('A header with a URL, mail address and phone number as content')
+          );
+          const elem = getAllByText('https://foo.bar.baz/xyz?a=b&d#foo');
+          // There's exactly one such URL
+          expect(elem.length).toEqual(1);
+          // And it renders as such
+          expect(elem[0]).toHaveAttribute('href', 'https://foo.bar.baz/xyz?a=b&d#foo');
+          expect(elem[0]).toHaveTextContent('https://foo.bar.baz/xyz?a=b&d#foo');
+        });
+        test('recognizes email addresses', () => {
+          fireEvent.click(
+            queryByText('A header with a URL, mail address and phone number as content')
+          );
+          const elem = getAllByText('foo.bar@baz.org');
+          // There's exactly one such email address
+          expect(elem.length).toEqual(1);
+          // And it renders as such
+          expect(elem[0]).toHaveAttribute('href', 'mailto:foo.bar@baz.org');
+          expect(elem[0]).toHaveTextContent('foo.bar@baz.org');
+        });
       });
     });
   });

--- a/src/components/OrgFile/__snapshots__/OrgFile.integration.test.js.snap
+++ b/src/components/OrgFile/__snapshots__/OrgFile.integration.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Render all views Renders everything starting from an Org file renders an Org file 1`] = `
+exports[`Render all views Org Functionality Renders everything starting from an Org file renders an Org file 1`] = `
 <div>
   <div
     class="header-bar header-bar--with-logo"

--- a/src/components/OrgFile/components/Header/components/HeaderActionDrawer/index.js
+++ b/src/components/OrgFile/components/Header/components/HeaderActionDrawer/index.js
@@ -55,7 +55,7 @@ export default class HeaderActionDrawer extends PureComponent {
 
           <span className="header-action-drawer__separator" />
 
-          {this.iconWithFFClickCatcher('fas fa-plus fa-lg', onAddNewHeader)}
+          {this.iconWithFFClickCatcher('fas fa-plus fa-lg', onAddNewHeader, 'header-action-plus')}
         </div>
         <div className="header-action-drawer__row">
           <div

--- a/src/components/OrgFile/components/TitleLine/index.js
+++ b/src/components/OrgFile/components/TitleLine/index.js
@@ -222,6 +222,7 @@ class TitleLine extends PureComponent {
             <textarea
               autoFocus
               className="textarea"
+              data-testid="titleLineInput"
               rows="3"
               ref={this.handleTextareaRef}
               value={this.state.titleValue}
@@ -288,7 +289,4 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(TitleLine);
+export default connect(mapStateToProps, mapDispatchToProps)(TitleLine);

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -248,7 +248,7 @@ const addHeader = (state, action) => {
   const subheaders = subheadersOfHeaderWithId(headers, action.headerId);
 
   const newHeader = newHeaderWithTitle(
-    '',
+    header.getIn(['titleLine', 'todoKeyword']) + ' ',
     header.get('nestingLevel'),
     state.get('todoKeywordSets')
   );

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -247,8 +247,10 @@ const addHeader = (state, action) => {
 
   const subheaders = subheadersOfHeaderWithId(headers, action.headerId);
 
+  const todoKeyword = header.getIn(['titleLine', 'todoKeyword']);
+
   const newHeader = newHeaderWithTitle(
-    header.getIn(['titleLine', 'todoKeyword']) + ' ',
+    todoKeyword ? todoKeyword + ' ' : '',
     header.get('nestingLevel'),
     state.get('todoKeywordSets')
   );


### PR DESCRIPTION
This should close #20 

@munen When editing the title of a header (pressing the title edit icon), shouldn't we place the curser at the end of the line by default? At least for new headers (with a TODO keyword) this would make very much sense. And for existing headers with much text it wouldn't hurt, what do you think?