### PR TITLE
Show Org filename in Header where applicable

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
         (before it was required to scroll all the way to the top)
     - Deselect headline by clicking into the title (or empty space) in
       the HeaderBar
+    - Show Org filename in Header
 
 *** Fixed
     - *Major synchronization improvements*

--- a/src/components/HeaderBar/index.js
+++ b/src/components/HeaderBar/index.js
@@ -38,6 +38,18 @@ class HeaderBar extends PureComponent {
     return pathname.split('/')[1];
   }
 
+  getFilename() {
+    const {
+      location: { pathname },
+    } = this.props;
+    // only show a filename if it's a file and not a path
+    if (pathname.includes('.org')) {
+      return pathname.substring(pathname.lastIndexOf('/') + 1, pathname.lastIndexOf('.'));
+    } else {
+      return '';
+    }
+  }
+
   renderFileBrowserBackButton() {
     const {
       location: { pathname },
@@ -191,7 +203,7 @@ class HeaderBar extends PureComponent {
       default:
     }
 
-    return titleContainerWithText('');
+    return titleContainerWithText(this.getFilename());
   }
 
   handleChangelogClick() {

--- a/src/components/HeaderBar/stylesheet.css
+++ b/src/components/HeaderBar/stylesheet.css
@@ -6,7 +6,8 @@
   padding: 10px;
 
   display: grid;
-  grid-template-columns: 3fr 4fr 3fr;
+  grid-template-columns: minmax(2em, 2fr) minmax(1em, 3fr) 1fr;
+  grid-template-areas: 'back title actions';
   align-items: center;
 
   position: sticky;
@@ -38,6 +39,10 @@
   text-align: center;
   font-size: 20px;
   height: 100%;
+  grid-area: title;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
 }
 
 .header-bar__back-button {
@@ -47,10 +52,11 @@
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
+  grid-area: back;
 }
 
 .header-bar__back-button__directory-path {
-  margin-left: 5px;
+  margin-left: 0.25em;
 }
 
 .header-bar__actions {
@@ -60,12 +66,13 @@
   cursor: pointer;
 
   color: var(--base01);
+  grid-area: actions;
 }
 
 .header-bar__actions__item {
   color: var(--base01);
 
-  margin-left: 20px;
+  margin-left: 0.5em;
 }
 
 .settings-icon--has-unseen-changelog {


### PR DESCRIPTION
This example file is called `things.org`. For brevity, organice shows its name in the header as `things`.

The whole header is constructed with a CSS grid, so it behaves pretty well in constrained conditions. The filename, of course, is the least important, so it will shrink where needed. 

![Screen Shot 2020-01-12 at 20 09 27](https://user-images.githubusercontent.com/505721/72224193-c1fa2d00-3577-11ea-96a7-44f556dd1a85.png)
