### PR TITLE
Make node setup easier for dev environments

### DIFF
--- a/README.org
+++ b/README.org
@@ -172,6 +172,21 @@ organice is built with [[https://reactjs.org/][React]] and [[https://redux.js.or
 [[https://github.com/facebook/create-react-app][Create React App]]. The tests are written with [[https://testing-library.com/docs/react-testing-library/intro][React Testing Library]].
 The internal data structures are written as immutable persistent
 data collections with the [[https://github.com/immutable-js/immutable-js][Immutable]] library.
+*** Prerequisites
+
+You will need a version of the Node.js engine installed which fulfils
+the requirement stated in =package.json=.  If you don't already have
+this installed, it is recommended to install it via [[https://nvm.sh/][nvm]].  This
+repository already contains an =.nvmrc= file, so once you have nvm
+installed, the following commands should be sufficient:
+
+#+BEGIN_SRC shell
+nvm install
+nvm use
+#+END_SRC
+
+It's worth noting that the =Dockerfile= will also specify a particular
+Node.js version.
 
 *** Setup
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "private": true,
   "engines": {
-    "node": "12.13.1"
+    "node": "^12.13.1"
   },
   "dependencies": {
     "bowser": "^2.6.1",


### PR DESCRIPTION
Slightly relax the requirements on a particular node engine version, and also document some helpful tips on how to install the correct version.