### PR TITLE
Trim headline title at both sides before saving

### DIFF
--- a/src/lib/parse_org.js
+++ b/src/lib/parse_org.js
@@ -685,6 +685,9 @@ const concatRegexes = (...regexes) =>
   );
 
 export const newHeaderFromText = (rawText, todoKeywordSets) => {
+  // This function is currently only used for capture templates.
+  // Hence, it's acceptable that it is opinionated on treating
+  // whitespace.
   const titleLine = rawText.split('\n')[0].replace(/^\**\s*|\s*$/g, '');
   const description = rawText
     .split('\n')

--- a/src/lib/parse_org.js
+++ b/src/lib/parse_org.js
@@ -685,7 +685,7 @@ const concatRegexes = (...regexes) =>
   );
 
 export const newHeaderFromText = (rawText, todoKeywordSets) => {
-  const titleLine = rawText.split('\n')[0].replace(/^\**\s*/, '');
+  const titleLine = rawText.split('\n')[0].replace(/^\**\s*|\s*$/g, '');
   const description = rawText
     .split('\n')
     .slice(1)

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -214,7 +214,7 @@ const updateHeaderTitle = (state, action) => {
   const headers = state.get('headers');
   const headerIndex = indexOfHeaderWithId(headers, action.headerId);
 
-  const newTitleLine = parseTitleLine(action.newRawTitle, state.get('todoKeywordSets'));
+  const newTitleLine = parseTitleLine(action.newRawTitle.trim(), state.get('todoKeywordSets'));
 
   state = state.setIn(['headers', headerIndex, 'titleLine'], newTitleLine);
 

--- a/test_helpers/fixtures/all_the_features.org
+++ b/test_helpers/fixtures/all_the_features.org
@@ -96,3 +96,14 @@ qui dolorem eum fugiat quo voluptas nulla pariatur?"
    CLOCK: [2019-11-11 Mon 13:12]--[2019-11-12 Tue 13:12] => 24:00
    CLOCK: [2019-10-13 Sun 12:15]--[2019-10-13 Sun 14:12] =>  1:57
    :END:
+** A messy headline with trailing whitespace                    
+
+organice's parser is build on the premise that it should not produce a
+diff on users Org files. Lets say there's a new user with a big file.
+She has loads of trailing whitespace in headers. She opens the file in
+organice, makes a one byte change and looks at the diff. She should
+only find the one byte change. Or, The one byte change plus trimmed
+whitespace on the headline she made the change to. She shouldn't have
+her file 'messed with', even if we think it's cleaner.
+
+NB: organice is opinionated about helping users, though. Hence, it does trim whitespace when entered in capture templates.


### PR DESCRIPTION
... when capturing via template and when adding/editing a headline.

Makes sense?

I think it does not make sense to have trailing whitespace in any source code. OK, markdown uses trailing whitespace to declare a `<br>` but a headline in emacs does not need trailing space, right?