### PR TITLE
Bugfix: Docker build with bash scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,17 +51,17 @@ jobs:
 
       - run: yarn test
 
-  # push-image:
-  #   machine: true
-  #   steps:
-  #     - checkout
-  #     # Build docker image and push it to DockerHub
-  #     - run: docker build --rm=false -t ${DOCKER_HUB_USR}/organice:${CIRCLE_BUILD_NUM} .
-  #     - run: docker login --username ${DOCKER_HUB_USR} --password ${DOCKER_HUB_PWD}
-  #     - run: docker push ${DOCKER_HUB_USR}/organice:${CIRCLE_BUILD_NUM}
-  #     # Re-assign latest tag to current build
-  #     - run: docker tag ${DOCKER_HUB_USR}/organice:${CIRCLE_BUILD_NUM} ${DOCKER_HUB_USR}/organice:latest
-  #     - run: docker push ${DOCKER_HUB_USR}/organice:latest
+  push-image:
+    machine: true
+    steps:
+      - checkout
+      # Build docker image and push it to DockerHub
+      - run: docker build --rm=false -t ${DOCKER_HUB_USR}/organice:${CIRCLE_BUILD_NUM} .
+      - run: docker login --username ${DOCKER_HUB_USR} --password ${DOCKER_HUB_PWD}
+      - run: docker push ${DOCKER_HUB_USR}/organice:${CIRCLE_BUILD_NUM}
+      # Re-assign latest tag to current build
+      - run: docker tag ${DOCKER_HUB_USR}/organice:${CIRCLE_BUILD_NUM} ${DOCKER_HUB_USR}/organice:latest
+      - run: docker push ${DOCKER_HUB_USR}/organice:latest
 
 workflows:
   version: 2
@@ -74,9 +74,9 @@ workflows:
           filters:
             branches:
               only: master
-      # - push-image:
-      #     requires:
-      #       - build  # because of tests
-      #     filters:
-      #       branches:
-      #         only: master
+      - push-image:
+          requires:
+            - build  # because of tests
+          filters:
+            branches:
+              only: master

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,0 @@
-node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM node:12.13-alpine3.9
 # https://github.com/gliderlabs/docker-alpine/issues/307#issuecomment-427465925
 RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/http\:\/\/mirror.clarkson.edu/g' /etc/apk/repositories
 
-RUN apk add --no-cache yarn
+RUN apk add --no-cache bash yarn
 
 COPY . /opt/organice
 WORKDIR /opt/organice


### PR DESCRIPTION
This PR fixes issue #183. It installs `bash` in the docker container, so that the newly introduced bash scripts work without an error. It reverts also 012f00f, but keeps the `.dockerignore` file.