### PR TITLE
Place cursor after the TODO keyword when creating a new header

### DIFF
--- a/src/components/OrgFile/components/TitleLine/index.js
+++ b/src/components/OrgFile/components/TitleLine/index.js
@@ -138,9 +138,13 @@ class TitleLine extends PureComponent {
   }
 
   handleTextareaFocus(event) {
-    const text = event.target.value;
-    event.target.selectionStart = text.length;
-    event.target.selectionEnd = text.length;
+    const { header } = this.props;
+    const rawTitle = header.getIn(['titleLine', 'rawTitle']);
+    if (rawTitle === '') {
+      const text = event.target.value;
+      event.target.selectionStart = text.length;
+      event.target.selectionEnd = text.length;
+    }
   }
 
   handleTitleChange(event) {

--- a/src/components/OrgFile/components/TitleLine/index.js
+++ b/src/components/OrgFile/components/TitleLine/index.js
@@ -26,6 +26,7 @@ class TitleLine extends PureComponent {
       'handleTextareaRef',
       'handleTitleClick',
       'handleTextareaBlur',
+      'handleTextareaFocus',
       'handleTitleChange',
       'handleTitleFieldClick',
       'handleTodoClick',
@@ -136,6 +137,12 @@ class TitleLine extends PureComponent {
     }, 0);
   }
 
+  handleTextareaFocus(event) {
+    const text = event.target.value;
+    event.target.selectionStart = text.length;
+    event.target.selectionEnd = text.length;
+  }
+
   handleTitleChange(event) {
     // If the last character typed was a newline at the end, exit edit mode.
     const newTitle = event.target.value;
@@ -235,6 +242,7 @@ class TitleLine extends PureComponent {
               ref={this.handleTextareaRef}
               value={this.state.titleValue}
               onBlur={this.handleTextareaBlur}
+              onFocus={this.handleTextareaFocus}
               onChange={this.handleTitleChange}
               onClick={this.handleTitleFieldClick}
             />


### PR DESCRIPTION
This PR supersedes #168. As discussed there and in the linked comment, placing the cursor at the end of the input is problematic. But not for newly added headers, that only contain the TODO keyword.

PR #168 can be closed without merge.
