### PR TITLE
Refactoring

### DIFF
--- a/sample.org
+++ b/sample.org
@@ -203,50 +203,42 @@ Once signed in, you can set up capture templates that specify header paths (and 
 
 Below, there is a button to open up a task list.
 
-Tap a header in the task list view to jump to it, and tap on the date to
-switch to a more readable relative date format.
+Tap a header in the task list view to jump to it, and tap on the date to switch to a more readable relative date format.
 
-By default, only tasks, i.e. headlines with a TODO keyword are displayed.
-You can display all headlines by checking the checkbox.
+By default, only tasks, i.e. headlines with a TODO keyword are displayed. You can display all headlines by checking the checkbox.
 
-Using the filter input, you can search for headlines.
-Specifically, you can search for headline text, TODO keywords, tags, and
-[[https://orgmode.org/guide/Properties.html][orgmode properties]].
-It also supports alternatives, and you can exclude headlines by negating a
-filter.
+Using the filter input, you can search for headlines. Specifically, you can search for headline text, TODO keywords, tags, and [[https://orgmode.org/guide/Properties.html][orgmode properties]]. It also supports alternatives, and you can exclude headlines by negating a filter.
 
 ** Examples for the search syntax
 
 You can simply search for
-: TODO check out organice|orgmode
-to filter for tasks containing these
-words.
-The pipe symbol (=|=) means a logical /OR/.
-The filter is a smart-case search:
+
+TODO check out organice|orgmode
+
+to filter for tasks containing these words. The pipe symbol (=|=) means a logical /OR/. The filter is a smart-case search:
+
 - Lower-case words mean that the filter ignores the case.
 - If a word contains upper-case letters, the filter is case-sensitive.
 
-The following example searches for headlines containing =START= or =FINISHED=
-keywords and the string "states are".
-You can also use single-quotes.
-: START|FINISHED "states are"
+The following example searches for headlines containing =START= or =FINISHED= keywords and the string "states are". You can also use single-quotes.
+
+START|FINISHED "states are"
 
 The next example excludes =DONE= headlines but requires the tag =fun=.
-: -DONE  :fun
 
-You can exclude text strings, tags, and properties as well by prepending the
-minus sign (=-=).
+-DONE  :fun
+
+You can exclude text strings, tags, and properties as well by prepending the minus sign (=-=).
 
 Last but not least, you can search for headlines with defined properties:
-: TODO  :blocked_by:  :assignee:nobody|none
-This filters headlines having a property =blocked_by= (with any value) and a
-property =assignee= with a value containing =nobody= or =none=.
+
+TODO  :blocked_by:  :assignee:nobody|none
+
+This filters headlines having a property =blocked_by= (with any value) and a property =assignee= with a value containing =nobody= or =none=.
 
 ** Auto-completion for filters
 
-You probably noticed that organice provides suggestions for your filter.
-After space, =-=, =:=, and =|= you can tap on the completion – no need to
-type the tag, property, etc.
+You probably noticed that organice provides suggestions for your filter. After space, =-=, =:=, and =|= you can tap on the completion – no need to type the tag, property, etc.
 
 ** TODO Example with properties							:fun:
 :PROPERTIES:

--- a/sample.org
+++ b/sample.org
@@ -165,7 +165,7 @@ Try tapping on the timestamps below to get a feel for the editor:
 
 <2018-09-17 Sun>--<2018-09-25 Tue>
 * Property lists
-organice has native support for viewing and editing property lists. To bring up an editor, expand the ~PROPERTIES~ drawer below and tap on any of the properties.
+organice has native support for viewing and editing [[https://orgmode.org/guide/Properties.html][property lists]]. To bring up an editor, expand the ~PROPERTIES~ drawer below and tap on any of the properties.
 ** Example
 :PROPERTIES:
 :callsign: Maverick
@@ -198,6 +198,62 @@ Once signed in, you can set up capture templates that specify header paths (and 
 **** Headers
 ***** Work
 ****** Too!
+
+* Task list with search filter to find any headline
+
+Below, there is a button to open up a task list.
+
+Tap a header in the task list view to jump to it, and tap on the date to
+switch to a more readable relative date format.
+
+By default, only tasks, i.e. headlines with a TODO keyword are displayed.
+You can display all headlines by checking the checkbox.
+
+Using the filter input, you can search for headlines.
+Specifically, you can search for headline text, TODO keywords, tags, and
+[[https://orgmode.org/guide/Properties.html][orgmode properties]].
+It also supports alternatives, and you can exclude headlines by negating a
+filter.
+
+** Examples for the search syntax
+
+You can simply search for
+: TODO check out organice|orgmode
+to filter for tasks containing these
+words.
+The pipe symbol (=|=) means a logical /OR/.
+The filter is a smart-case search:
+- Lower-case words mean that the filter ignores the case.
+- If a word contains upper-case letters, the filter is case-sensitive.
+
+The following example searches for headlines containing =START= or =FINISHED=
+keywords and the string "states are".
+You can also use single-quotes.
+: START|FINISHED "states are"
+
+The next example excludes =DONE= headlines but requires the tag =fun=.
+: -DONE  :fun
+
+You can exclude text strings, tags, and properties as well by prepending the
+minus sign (=-=).
+
+Last but not least, you can search for headlines with defined properties:
+: TODO  :blocked_by:  :assignee:nobody|none
+This filters headlines having a property =blocked_by= (with any value) and a
+property =assignee= with a value containing =nobody= or =none=.
+
+** Auto-completion for filters
+
+You probably noticed that organice provides suggestions for your filter.
+After space, =-=, =:=, and =|= you can tap on the completion – no need to
+type the tag, property, etc.
+
+** TODO Example with properties							:fun:
+:PROPERTIES:
+:assignee: nobody
+:blocked_by: the others
+:END:
+
 * Agenda
 organice has a basic agenda view that you can access by tapping the calendar button at the bottom of the page.
 

--- a/sample.org
+++ b/sample.org
@@ -213,28 +213,28 @@ Using the filter input, you can search for headlines. Specifically, you can sear
 
 You can simply search for
 
-TODO check out organice|orgmode
+=TODO check out organice|orgmode=
 
-to filter for tasks containing these words. The pipe symbol (=|=) means a logical /OR/. The filter is a smart-case search:
+to filter for tasks containing these words. The pipe symbol (|) is a logical /OR/. The filter is a smart-case search:
 
 - Lower-case words mean that the filter ignores the case.
 - If a word contains upper-case letters, the filter is case-sensitive.
 
-The following example searches for headlines containing =START= or =FINISHED= keywords and the string "states are". You can also use single-quotes.
+The following example searches for headlines containing *START* or *FINISHED* keywords and the string "states are". You can also use single-quotes.
 
-START|FINISHED "states are"
+=START|FINISHED "states are"=
 
-The next example excludes =DONE= headlines but requires the tag =fun=.
+The next example excludes *DONE* headlines but requires the tag *fun*.
 
--DONE  :fun
+=-DONE  :fun=
 
-You can exclude text strings, tags, and properties as well by prepending the minus sign (=-=).
+You can exclude text strings, tags, and properties as well by prepending the minus sign (-).
 
 Last but not least, you can search for headlines with defined properties:
 
-TODO  :blocked_by:  :assignee:nobody|none
+=TODO :blocked_by:  :assignee:nobody|none=
 
-This filters headlines having a property =blocked_by= (with any value) and a property =assignee= with a value containing =nobody= or =none=.
+This filters headlines having a property *blocked_by* (with any value) and a property *assignee* with a value containing =nobody= or =none=.
 
 ** Auto-completion for filters
 

--- a/src/components/CaptureTemplatesEditor/index.js
+++ b/src/components/CaptureTemplatesEditor/index.js
@@ -86,7 +86,7 @@ const CaptureTemplatesEditor = ({ captureTemplates, syncBackendType, capture }) 
 
 const mapStateToProps = (state, props) => {
   return {
-    captureTemplates: state.capture.get('captureTemplates', new List()),
+    captureTemplates: state.capture.get('captureTemplates', List()),
     syncBackendType: state.syncBackend.get('client').type,
   };
 };

--- a/src/components/OrgFile/OrgFile.integration.test.js
+++ b/src/components/OrgFile/OrgFile.integration.test.js
@@ -56,14 +56,14 @@ Some description content
   let store;
 
   beforeEach(() => {
-    let capture = new Map();
+    let capture = Map();
     capture = capture.set('captureTemplates', []);
     store = createStore(
       rootReducer,
       {
         org: {
           past: [],
-          present: new Map(),
+          present: Map(),
           future: [],
         },
         syncBackend: Map({

--- a/src/components/OrgFile/components/ActionDrawer/index.js
+++ b/src/components/OrgFile/components/ActionDrawer/index.js
@@ -322,7 +322,7 @@ const mapStateToProps = (state, props) => {
     isDirty: state.org.present.get('isDirty'),
     isFocusedHeaderActive: !!state.org.present.get('focusedHeaderId'),
     selectedTableCellId: state.org.present.get('selectedTableCellId'),
-    captureTemplates: state.capture.get('captureTemplates', new List()),
+    captureTemplates: state.capture.get('captureTemplates', List()),
     path: state.org.present.get('path'),
     isLoading: state.base.get('isLoading'),
   };

--- a/src/components/OrgFile/components/AttributedString/stylesheet.css
+++ b/src/components/OrgFile/components/AttributedString/stylesheet.css
@@ -1,16 +1,19 @@
+@import '../../../../colors.css';
+
 .attributed-string__cookie-part {
   font-weight: bold;
-  color: red;
+  color: var(--red);
 }
 
 .attributed-string__cookie-part--complete {
-  color: green;
+  color: var(--green);
 }
 
-.attributed-string__inline-markup--inline-code {
+.attributed-string__inline-markup--inline-code,
+.attributed-string__inline-markup--verbatim {
   color: black;
-  background-color: #eaeaea;
-  border: 1px solid gray;
+  background-color: var(--base2);
+  border: 1px solid var(--base1);
   padding: 2px;
 }
 

--- a/src/lib/headline_filter.unit.test.js
+++ b/src/lib/headline_filter.unit.test.js
@@ -30,119 +30,121 @@ describe('Match function for headline filter', () => {
   const headers = parsedFile.get('headers');
   const header = headers.get(0);
 
+  const expectMatch = filterExpr => expect(isMatch(filterExpr)(header));
+
   describe('Tests for tag matching', () => {
     test('Matches if no filter is given', () => {
       const filterExpr = [];
-      expect(isMatch(filterExpr)(header)).toBe(true);
+      expectMatch(filterExpr).toBe(true);
     });
     test('Matches single tag', () => {
       const filterExpr = gtag('spec_tag');
-      expect(isMatch(filterExpr)(header)).toBe(true);
+      expectMatch(filterExpr).toBe(true);
     });
     test('Not matches wrong tag', () => {
       const filterExpr = gtag('non-existing-tag');
-      expect(isMatch(filterExpr)(header)).toBe(false);
+      expectMatch(filterExpr).toBe(false);
     });
     test('Only matches exact tag names', () => {
       const filterExpr = gtag('spec_');
-      expect(isMatch(filterExpr)(header)).toBe(false);
+      expectMatch(filterExpr).toBe(false);
     });
     test('Only matches if all tags are matched (AND)', () => {
       const filterExpr = gtags(['tag2', 'spec_tag']);
-      expect(isMatch(filterExpr)(header)).toBe(true);
+      expectMatch(filterExpr).toBe(true);
     });
     test('Match tag1 OR tag2', () => {
       const filterExpr = gtagsOr([['nonexisting', 'spec_tag']]);
-      expect(isMatch(filterExpr)(header)).toBe(true);
+      expectMatch(filterExpr).toBe(true);
     });
     test('Match (tag1 OR tag2) AND (tag3 OR tag4)', () => {
       const filterExpr = gtagsOr([['nonexisting', 'spec_tag'], ['tag2', 'nonexisting2']]);
-      expect(isMatch(filterExpr)(header)).toBe(true);
+      expectMatch(filterExpr).toBe(true);
     });
   });
 
   describe('Tests for case-sensitive matching in headline text', () => {
     test('Match TODO', () => {
       const filterExpr = gcs('TODO');
-      expect(isMatch(filterExpr)(header)).toBe(true);
+      expectMatch(filterExpr).toBe(true);
     });
     test('Match for substring of TODO', () => {
       const filterExpr = gcs('TOD');
-      expect(isMatch(filterExpr)(header)).toBe(true);
+      expectMatch(filterExpr).toBe(true);
     });
     test('No match for wrongly spelled TODO', () => {
       const filterExpr = gcs('TIDI');
-      expect(isMatch(filterExpr)(header)).toBe(false);
+      expectMatch(filterExpr).toBe(false);
     });
     test('Match for two substrings with AND', () => {
       const filterExpr = gcss(['TODO', 'Spec']);
-      expect(isMatch(filterExpr)(header)).toBe(true);
+      expectMatch(filterExpr).toBe(true);
     });
     test('Match for two substrings with AND, one with OR', () => {
       const filterExpr = gcssOr([['TODO', 'FIXME'], ['Spec']]);
-      expect(isMatch(filterExpr)(header)).toBe(true);
+      expectMatch(filterExpr).toBe(true);
     });
     test('Not match (misspelled) for two substrings with AND, one with OR', () => {
       const filterExpr = gcssOr([['TIDI', 'FIXME'], ['Spec']]);
-      expect(isMatch(filterExpr)(header)).toBe(false);
+      expectMatch(filterExpr).toBe(false);
     });
   });
 
   describe('Tests for ignore-case matching in headline text', () => {
     test('Match a word', () => {
       const filterExpr = gic('spec');
-      expect(isMatch(filterExpr)(header)).toBe(true);
+      expectMatch(filterExpr).toBe(true);
     });
     test('Not match a word', () => {
       const filterExpr = gic('xyz');
-      expect(isMatch(filterExpr)(header)).toBe(false);
+      expectMatch(filterExpr).toBe(false);
     });
   });
 
   describe('Tests for property matching', () => {
     test('Match property with value', () => {
       const filterExpr = gprop('prop1', 'abc');
-      expect(isMatch(filterExpr)(header)).toBe(true);
+      expectMatch(filterExpr).toBe(true);
     });
     test('Match property with value (name/key matches case-insensitive)', () => {
       const filterExpr = gprop('PROP1', 'abc');
-      expect(isMatch(filterExpr)(header)).toBe(true);
+      expectMatch(filterExpr).toBe(true);
     });
     test('Match property with part of value', () => {
       const filterExpr = gprop('prop1', 'b');
-      expect(isMatch(filterExpr)(header)).toBe(true);
+      expectMatch(filterExpr).toBe(true);
     });
     test('Not match property with wrong value', () => {
       const filterExpr = gprop('prop1', 'aaa');
-      expect(isMatch(filterExpr)(header)).toBe(false);
+      expectMatch(filterExpr).toBe(false);
     });
     test('Match two properties (AND)', () => {
       const filterExpr = gprops([['prop1', 'abc'], ['prop2', 'xyz']]);
-      expect(isMatch(filterExpr)(header)).toBe(true);
+      expectMatch(filterExpr).toBe(true);
     });
     test('Match two properties but one is wrong', () => {
       const filterExpr = gprops([['prop1', 'abc'], ['prop2', 'xxx']]);
-      expect(isMatch(filterExpr)(header)).toBe(false);
+      expectMatch(filterExpr).toBe(false);
     });
     test('Match two times the same property with different values (see example org)', () => {
       const filterExpr = gprops([['prop1', 'abc'], ['prop1', 'def']]);
-      expect(isMatch(filterExpr)(header)).toBe(true);
+      expectMatch(filterExpr).toBe(true);
     });
     test('Match property with no value', () => {
       const filterExpr = gprop('prop3', '');
-      expect(isMatch(filterExpr)(header)).toBe(true);
+      expectMatch(filterExpr).toBe(true);
     });
     test('Not match property with no value', () => {
       const filterExpr = gprop('prop3', 'xxx');
-      expect(isMatch(filterExpr)(header)).toBe(false);
+      expectMatch(filterExpr).toBe(false);
     });
     test('Match property without providing a value', () => {
       const filterExpr = gprop('prop1', '');
-      expect(isMatch(filterExpr)(header)).toBe(true);
+      expectMatch(filterExpr).toBe(true);
     });
     test('Match property with either value (OR)', () => {
       const filterExpr = gpropsOr([['prop1', ['aaa', 'abc']]]);
-      expect(isMatch(filterExpr)(header)).toBe(true);
+      expectMatch(filterExpr).toBe(true);
     });
   });
 
@@ -155,55 +157,55 @@ describe('Match function for headline filter', () => {
     test('Not match text when using exclude filter #1', () => {
       let filterExpr = gic('header');
       filterExpr = makeExclude(filterExpr);
-      expect(isMatch(filterExpr)(header)).toBe(false);
+      expectMatch(filterExpr).toBe(false);
     });
     test('Not match text when using exclude filter #2', () => {
       let filterExpr = gcs('Spec');
       filterExpr = makeExclude(filterExpr);
-      expect(isMatch(filterExpr)(header)).toBe(false);
+      expectMatch(filterExpr).toBe(false);
     });
     test('Not match tag when using exclude filter', () => {
       let filterExpr = gtag('tag2');
       filterExpr = makeExclude(filterExpr);
-      expect(isMatch(filterExpr)(header)).toBe(false);
+      expectMatch(filterExpr).toBe(false);
     });
     test('Not match property when using exclude filter', () => {
       let filterExpr = gprop('prop1', 'abc');
       filterExpr = makeExclude(filterExpr);
-      expect(isMatch(filterExpr)(header)).toBe(false);
+      expectMatch(filterExpr).toBe(false);
     });
     test('Match property when using exclude filter with non-matching value', () => {
       let filterExpr = gprop('prop1', 'xxxxx');
       filterExpr = makeExclude(filterExpr);
-      expect(isMatch(filterExpr)(header)).toBe(true);
+      expectMatch(filterExpr).toBe(true);
     });
     test('Not match property when using exclude filter on empty property', () => {
       let filterExpr = gprop('prop3', '');
       filterExpr = makeExclude(filterExpr);
-      expect(isMatch(filterExpr)(header)).toBe(false);
+      expectMatch(filterExpr).toBe(false);
     });
   });
 
   describe('Tests for combined matching', () => {
     test('Empty filter matches everything', () => {
       const filterExpr = [];
-      expect(isMatch(filterExpr)(header)).toBe(true);
+      expectMatch(filterExpr).toBe(true);
     });
     test('Match tag and TODO', () => {
       const filterExpr = gtag('spec_tag').concat(gcs('TODO'));
-      expect(isMatch(filterExpr)(header)).toBe(true);
+      expectMatch(filterExpr).toBe(true);
     });
     test('Not match misspelled tag and correct TODO', () => {
       const filterExpr = gtag('spec_').concat(gcs('TODO'));
-      expect(isMatch(filterExpr)(header)).toBe(false);
+      expectMatch(filterExpr).toBe(false);
     });
     test('Match tag, TODO, and ignore-case', () => {
       const filterExpr = gtag('spec_tag').concat(gcs('TODO'), gic('spec'));
-      expect(isMatch(filterExpr)(header)).toBe(true);
+      expectMatch(filterExpr).toBe(true);
     });
     test('Match tag, TODO, ignore-case, and property', () => {
       const filterExpr = gtag('spec_tag').concat(gcs('TODO'), gic('spec'), gprop('prop1', 'def'));
-      expect(isMatch(filterExpr)(header)).toBe(true);
+      expectMatch(filterExpr).toBe(true);
     });
   });
 });

--- a/src/lib/org_utils.js
+++ b/src/lib/org_utils.js
@@ -500,7 +500,7 @@ export const newEmptyTableRowLikeRows = rows =>
       contents.map(cell =>
         cell
           .set('id', generateId())
-          .set('contents', new List())
+          .set('contents', List())
           .set('rawContents', '')
       )
     );

--- a/src/lib/parse_org.js
+++ b/src/lib/parse_org.js
@@ -707,12 +707,12 @@ export const newHeaderFromText = (rawText, todoKeywordSets) => {
 };
 
 export const parseOrg = fileContents => {
-  let headers = new List();
+  let headers = List();
   const lines = fileContents.split('\n');
 
-  let todoKeywordSets = new List();
-  let fileConfigLines = new List();
-  let linesBeforeHeadings = new List();
+  let todoKeywordSets = List();
+  let fileConfigLines = List();
+  let linesBeforeHeadings = List();
 
   lines.forEach(line => {
     // A header has to start with at least one consecutive asterisk

--- a/src/reducers/base.js
+++ b/src/reducers/base.js
@@ -40,7 +40,7 @@ const setLastViewedFile = (state, action) =>
 
 const setCustomKeybinding = (state, action) => {
   if (!state.get('customKeybindings')) {
-    state = state.set('customKeybindings', new Map());
+    state = state.set('customKeybindings', Map());
   }
 
   return state.setIn(['customKeybindings', action.keybindingName], action.keybinding);
@@ -77,7 +77,7 @@ const closePopup = state => state.set('activePopup', null);
 
 const setIsLoading = (state, action) => state.set('isLoading', action.isLoading);
 
-export default (state = new Map(), action) => {
+export default (state = Map(), action) => {
   switch (action.type) {
     case 'SET_LOADING_MESSAGE':
       return setLoadingMessage(state, action);

--- a/src/reducers/capture.js
+++ b/src/reducers/capture.js
@@ -8,7 +8,7 @@ const indexOfTemplateWithId = (templates, templateId) =>
 
 const addNewEmptyCaptureTemplate = state => {
   if (!state.get('captureTemplates')) {
-    state = state.set('captureTemplates', new List());
+    state = state.set('captureTemplates', List());
   }
 
   return state.update('captureTemplates', templates =>
@@ -85,7 +85,7 @@ const reorderCaptureTemplate = (state, action) =>
     templates.splice(action.fromIndex, 1).splice(action.toIndex, 0, templates.get(action.fromIndex))
   );
 
-export default (state = new Map(), action) => {
+export default (state = Map(), action) => {
   switch (action.type) {
     case 'ADD_NEW_EMPTY_CAPTURE_TEMPLATE':
       return addNewEmptyCaptureTemplate(state, action);

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -884,7 +884,7 @@ export const updateLogEntryTime = (state, action) => {
 
 const setOrgFileErrorMessage = (state, action) => state.set('orgFileErrorMessage', action.message);
 
-export default (state = new Map(), action) => {
+export default (state = Map(), action) => {
   if (action.dirtying) {
     state = state.set('isDirty', true);
   }

--- a/src/reducers/sync_backend.js
+++ b/src/reducers/sync_backend.js
@@ -21,7 +21,7 @@ const setIsLoadingMoreDirectoryListing = (state, action) =>
     )
     .setIn(['currentFileBrowserDirectoryListing', 'isLoadingMore'], action.isLoadingMore);
 
-export default (state = new Map(), action) => {
+export default (state = Map(), action) => {
   switch (action.type) {
     case 'SIGN_OUT':
       return signOut(state, action);

--- a/src/util/settings_persister.js
+++ b/src/util/settings_persister.js
@@ -110,7 +110,7 @@ export const persistableFields = [
     name: 'captureTemplates',
     type: 'json',
     shouldStoreInConfig: true,
-    default: new List(),
+    default: List(),
   },
 ];
 
@@ -202,7 +202,7 @@ export const readInitialState = () => {
       value = value === 'true';
     } else if (field.type === 'json') {
       if (!value) {
-        value = field.default || new Map();
+        value = field.default || Map();
       } else {
         value = fromJS(JSON.parse(value));
       }


### PR DESCRIPTION
This should close #182: Refactor and clean-up after the search filter PR.

- [ ] On invalid filter syntax, all items are displayed. Instead, the current view should not be changed.
- [ ] Having unpushed changes, the browser pops up an dialog, asking to continue (see comment below). Create GIF and separate issue if not easily resolvable.
- [x] Add documentation for filter/search feature to sample.org.


...