### PR TITLE
fix: Capture template styling for iOS 13.3+

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -10,6 +10,12 @@ All notable changes to this project will be documented in this file.
     - Trim whitespace for entered or updated headlines
       - Thank you [[https://github.com/schoettl][@schoettl]] for the [[https://github.com/200ok-ch/organice/pull/177][PR]] 🙏
 
+*** Fixed
+    - Capture templates in iOS 13.3 are positioned properly
+      - iOS 13 introduced a styling regression when setting focus
+        without user interaction. iOS 13.3 reverts to the way other
+        browsers do it.
+
 ** <2019-12-31 Tue>
 
 *** Added

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": "12.13.1"
   },
   "dependencies": {
-    "bowser": "^2.6.1",
+    "bowser": "^2.7.0",
     "classnames": "^2.2.6",
     "date-fns": "^2.6.0",
     "dotenv": "^8.2.0",

--- a/src/components/OrgFile/components/CaptureModal/index.js
+++ b/src/components/OrgFile/components/CaptureModal/index.js
@@ -1,6 +1,6 @@
 import React, { Fragment, useState, useEffect, useRef, useMemo } from 'react';
 import {
-  isNewestMobileSafari,
+  isMobileSafari13,
   isRunningAsPWA,
   isInLandscapeMode,
   isIphoneX,
@@ -30,18 +30,19 @@ export default ({ template, onCapture, headers, onClose }) => {
   const [textareaValue, setTextareaValue] = useState(substitutedTemplate);
   const [shouldPrepend, setShouldPrepend] = useState(template.get('shouldPrepend'));
 
-  /** INFO: Mobile Safari does _not_ like it when the focus is set
-   * without an explicit user interaction. This is the case in
-   * organice, because the user interaction is on a button which in
-   * turn opens a textarea which should have the focus. It will open
-   * the software keyboard, but the capture template will stay on the
-   * bottom of the view, so it will be hidden by the keyboard. The
-   * user would have to manually scroll down. On iOS 12, it worked
-   * without this workaround. */
+  /** INFO: Some versions of Mobile Safari do _not_ like it when the
+  focus is set * without an explicit user interaction. This is the
+  case in * organice, because the user interaction is on a button
+  which in * turn opens a textarea which should have the focus. It
+  will open * the software keyboard, but the capture template will
+  stay on the * bottom of the view, so it will be hidden by the
+  keyboard. The * user would have to manually scroll down. On iOS 12,
+  it worked * without this workaround. Starting with iOS 13.3, the
+  workaround isn't needed, anymore. */
   const getMinHeight = () => {
     // Only Mobile Safari needs the shenannigans for moving the input
     // above the software keyboard.
-    if (isNewestMobileSafari) {
+    if (isMobileSafari13) {
       if (isRunningAsPWA) {
         if (isInLandscapeMode()) {
           return '9em';
@@ -132,7 +133,7 @@ export default ({ template, onCapture, headers, onClose }) => {
           </div>
           {/* Add padding to move the above textarea above the fold.
           More documentation, see getMinHeight(). */}
-          {isNewestMobileSafari && <div style={{ minHeight: getMinHeight() }} />}
+          {isMobileSafari13 && <div style={{ minHeight: getMinHeight() }} />}
         </Fragment>
       ) : (
         <div className="capture-modal-error-message">

--- a/src/components/OrgFile/components/CaptureModal/index.js
+++ b/src/components/OrgFile/components/CaptureModal/index.js
@@ -31,14 +31,14 @@ export default ({ template, onCapture, headers, onClose }) => {
   const [shouldPrepend, setShouldPrepend] = useState(template.get('shouldPrepend'));
 
   /** INFO: Some versions of Mobile Safari do _not_ like it when the
-  focus is set * without an explicit user interaction. This is the
-  case in * organice, because the user interaction is on a button
-  which in * turn opens a textarea which should have the focus. It
-  will open * the software keyboard, but the capture template will
-  stay on the * bottom of the view, so it will be hidden by the
-  keyboard. The * user would have to manually scroll down. On iOS 12,
-  it worked * without this workaround. Starting with iOS 13.3, the
-  workaround isn't needed, anymore. */
+  focus is set without an explicit user interaction. This is the case
+  in organice, because the user interaction is on a button which in
+  turn opens a textarea which should have the focus. It will open the
+  software keyboard, but the capture template will stay on the bottom
+  of the view, so it will be hidden by the keyboard. The user would
+  have to manually scroll down. On iOS 12, it worked without this
+  workaround. Starting with iOS 13.3, the workaround isn't needed,
+  anymore. */
   const getMinHeight = () => {
     // Only Mobile Safari needs the shenannigans for moving the input
     // above the software keyboard.

--- a/src/lib/browser_utils.js
+++ b/src/lib/browser_utils.js
@@ -1,12 +1,14 @@
 import Bowser from 'bowser';
 
-/** Is the browser Mobile Safari with iOS version of at least 13 */
-export const isNewestMobileSafari = (() => {
+/** Is the browser Mobile Safari with iOS version of at least 13, but
+less than 13.3 */
+export const isMobileSafari13 = (() => {
   const browser = Bowser.getParser(window.navigator.userAgent);
 
   return browser.satisfies({
     mobile: {
       safari: '>=13',
+      safari: '<13.0.4',
     },
   });
 })();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3092,10 +3092,10 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
-bowser@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.6.1.tgz#196599588af6f0413449c79ab3bf7a5a1bb3384f"
-  integrity sha512-hySGUuLhi0KetfxPZpuJOsjM0kRvCiCgPBygBkzGzJNsq/nbJmaO8QJc6xlWfeFFnMvtd/LeKkhDJGVrmVobUA==
+bowser@^2.7.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.8.1.tgz#35b74165e17b80ba8af6aa4736c2861b001fc09e"
+  integrity sha512-FxxltGKqMHkVa3KtpA+kdnxH0caHPDewccyrK3vW1bsMw6Zco4vRPmMunowX0pXlDZqhxkKSpToADQI2Sk4OeQ==
 
 brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
Some versions of Mobile Safari do _not_ like it when the
  focus is set without an explicit user interaction. This is the case
  in organice, because the user interaction is on a button which in
  turn opens a textarea which should have the focus. It will open the
  software keyboard, but the capture template will stay on the bottom
  of the view, so it will be hidden by the keyboard. The user would
  have to manually scroll down. On iOS 12, it worked without this
  workaround. Starting with iOS 13.3, the workaround isn't needed,
  anymore.