### PR TITLE
Fix docker run line in README

### DIFF
--- a/README.org
+++ b/README.org
@@ -323,7 +323,7 @@ docker-compose -f docker-compose-dev.yaml up
 If =docker-compose= is not installed the command looks like this:
 
 #+BEGIN_SRC shell
-docker run -p 5000:5000 -t organice twohundredok/organice:latest
+docker run -p 5000:5000 --name organice twohundredok/organice:latest
 #+END_SRC
 
 Again the webserver is listening on port 5000 and can be reached here:


### PR DESCRIPTION
`docker run -p 5000:5000 -t organice twohundredok/organice:latest` means running the image named organice which does not exist.

Thanks for organice!