### PR TITLE
Introduce Search next to TaskList

### DIFF
--- a/CONTRIBUTING.org
+++ b/CONTRIBUTING.org
@@ -44,7 +44,7 @@ These are the steps we take to ensure a high quality in the backlog:
    behavior, we ask a question or link to the documentation. We also
    add a 'question' label to the issue. If the issue creator does not
    respond to the question within 14 days, we close the issue. If she
-   does chose to respond at some point, she can re-open the issue.
+   does choose to respond at some point, she can re-open the issue.
 
 *** Development collaboration
 

--- a/src/actions/org.js
+++ b/src/actions/org.js
@@ -483,8 +483,3 @@ export const setSearchFilterInformation = (searchFilter, cursorPosition) => ({
   searchFilter,
   cursorPosition,
 });
-
-export const setSearchAllHeadersFlag = searchAllHeaders => ({
-  type: 'SET_SEARCH_ALL_HEADERS_FLAG',
-  searchAllHeaders,
-});

--- a/src/components/OrgFile/OrgFile.integration.test.js
+++ b/src/components/OrgFile/OrgFile.integration.test.js
@@ -298,16 +298,45 @@ Some description content
         });
       });
 
+      describe('Search', () => {
+        test('renders Search for an Org file', () => {
+          expect(queryByText('Search')).toBeFalsy();
+          expect(queryByText('A todo item with schedule and deadline')).toBeFalsy();
+
+          fireEvent.click(getByTitle('Show search'));
+          const drawerElem = getByTestId('drawer');
+          expect(drawerElem).toHaveTextContent('Search');
+          expect(drawerElem).toHaveTextContent('A todo item with schedule and deadline');
+        });
+
+        test('searches in all headers', () => {
+          fireEvent.click(getByTitle('Show search'));
+          const drawerElem = getByTestId('drawer');
+          const input = getByPlaceholderText(
+            'e.g. -DONE doc|man :simple|easy :assignee:nobody|none'
+          );
+
+          // All kinds of headers are visible
+          expect(drawerElem).toHaveTextContent('A todo item with schedule and deadline');
+          expect(drawerElem).toHaveTextContent('A header with tags');
+          expect(drawerElem).toHaveTextContent('Another top level header');
+
+          // Filter down to headers with tag :tag1:
+          fireEvent.change(input, { target: { value: ':tag1' } });
+
+          expect(drawerElem).toHaveTextContent('A header with tags');
+          expect(drawerElem).not.toHaveTextContent('Another top level header');
+        });
+      });
+
       describe('TaskList', () => {
         test('renders TaskList for an Org file', () => {
           expect(queryByText('Task list')).toBeFalsy();
-          expect(queryByText('Search all headlines')).toBeFalsy();
           expect(queryByText('A todo item with schedule and deadline')).toBeFalsy();
 
           fireEvent.click(getByTitle('Show task list'));
           const drawerElem = getByTestId('drawer');
           expect(drawerElem).toHaveTextContent('Task list');
-          expect(drawerElem).toHaveTextContent('Search all headlines');
           expect(drawerElem).toHaveTextContent('A todo item with schedule and deadline');
         });
 
@@ -334,19 +363,6 @@ Some description content
             'e.g. -DONE doc|man :simple|easy :assignee:nobody|none'
           );
 
-          expect(drawerElem).not.toHaveTextContent('Another top level header');
-
-          // Enable searching for all headers
-          fireEvent.click(getByTestId('task-list__checkbox'));
-
-          // All kinds of headers are visible
-          expect(drawerElem).toHaveTextContent('A header with tags');
-          expect(drawerElem).toHaveTextContent('Another top level header');
-
-          // Filter down to headers with tag :tag1:
-          fireEvent.change(input, { target: { value: ':tag1' } });
-
-          expect(drawerElem).toHaveTextContent('A header with tags');
           expect(drawerElem).not.toHaveTextContent('Another top level header');
         });
       });

--- a/src/components/OrgFile/__snapshots__/OrgFile.integration.test.js.snap
+++ b/src/components/OrgFile/__snapshots__/OrgFile.integration.test.js.snap
@@ -416,11 +416,25 @@ exports[`Render all views Org Functionality Renders everything starting from an 
           style="opacity: 1;"
           title="Show agenda"
         />
-        <button
-          class="btn btn--circle action-drawer__btn fas fa-lg fa-tasks"
-          style="opacity: 1;"
-          title="Show task list"
-        />
+        <div
+          class="action-drawer__capture-buttons-container"
+        >
+          <button
+            class="btn btn--circle action-drawer__btn fas fa-lg fa-search-plus"
+            style="opacity: 1; position: relative; z-index: 1;"
+            title="Show Search / Task List"
+          />
+          <button
+            class="btn btn--circle action-drawer__btn fas fa-lg fa-search"
+            style="position: absolute; z-index: 0; left: 0px; opacity: 1; box-shadow: none; bottom: 0px;"
+            title="Show search"
+          />
+          <button
+            class="btn btn--circle action-drawer__btn fas fa-lg fa-tasks"
+            style="position: absolute; z-index: 0; left: 0px; opacity: 1; box-shadow: none; bottom: 0px;"
+            title="Show task list"
+          />
+        </div>
         <div
           class="action-drawer__capture-buttons-container"
         >

--- a/src/components/OrgFile/__snapshots__/OrgFile.integration.test.js.snap
+++ b/src/components/OrgFile/__snapshots__/OrgFile.integration.test.js.snap
@@ -412,7 +412,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
           />
         </div>
         <button
-          class="btn btn--circle action-drawer__btn fas fa-lg fa-calendar-alt"
+          class="btn btn--circle action-drawer__btn fas fa-lg fa-calendar-check"
           style="opacity: 1;"
           title="Show agenda"
         />
@@ -420,7 +420,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
           class="action-drawer__capture-buttons-container"
         >
           <button
-            class="btn btn--circle action-drawer__btn fas fa-lg fa-search-plus"
+            class="btn btn--circle action-drawer__btn fas fa-lg fa-search"
             style="opacity: 1; position: relative; z-index: 1;"
             title="Show Search / Task List"
           />

--- a/src/components/OrgFile/components/ActionDrawer/index.js
+++ b/src/components/OrgFile/components/ActionDrawer/index.js
@@ -374,7 +374,7 @@ const ActionDrawer = ({
           {renderMovementButtons()}
 
           <ActionButton
-            iconName="calendar-alt"
+            iconName="calendar-check"
             shouldSpinSubIcon={isLoading}
             isDisabled={false}
             onClick={handleAgendaClick}

--- a/src/components/OrgFile/components/ActionDrawer/index.js
+++ b/src/components/OrgFile/components/ActionDrawer/index.js
@@ -185,7 +185,7 @@ const ActionDrawer = ({
         {style => (
           <div className="action-drawer__capture-buttons-container">
             <ActionButton
-              iconName={isDisplayingSearchButtons ? 'times' : 'search'}
+              iconName={isDisplayingSearchButtons ? 'times' : 'search-plus'}
               isDisabled={false}
               onClick={handleMainSearchButtonClick}
               style={mainButtonStyle}

--- a/src/components/OrgFile/components/ActionDrawer/index.js
+++ b/src/components/OrgFile/components/ActionDrawer/index.js
@@ -185,7 +185,7 @@ const ActionDrawer = ({
         {style => (
           <div className="action-drawer__capture-buttons-container">
             <ActionButton
-              iconName={isDisplayingSearchButtons ? 'times' : 'search-plus'}
+              iconName={isDisplayingSearchButtons ? 'times' : 'search'}
               isDisabled={false}
               onClick={handleMainSearchButtonClick}
               style={mainButtonStyle}

--- a/src/components/OrgFile/components/ActionDrawer/index.js
+++ b/src/components/OrgFile/components/ActionDrawer/index.js
@@ -30,6 +30,7 @@ const ActionDrawer = ({
 }) => {
   const [isDisplayingArrowButtons, setIsDisplayingArrowButtons] = useState(false);
   const [isDisplayingCaptureButtons, setIsDisplayingCaptureButtons] = useState(false);
+  const [isDisplayingSearchButtons, setIsDisplayingSearchButtons] = useState(false);
 
   useEffect(() => {
     document.querySelector('html').style.paddingBottom = '90px';
@@ -89,6 +90,10 @@ const ActionDrawer = ({
 
   const handleMainArrowButtonClick = () => setIsDisplayingArrowButtons(!isDisplayingArrowButtons);
 
+  const handleMainSearchButtonClick = () => {
+    setIsDisplayingSearchButtons(!isDisplayingSearchButtons);
+  };
+
   const handleMainCaptureButtonClick = () => {
     if (!isDisplayingCaptureButtons && getAvailableCaptureTemplates().size === 0) {
       alert(
@@ -107,14 +112,14 @@ const ActionDrawer = ({
       position: 'absolute',
       zIndex: 0,
       left: 0,
-      opacity: isDisplayingArrowButtons ? 0 : 1,
+      opacity: isDisplayingArrowButtons || isDisplayingSearchButtons ? 0 : 1,
     };
     if (!isDisplayingCaptureButtons) {
       baseCaptureButtonStyle.boxShadow = 'none';
     }
 
     const mainButtonStyle = {
-      opacity: isDisplayingArrowButtons ? 0 : 1,
+      opacity: isDisplayingArrowButtons || isDisplayingSearchButtons ? 0 : 1,
       position: 'relative',
       zIndex: 1,
     };
@@ -154,9 +159,65 @@ const ActionDrawer = ({
     );
   };
 
+  const renderSearchButtons = () => {
+    const baseSearchButtonStyle = {
+      position: 'absolute',
+      zIndex: 0,
+      left: 0,
+      opacity: isDisplayingArrowButtons || isDisplayingCaptureButtons ? 0 : 1,
+    };
+    if (!isDisplayingSearchButtons) {
+      baseSearchButtonStyle.boxShadow = 'none';
+    }
+
+    const mainButtonStyle = {
+      opacity: isDisplayingArrowButtons || isDisplayingCaptureButtons ? 0 : 1,
+      position: 'relative',
+      zIndex: 1,
+    };
+
+    const animatedStyle = {
+      bottom: spring(isDisplayingSearchButtons ? 70 : 0, { stiffness: 300 }),
+    };
+
+    return (
+      <Motion style={animatedStyle}>
+        {style => (
+          <div className="action-drawer__capture-buttons-container">
+            <ActionButton
+              iconName={isDisplayingSearchButtons ? 'times' : 'search'}
+              isDisabled={false}
+              onClick={handleMainSearchButtonClick}
+              style={mainButtonStyle}
+              tooltip={
+                isDisplayingSearchButtons ? 'Hide Search / Task List' : 'Show Search / Task List'
+              }
+            />
+
+            <ActionButton
+              iconName="search"
+              isDisabled={false}
+              onClick={handleSearchClick}
+              style={{ ...baseSearchButtonStyle, bottom: style.bottom * 1 }}
+              tooltip="Show search"
+            />
+
+            <ActionButton
+              iconName="tasks"
+              isDisabled={false}
+              onClick={handleTaskListClick}
+              style={{ ...baseSearchButtonStyle, bottom: style.bottom * 2 }}
+              tooltip="Show task list"
+            />
+          </div>
+        )}
+      </Motion>
+    );
+  };
+
   const renderMovementButtons = () => {
     const baseArrowButtonStyle = {
-      opacity: isDisplayingCaptureButtons ? 0 : 1,
+      opacity: isDisplayingCaptureButtons || isDisplayingSearchButtons ? 0 : 1,
     };
     if (!isDisplayingArrowButtons) {
       baseArrowButtonStyle.boxShadow = 'none';
@@ -267,7 +328,7 @@ const ActionDrawer = ({
               additionalClassName="action-drawer__main-arrow-button"
               isDisabled={false}
               onClick={handleMainArrowButtonClick}
-              style={{ opacity: isDisplayingCaptureButtons ? 0 : 1 }}
+              style={{ opacity: isDisplayingCaptureButtons || isDisplayingSearchButtons ? 0 : 1 }}
               tooltip={isDisplayingArrowButtons ? 'Hide movement buttons' : 'Show movement buttons'}
               onRef={mainArrowButton}
             />
@@ -278,7 +339,14 @@ const ActionDrawer = ({
   };
 
   const handleAgendaClick = () => base.activatePopup('agenda');
-  const handleTaskListClick = () => base.activatePopup('task-list');
+  const handleTaskListClick = () => {
+    setIsDisplayingSearchButtons(false);
+    base.activatePopup('task-list');
+  };
+  const handleSearchClick = () => {
+    setIsDisplayingSearchButtons(false);
+    base.activatePopup('search');
+  };
 
   return (
     <div className="action-drawer-container nice-scroll">
@@ -294,7 +362,12 @@ const ActionDrawer = ({
             shouldSpinSubIcon={isLoading}
             isDisabled={shouldDisableSyncButtons}
             onClick={handleSync}
-            style={{ opacity: isDisplayingArrowButtons || isDisplayingCaptureButtons ? 0 : 1 }}
+            style={{
+              opacity:
+                isDisplayingArrowButtons || isDisplayingCaptureButtons || isDisplayingSearchButtons
+                  ? 0
+                  : 1,
+            }}
             tooltip="Sync changes"
           />
 
@@ -305,19 +378,16 @@ const ActionDrawer = ({
             shouldSpinSubIcon={isLoading}
             isDisabled={false}
             onClick={handleAgendaClick}
-            style={{ opacity: isDisplayingArrowButtons || isDisplayingCaptureButtons ? 0 : 1 }}
+            style={{
+              opacity:
+                isDisplayingArrowButtons || isDisplayingCaptureButtons || isDisplayingSearchButtons
+                  ? 0
+                  : 1,
+            }}
             tooltip="Show agenda"
           />
 
-          <ActionButton
-            iconName="tasks"
-            shouldSpinSubIcon={isLoading}
-            isDisabled={false}
-            onClick={handleTaskListClick}
-            style={{ opacity: isDisplayingArrowButtons || isDisplayingCaptureButtons ? 0 : 1 }}
-            tooltip="Show task list"
-          />
-
+          {renderSearchButtons()}
           {renderCaptureButtons()}
         </Fragment>
       )}
@@ -346,7 +416,4 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(ActionDrawer);
+export default connect(mapStateToProps, mapDispatchToProps)(ActionDrawer);

--- a/src/components/OrgFile/components/AgendaModal/index.js
+++ b/src/components/OrgFile/components/AgendaModal/index.js
@@ -24,6 +24,9 @@ import {
 } from 'date-fns';
 import format from 'date-fns/format';
 
+// INFO: SearchModal, AgendaModal and TaskListModal are very similar
+// in structure and partially in logic. When changing one, consider
+// changing all.
 function AgendaModal(props) {
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [timeframeType, setTimeframeType] = useState('Week');

--- a/src/components/OrgFile/components/SearchModal/components/HeaderListView/index.js
+++ b/src/components/OrgFile/components/SearchModal/components/HeaderListView/index.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import './stylesheet.css';
+
+import TitleLine from '../../../TitleLine';
+
+function HeaderListView(props) {
+  function handleHeaderClick(headerId) {
+    return () => props.onHeaderClick(headerId);
+  }
+
+  const { headers } = props;
+
+  return (
+    <div className="agenda-day__container">
+      <div className="agenda-day__headers-container">
+        {headers.map(header => {
+          return (
+            <div key={header.get('id')} className="agenda-day__header-container">
+              <div className="agenda-day__header__header-container">
+                <TitleLine
+                  header={header}
+                  color="black"
+                  hasContent={false}
+                  isSelected={false}
+                  shouldDisableActions
+                  shouldDisableExplicitWidth
+                  onClick={handleHeaderClick(header.get('id'))}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+const mapStateToProps = state => ({
+  // When no filtering has happened, yet (initial state), use all headers.
+  headers:
+    state.org.present.getIn(['search', 'filteredHeaders']) || state.org.present.get('headers'),
+});
+
+const mapDispatchToProps = dispatch => ({});
+
+export default connect(mapStateToProps, mapDispatchToProps)(HeaderListView);

--- a/src/components/OrgFile/components/SearchModal/components/HeaderListView/stylesheet.css
+++ b/src/components/OrgFile/components/SearchModal/components/HeaderListView/stylesheet.css
@@ -1,0 +1,18 @@
+/* Currently, the markup is the same as in the AgendaDay component. Hence */
+/* the CSS rules from there apply. */
+
+
+.task-list__header-planning-type {
+  color: var(--base01);
+  min-width: 8em;
+  margin: 0 5px 0 0;
+  display: inline-block;
+}
+
+.task-list__header-planning-date {
+  display: inline-block;
+}
+
+.task-list__header-planning-date--overdue {
+  color: var(--orange);
+}

--- a/src/components/OrgFile/components/SearchModal/index.js
+++ b/src/components/OrgFile/components/SearchModal/index.js
@@ -5,7 +5,7 @@ import { bindActionCreators } from 'redux';
 import './stylesheet.css';
 
 import classNames from 'classnames';
-import TaskListView from './components/TaskListView';
+import HeaderListView from './components/HeaderListView';
 import Drawer from '../../../UI/Drawer';
 
 import { isMobileBrowser } from '../../../../lib/browser_utils';
@@ -15,7 +15,7 @@ import * as orgActions from '../../../../actions/org';
 // INFO: SearchModal, AgendaModal and TaskListModal are very similar
 // in structure and partially in logic. When changing one, consider
 // changing all.
-function TaskListModal(props) {
+function SearchModal(props) {
   const [dateDisplayType, setdateDisplayType] = useState('absolute');
 
   function handleHeaderClick(headerId) {
@@ -27,21 +27,11 @@ function TaskListModal(props) {
     setdateDisplayType(dateDisplayType === 'absolute' ? 'relative' : 'absolute');
   }
 
-  function handleSearchAllCheckboxChange(event) {
-    props.org.setSearchAllHeadersFlag(event.target.checked);
-  }
-
   function handleFilterChange(event) {
     props.org.setSearchFilterInformation(event.target.value, event.target.selectionStart);
   }
 
-  const {
-    onClose,
-    searchFilter,
-    searchFilterValid,
-    searchFilterSuggestions,
-    searchAllHeaders,
-  } = props;
+  const { onClose, searchFilter, searchFilterValid, searchFilterSuggestions } = props;
 
   // On mobile devices, the Drawer already handles the touch event.
   // Hence, scrolling within the Drawers container does not work with
@@ -56,7 +46,7 @@ function TaskListModal(props) {
 
   return (
     <Drawer onClose={onClose} maxSize={true}>
-      <h2 className="agenda__title">Task list</h2>
+      <h2 className="agenda__title">Search</h2>
 
       <datalist id="task-list__datalist-filter">
         {searchFilterSuggestions.map((string, idx) => (
@@ -75,23 +65,10 @@ function TaskListModal(props) {
           list="task-list__datalist-filter"
           onChange={handleFilterChange}
         />
-        <div className="agenda__tab-container">
-          <input
-            type="checkbox"
-            className="checkbox"
-            checked={searchAllHeaders}
-            id="task-list__checkbox-search-all-headers"
-            data-testid="task-list__checkbox"
-            onChange={handleSearchAllCheckboxChange}
-          />
-          <label className="label-for-checkbox" htmlFor="task-list__checkbox-search-all-headers">
-            Search all headlines
-          </label>
-        </div>
       </div>
 
       <div className="task-list__headers-container" style={taskListViewStyle}>
-        <TaskListView
+        <HeaderListView
           onHeaderClick={handleHeaderClick}
           dateDisplayType={dateDisplayType}
           onToggleDateDisplayType={handleToggleDateDisplayType}
@@ -107,11 +84,10 @@ const mapStateToProps = state => ({
   searchFilter: state.org.present.getIn(['search', 'searchFilter']) || '',
   searchFilterValid: state.org.present.getIn(['search', 'searchFilterValid']),
   searchFilterSuggestions: state.org.present.getIn(['search', 'searchFilterSuggestions']) || [],
-  searchAllHeaders: state.org.present.getIn(['search', 'searchAllHeaders']) || false,
 });
 
 const mapDispatchToProps = dispatch => ({
   org: bindActionCreators(orgActions, dispatch),
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(TaskListModal);
+export default connect(mapStateToProps, mapDispatchToProps)(SearchModal);

--- a/src/components/OrgFile/components/SearchModal/stylesheet.css
+++ b/src/components/OrgFile/components/SearchModal/stylesheet.css
@@ -1,0 +1,22 @@
+@import '../../../../colors.css';
+
+/* Currently, the markup is the same as in the AgendaModal component.
+ * Hence the CSS rules from there apply. */
+
+.task-list__filter-input,
+.task-list__filter-input-invalid {
+  box-sizing: border-box;
+  width: 100%;
+}
+
+.task-list__input-container {
+  flex-shrink: 0;
+  margin-bottom: 2em;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+}
+
+.task-list__filter-input-invalid {
+  border: 2px solid var(--red);
+}

--- a/src/components/OrgFile/components/TaskListModal/components/TaskListView/index.js
+++ b/src/components/OrgFile/components/TaskListModal/components/TaskListView/index.js
@@ -15,17 +15,10 @@ function TaskListView(props) {
     return () => props.onHeaderClick(headerId);
   }
 
-  const {
-    dateDisplayType,
-    onToggleDateDisplayType,
-    headers,
-    searchAllHeaders,
-    todoKeywordSets,
-  } = props;
+  const { dateDisplayType, onToggleDateDisplayType, headers, todoKeywordSets } = props;
 
   const planningItemsAndHeaders = getPlanningItemsAndHeaders({
     headers,
-    searchAllHeaders,
     todoKeywordSets,
   });
 
@@ -90,9 +83,9 @@ function TaskListView(props) {
   // on every update of the headers state when not even looking at the
   // Agenda is certainly more inefficient. Hence, we're doing it on
   // every render.
-  function getPlanningItemsAndHeaders({ headers, searchAllHeaders, todoKeyword }) {
+  function getPlanningItemsAndHeaders({ headers, todoKeyword }) {
     return headers
-      .filter(header => searchAllHeaders || header.getIn(['titleLine', 'todoKeyword']))
+      .filter(header => header.getIn(['titleLine', 'todoKeyword']))
       .map(header => {
         const earliestPlanningItem = header
           .get('planningItems')
@@ -112,7 +105,6 @@ function TaskListView(props) {
 
 const mapStateToProps = state => ({
   todoKeywordSets: state.org.present.get('todoKeywordSets'),
-  searchAllHeaders: state.org.present.getIn(['search', 'searchAllHeaders']),
   // When no filtering has happened, yet (initial state), use all headers.
   headers:
     state.org.present.getIn(['search', 'filteredHeaders']) || state.org.present.get('headers'),

--- a/src/components/OrgFile/components/TaskListModal/index.js
+++ b/src/components/OrgFile/components/TaskListModal/index.js
@@ -27,21 +27,11 @@ function TaskListModal(props) {
     setdateDisplayType(dateDisplayType === 'absolute' ? 'relative' : 'absolute');
   }
 
-  function handleSearchAllCheckboxChange(event) {
-    props.org.setSearchAllHeadersFlag(event.target.checked);
-  }
-
   function handleFilterChange(event) {
     props.org.setSearchFilterInformation(event.target.value, event.target.selectionStart);
   }
 
-  const {
-    onClose,
-    searchFilter,
-    searchFilterValid,
-    searchFilterSuggestions,
-    searchAllHeaders,
-  } = props;
+  const { onClose, searchFilter, searchFilterValid, searchFilterSuggestions } = props;
 
   // On mobile devices, the Drawer already handles the touch event.
   // Hence, scrolling within the Drawers container does not work with
@@ -75,19 +65,6 @@ function TaskListModal(props) {
           list="task-list__datalist-filter"
           onChange={handleFilterChange}
         />
-        <div className="agenda__tab-container">
-          <input
-            type="checkbox"
-            className="checkbox"
-            checked={searchAllHeaders}
-            id="task-list__checkbox-search-all-headers"
-            data-testid="task-list__checkbox"
-            onChange={handleSearchAllCheckboxChange}
-          />
-          <label className="label-for-checkbox" htmlFor="task-list__checkbox-search-all-headers">
-            Search all headlines
-          </label>
-        </div>
       </div>
 
       <div className="task-list__headers-container" style={taskListViewStyle}>
@@ -107,7 +84,6 @@ const mapStateToProps = state => ({
   searchFilter: state.org.present.getIn(['search', 'searchFilter']) || '',
   searchFilterValid: state.org.present.getIn(['search', 'searchFilterValid']),
   searchFilterSuggestions: state.org.present.getIn(['search', 'searchFilterSuggestions']) || [],
-  searchAllHeaders: state.org.present.getIn(['search', 'searchAllHeaders']) || false,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/OrgFile/index.js
+++ b/src/components/OrgFile/index.js
@@ -17,6 +17,7 @@ import TimestampEditorModal from './components/TimestampEditorModal';
 import PropertyListEditorModal from './components/PropertyListEditorModal';
 import AgendaModal from './components/AgendaModal';
 import TaskListModal from './components/TaskListModal';
+import SearchModal from './components/SearchModal';
 
 import * as baseActions from '../../actions/base';
 import * as syncBackendActions from '../../actions/sync_backend';
@@ -335,6 +336,8 @@ class OrgFile extends PureComponent {
         return <AgendaModal onClose={this.handlePopupClose} headers={headers} />;
       case 'task-list':
         return <TaskListModal onClose={this.handlePopupClose} headers={headers} />;
+      case 'search':
+        return <SearchModal onClose={this.handlePopupClose} headers={headers} />;
       default:
         return null;
     }

--- a/src/reducers/base.js
+++ b/src/reducers/base.js
@@ -70,7 +70,7 @@ const activatePopup = (state, action) => {
   // Remember active popup in URL state for popups that are uniquely
   // identifiable (aka not related to a single header like tags,
   // properties or timestamps).
-  if (['task-list', 'agenda'].includes(popupType)) {
+  if (['search', 'task-list', 'agenda'].includes(popupType)) {
     window.location.hash = popupType;
   }
 

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -946,11 +946,6 @@ export const setSearchFilterInformation = (state, action) => {
   return state.asImmutable();
 };
 
-export const setSearchAllHeadersFlag = (state, action) => {
-  const { searchAllHeaders } = action;
-  return state.setIn(['search', 'searchAllHeaders'], searchAllHeaders);
-};
-
 const setOrgFileErrorMessage = (state, action) => state.set('orgFileErrorMessage', action.message);
 
 export default (state = Map(), action) => {
@@ -1065,8 +1060,6 @@ export default (state = Map(), action) => {
       return updateLogEntryTime(state, action);
     case 'SET_SEARCH_FILTER_INFORMATION':
       return setSearchFilterInformation(state, action);
-    case 'SET_SEARCH_ALL_HEADERS_FLAG':
-      return setSearchAllHeadersFlag(state, action);
 
     default:
       return state;


### PR DESCRIPTION
A TaskList should just be what the name says - a task list. It totally makes sense to have task specific feature that filters down to tasks and orders them by various task related critieria. Complecting this feature with a more generic "Search" will complicate the interface, the code and the understanding of the user.

Instead of going down that route, I propose to have a TaskList which does just that. Next to it, there is a standalone Search which has fewer features and only filters down on headers.

For the GUI, I've harmonized them into one collapsible FAB, because even though they are doing very different jobs - they are pretty aligned in terms of how they operate.

Open tasks:

- [x] Introcuce SearchModal
- [x] Harmonize TaskList and Search in the GUI
- [x] Refactor Task List and remove "Search all headlines" logic
- [x] Think if it makes sense to extract common markup from Agenda/TaskList and Search
- [x] Write acceptance tests for Search

@schoettl What do you think - does this work for you?
