### PR TITLE
Bugfix: don't crash on using capture template when header path is invalid

### DIFF
--- a/src/components/OrgFile/components/CaptureModal/index.js
+++ b/src/components/OrgFile/components/CaptureModal/index.js
@@ -84,9 +84,9 @@ export default ({ template, onCapture, headers, onClose }) => {
   useEffect(() => {
     if (textarea.current) {
       textarea.current.focus();
+      // Set Cursor position to the %? part of the template.
+      textarea.current.setSelectionRange(initialCursorIndex, initialCursorIndex);
     }
-    // Set Cursor position to the %? part of the template.
-    textarea.current.setSelectionRange(initialCursorIndex, initialCursorIndex);
   }, [textarea, initialCursorIndex]);
 
   const handleCaptureClick = () => onCapture(template.get('id'), textareaValue, shouldPrepend);
@@ -111,7 +111,7 @@ export default ({ template, onCapture, headers, onClose }) => {
 
       <div className="capture-modal-header-path">{template.get('headerPaths').join(' > ')}</div>
 
-      {!!targetHeader ? (
+      {targetHeader ? (
         <Fragment>
           <textarea
             className="textarea capture-modal-textarea"

--- a/src/lib/org_utils.js
+++ b/src/lib/org_utils.js
@@ -174,7 +174,7 @@ export const headerWithPath = (headers, headerPath) => {
   }
 
   const subheaders = subheadersOfHeaderWithId(headers, firstHeader.get('id'));
-  return headerWithPath(subheaders, headerPath.skip(1));
+  return headerWithPath(subheaders, headerPath.rest());
 };
 
 export const openHeaderWithPath = (headers, headerPath, maxNestingLevel = 1) => {


### PR DESCRIPTION
I also replaced `!!targetHeader` with `targetHeader` because as far as I know, this `!!` doesn't make sense in many cases. An object never evaluates to false and null always eveluates to false. That is all we are testing here.

Or is there any good reason to keep it?