### PR TITLE
Support single- and double-quoted strings in the search filter

### DIFF
--- a/src/lib/headline_filter.js
+++ b/src/lib/headline_filter.js
@@ -16,17 +16,18 @@ export const isMatch = filterExpr => header => {
 
   const filterFilter = (type, exclude) => x => x.type === type && x.exclude === exclude;
   const words = x => x.words;
+  const wordsLowerCase = x => x.words.map(y => y.toLowerCase());
 
   const filterTags = filterExpr.filter(filterFilter('tag', false)).map(words);
   const filterCS = filterExpr.filter(filterFilter('case-sensitive', false)).map(words);
-  const filterIC = filterExpr.filter(filterFilter('ignore-case', false)).map(words);
+  const filterIC = filterExpr.filter(filterFilter('ignore-case', false)).map(wordsLowerCase);
   const filterProps = filterExpr
     .filter(filterFilter('property', false))
     .map(x => [x.property, x.words]);
 
   const filterTagsExcl = filterExpr.filter(filterFilter('tag', true)).map(words);
   const filterCSExcl = filterExpr.filter(filterFilter('case-sensitive', true)).map(words);
-  const filterICExcl = filterExpr.filter(filterFilter('ignore-case', true)).map(words);
+  const filterICExcl = filterExpr.filter(filterFilter('ignore-case', true)).map(wordsLowerCase);
   const filterPropsExcl = filterExpr
     .filter(filterFilter('property', true))
     .map(x => [x.property, x.words]);

--- a/src/lib/headline_filter.js
+++ b/src/lib/headline_filter.js
@@ -110,14 +110,19 @@ export const computeCompletions = (todoKeywords, tagNames, allProperties) => (
         // Either property name or text filter
         const indexOfOtherColon = filterString.substring(0, curserPosition - 1).lastIndexOf(':');
         const maybePropertyName = filterString.substring(indexOfOtherColon + 1, curserPosition - 1);
-        const onlyFirstPartOfValue = x => {
-          const match = x.match(/^[^ ]*/);
-          return match ? [match[0]] : [];
+        const quoteStringIfPossible = x => {
+          if (x.match(/ /)) {
+            if (!x.match(/"/)) return [`"${x}"`];
+            if (!x.match(/'/)) return [`'${x}'`];
+            const match = x.match(/^[^ ]*/);
+            return [match[0]];
+          }
+          return [x];
         };
         if (indexOfOtherColon >= 0 && maybePropertyName.match(/^[^ ]+$/)) {
           // No space in property name -> is property -> return values for that property
           return computeAllPropertyValuesFor(fromJS(allProperties), maybePropertyName)
-            .flatMap(onlyFirstPartOfValue)
+            .flatMap(quoteStringIfPossible)
             .toJS();
         }
       }

--- a/src/lib/headline_filter.unit.test.js
+++ b/src/lib/headline_filter.unit.test.js
@@ -97,6 +97,10 @@ describe('Match function for headline filter', () => {
       const filterExpr = gic('SPEC');
       expect(isMatch(filterExpr)(header)).toBe(true);
     });
+    test('Match a quoted string', () => {
+      const filterExpr = gic('spec head');
+      expect(isMatch(filterExpr)(header)).toBe(true);
+    });
     test('Not match a word', () => {
       const filterExpr = gic('xyz');
       expect(isMatch(filterExpr)(header)).toBe(false);

--- a/src/lib/headline_filter.unit.test.js
+++ b/src/lib/headline_filter.unit.test.js
@@ -214,7 +214,7 @@ describe('Computation of completions and suggestions for task filter', () => {
   const allProperties = [['prop1', 'val1'], ['prop1', 'val2'], ['prop3', 'val 3']];
   const tagAndPropNames = [].concat(tagNames, ['prop1:', 'prop3:']);
   const propValsForProp1 = ['val1', 'val2'];
-  const propValsForProp3 = ['val'];
+  const propValsForProp3 = ['"val 3"'];
 
   describe('Computation of completions', () => {
     // Function under test:
@@ -303,7 +303,6 @@ describe('Computation of completions and suggestions for task filter', () => {
         expectComputation('a :prop1: ', 9).toEqual(propValsForProp1);
       });
       test('Completions for property value must be the value part up to the first whitespace', () => {
-        // ... because of the limitation that quoted filter strings are not allowed.
         expectComputation(':prop3: ', 7).toEqual(propValsForProp3);
       });
     });

--- a/src/lib/headline_filter.unit.test.js
+++ b/src/lib/headline_filter.unit.test.js
@@ -93,6 +93,10 @@ describe('Match function for headline filter', () => {
       const filterExpr = gic('spec');
       expect(isMatch(filterExpr)(header)).toBe(true);
     });
+    test('Match a word with really ignore-case', () => {
+      const filterExpr = gic('SPEC');
+      expect(isMatch(filterExpr)(header)).toBe(true);
+    });
     test('Not match a word', () => {
       const filterExpr = gic('xyz');
       expect(isMatch(filterExpr)(header)).toBe(false);

--- a/src/lib/headline_filter_parser.grammar.pegjs
+++ b/src/lib/headline_filter_parser.grammar.pegjs
@@ -82,8 +82,8 @@ TagAlternatives "tag alternatives"
 
 Word "word"
   = [^: \t|'"]+ { return text() }
-  / "'" a:([^']+) "'" { return ''.concat(...a) }
-  / '"' a:([^"]+) '"' { return ''.concat(...a) }
+  / "'" a:([^']+) "'" { return a.join('') }
+  / '"' a:([^"]+) '"' { return a.join('') }
 
 // https://orgmode.org/manual/Property-Syntax.html
 // - Property names (keys) are case-insensitive

--- a/src/lib/headline_filter_parser.grammar.pegjs
+++ b/src/lib/headline_filter_parser.grammar.pegjs
@@ -41,7 +41,7 @@ PlainTerm
   / TermTag
 
 TermText "text filter term"
-  = a:WordAlternatives {
+  = a:StringAlternatives {
         let type = 'ignore-case';
         // It's hard to check for upper-case chars in JS.
         // Best approach: https://stackoverflow.com/a/31415820/999007
@@ -56,7 +56,7 @@ TermTag "tag filter term"
   = ":" a:TagAlternatives { return {type: 'tag', words: a} }
 
 TermProp "property filter term"
-  = ":" a:PropertyName ":" b:WordAlternatives? {
+  = ":" a:PropertyName ":" b:StringAlternatives? {
           return {
             type: 'property',
             property: a,
@@ -64,8 +64,8 @@ TermProp "property filter term"
           }
         };
 
-WordAlternatives "alternatives"
-  = head:Word tail:("|" Word)* {
+StringAlternatives "alternatives"
+  = head:String tail:("|" String)* {
        return tail.reduce((result, element) => {
          result.push(element[1]);
          return result;
@@ -80,7 +80,7 @@ TagAlternatives "tag alternatives"
        }, [head])
      }
 
-Word "word"
+String "string"
   = [^: \t|'"]+ { return text() }
   / "'" a:([^']+) "'" { return a.join('') }
   / '"' a:([^"]+) '"' { return a.join('') }

--- a/src/lib/headline_filter_parser.grammar.pegjs
+++ b/src/lib/headline_filter_parser.grammar.pegjs
@@ -6,6 +6,11 @@
 
 // You can use https://pegjs.org/online to debug it.
 
+// Note: As suggested by alphapapa, the parser can be extended to support
+// additional types of filter terms ("predicates"), e.g. ts:on=today
+// ts-active:from=2019-12-31 priority:A,B
+// - https://github.com/alphapapa/org-ql#non-sexp-query-syntax
+
 // Note: The parser will fail when the syntax does not match the grammar.
 // For example, it fails for filter strings like ":" or "this|" because the
 // grammar dictates a property or tag after ":" and an alternative word after

--- a/src/lib/headline_filter_parser.grammar.pegjs
+++ b/src/lib/headline_filter_parser.grammar.pegjs
@@ -81,7 +81,9 @@ TagAlternatives "tag alternatives"
      }
 
 Word "word"
-  = [^: \t|]+ { return text() }
+  = [^: \t|'"]+ { return text() }
+  / "'" a:([^']+) "'" { return ''.concat(...a) }
+  / '"' a:([^"]+) '"' { return ''.concat(...a) }
 
 // https://orgmode.org/manual/Property-Syntax.html
 // - Property names (keys) are case-insensitive

--- a/src/lib/headline_filter_parser.unit.test.js
+++ b/src/lib/headline_filter_parser.unit.test.js
@@ -81,6 +81,27 @@ describe('Headline filter parser', () => {
     });
   });
 
+  describe('Parsing of quoted strings', () => {
+    const expectStrings = s => expect(parser.parse(s)[0].words);
+    test('Parses a double-quoted string', () => {
+      expectStrings('"a b"').toEqual(['a b']);
+    });
+    test('Parses a single-quoted string', () => {
+      expectStrings("'a b'").toEqual(['a b']);
+    });
+    test('Parses a single-quoted string with alternatives', () => {
+      expectStrings("'a b'|'c d'").toEqual(['a b', 'c d']);
+    });
+    test('Not parses a quoted empty string, because that is bad input for the matcher', () => {
+      // The empty string would only make sense for property matching, but that
+      // must be currently done with this filter string: :prop1:
+      expect(() => expectStrings("''")).toThrowError();
+    });
+    test('Parses a quoted string in a property filter term', () => {
+      expectStrings(":prop1:'a b'").toEqual(['a b']);
+    });
+  });
+
   describe('Parsing of alltogether', () => {
     const s1 = ':assignee:jak|nik TODO|DONE Spec test -doc :tag :foo|bar';
     const s2 = ' ';


### PR DESCRIPTION
[This commit](https://github.com/200ok-ch/organice/pull/176/commits/3fd26615cd64add6a1b985a6b662e45130f18cb2) breaks `yarn start` but not `yarn test`

Update: [Fixed](https://github.com/200ok-ch/organice/pull/176/commits/f68d469e6280d4bd06e8a851ff31a33caae96727)

```
Failed to compile.

./src/reducers/org.js
Attempted import error: '../lib/headline_filter_parser' does not contain a default export (imported as 'headline_filter_parser').
```

The generated file `headline_filter_parser.js` – with or without the last commit – exports:
```
module.exports = {
  SyntaxError: peg$SyntaxError,
  parse:       peg$parse
};
```

It is imported like this:

```
import headline_filter_parser from '../lib/headline_filter_parser';
```

What is the problem? Does it work on the CI here?