### PR TITLE
Revert "Move HeaderActionDrawer before headline"

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -16,6 +16,12 @@ All notable changes to this project will be documented in this file.
         without user interaction. iOS 13.3 reverts to the way other
         browsers do it.
 
+*** Changed
+    - Revert "Move HeaderActionDrawer before headline"
+      - As per #188, the changes introduced in #100 didn't fare well
+        with the community. Hence, as a first step to improve UX,
+        we're reverting to the previous state.
+
 ** <2019-12-31 Tue>
 
 *** Added

--- a/src/components/OrgFile/components/Header/index.js
+++ b/src/components/OrgFile/components/Header/index.js
@@ -458,6 +458,17 @@ ${header.get('rawDescription')}
                 }}
               </Motion>
 
+              <div style={{ marginLeft: -16, color }} className="header__bullet">
+                {bulletStyle === 'Fancy' ? '●' : '*'}
+              </div>
+              <TitleLine
+                header={header}
+                color={color}
+                hasContent={hasContent}
+                isSelected={isSelected}
+                shouldDisableActions={shouldDisableActions}
+              />
+
               <Collapse
                 isOpened={isSelected && !shouldDisableActions}
                 springConfig={{ stiffness: 300 }}
@@ -478,17 +489,6 @@ ${header.get('rawDescription')}
                   onShareHeader={this.handleShareHeaderClick}
                 />
               </Collapse>
-
-              <div style={{ marginLeft: -16, color }} className="header__bullet">
-                {bulletStyle === 'Fancy' ? '●' : '*'}
-              </div>
-              <TitleLine
-                header={header}
-                color={color}
-                hasContent={hasContent}
-                isSelected={isSelected}
-                shouldDisableActions={shouldDisableActions}
-              />
 
               <HeaderContent header={header} shouldDisableActions={shouldDisableActions} />
             </div>


### PR DESCRIPTION
As per https://github.com/200ok-ch/organice/issues/188, the changes introduced in https://github.com/200ok-ch/organice/issues/100 didn't fare well with the community. Hence, as a first step to improve UX, we're reverting to the previous state.