### PR TITLE
Support org-adapt-indentation

### DIFF
--- a/src/actions/base.js
+++ b/src/actions/base.js
@@ -102,6 +102,11 @@ export const setShouldLogIntoDrawer = shouldLogIntoDrawer => ({
   shouldLogIntoDrawer,
 });
 
+export const setShouldNotIndentOnExport = shouldNotIndentOnExport => ({
+  type: 'SET_SHOULD_NOT_INDENT_ON_EXPORT',
+  shouldNotIndentOnExport,
+});
+
 export const setShouldStoreSettingsInSyncBackend = newShouldStoreSettingsInSyncBackend => {
   return (dispatch, getState) => {
     dispatch({

--- a/src/actions/org.js
+++ b/src/actions/org.js
@@ -112,7 +112,8 @@ const doSync = ({
                 getState().org.present.get('headers'),
                 getState().org.present.get('todoKeywordSets'),
                 getState().org.present.get('fileConfigLines'),
-                getState().org.present.get('linesBeforeHeadings')
+                getState().org.present.get('linesBeforeHeadings'),
+                getState().base.get('shouldNotIndentOnExport')
               )
             )
             .then(() => {

--- a/src/components/OrgFile/OrgFile.unit.test.js
+++ b/src/components/OrgFile/OrgFile.unit.test.js
@@ -20,7 +20,9 @@ function parseAndExportOrgFile(testOrgFile) {
   const todoKeywordSets = parsedFile.get('todoKeywordSets');
   const fileConfigLines = parsedFile.get('fileConfigLines');
   const linesBeforeHeadings = parsedFile.get('linesBeforeHeadings');
-  const exportedFile = exportOrg(headers, todoKeywordSets, fileConfigLines, linesBeforeHeadings);
+  // we keep the default behaviour of indenting the element body according to nesting depth
+  const exportedFile = exportOrg(
+    headers, todoKeywordSets, fileConfigLines, linesBeforeHeadings, false);
   return exportedFile;
 }
 
@@ -40,25 +42,25 @@ describe('Tests for export', () => {
   test('Simple description export of empty description works', () => {
     const description = '';
     const header = createSimpleHeaderWithDescription(description);
-    expect(createRawDescriptionText(header, false)).toEqual(description);
+    expect(createRawDescriptionText(header, false, false)).toEqual(description);
   });
 
   test('Simple description export of empty line works', () => {
     const description = '\n';
     const header = createSimpleHeaderWithDescription(description);
-    expect(createRawDescriptionText(header, false)).toEqual(description);
+    expect(createRawDescriptionText(header, false, false)).toEqual(description);
   });
 
   test('Simple description export of non-empty line works', () => {
     const description = 'abc\n';
     const header = createSimpleHeaderWithDescription(description);
-    expect(createRawDescriptionText(header, false)).toEqual(description);
+    expect(createRawDescriptionText(header, false, false)).toEqual(description);
   });
 
   test('Simple description export of non-empty line without trailing newline works (newline will be added)', () => {
     const description = 'abc';
     const header = createSimpleHeaderWithDescription(description);
-    expect(createRawDescriptionText(header, false)).toEqual(`${description}\n`);
+    expect(createRawDescriptionText(header, false, false)).toEqual(`${description}\n`);
   });
 });
 

--- a/src/components/OrgFile/OrgFile.unit.test.js
+++ b/src/components/OrgFile/OrgFile.unit.test.js
@@ -13,16 +13,21 @@ import { fromJS } from 'immutable';
  * This is a convenience wrapper around parsing an org file using
  * `parseOrg` and then export it using `exportOrg`.
  * @param {String} testOrgFile - contents of an org file
+ * @param {Boolean} dontIndent - by default false, so indent drawers
  */
-function parseAndExportOrgFile(testOrgFile) {
+function parseAndExportOrgFile(testOrgFile, dontIndent = false) {
   const parsedFile = parseOrg(testOrgFile);
   const headers = parsedFile.get('headers');
   const todoKeywordSets = parsedFile.get('todoKeywordSets');
   const fileConfigLines = parsedFile.get('fileConfigLines');
   const linesBeforeHeadings = parsedFile.get('linesBeforeHeadings');
-  // we keep the default behaviour of indenting the element body according to nesting depth
   const exportedFile = exportOrg(
-    headers, todoKeywordSets, fileConfigLines, linesBeforeHeadings, false);
+    headers,
+    todoKeywordSets,
+    fileConfigLines,
+    linesBeforeHeadings,
+    dontIndent
+  );
   return exportedFile;
 }
 
@@ -374,6 +379,12 @@ ${description}`;
           expect(exportedFile).toEqual(testOrgFile);
         });
 
+        test('Properties are flush-left when dontIndent is true', () => {
+          const testOrgFile = readFixture('properties');
+          const exportedLines = parseAndExportOrgFile(testOrgFile, true).split('\n');
+          expect(exportedLines[2]).toEqual(':PROPERTIES:');
+        });
+
         test('Tags are formatted as is default in Emacs', () => {
           const testOrgFile = readFixture('tags');
           const exportedFile = parseAndExportOrgFile(testOrgFile);
@@ -386,6 +397,18 @@ ${description}`;
         const testOrgFile = readFixture('logbook');
         const exportedFile = parseAndExportOrgFile(testOrgFile);
         expect(exportedFile).toEqual(testOrgFile);
+      });
+      test('Logbook entries are indented by default', () => {
+        const testOrgFile = readFixture('logbook');
+        const exportedLines = parseAndExportOrgFile(testOrgFile).split('\n');
+        expect(exportedLines[1]).toEqual('  :LOGBOOK:');
+        expect(exportedLines[2].startsWith('  CLOCK:')).toBeTruthy();
+      });
+      test('Logbook entries are not indented when dontIndent', () => {
+        const testOrgFile = readFixture('logbook');
+        const exportedLines = parseAndExportOrgFile(testOrgFile, true).split('\n');
+        expect(exportedLines[1]).toEqual(':LOGBOOK:');
+        expect(exportedLines[2].startsWith('CLOCK:')).toBeTruthy();
       });
     });
   });

--- a/src/components/OrgFile/components/HeaderContent/index.js
+++ b/src/components/OrgFile/components/HeaderContent/index.js
@@ -78,7 +78,8 @@ class HeaderContent extends PureComponent {
   }
 
   calculateRawDescription(header) {
-    return createRawDescriptionText(header, false);
+    // this is for display only, se we keep the default indentation behaviour
+    return createRawDescriptionText(header, false, false);
   }
 
   handleTextareaRef(textarea) {

--- a/src/components/Settings/index.js
+++ b/src/components/Settings/index.js
@@ -21,6 +21,7 @@ const Settings = ({
   shouldSyncOnBecomingVisibile,
   shouldShowTitleInOrgFile,
   shouldLogIntoDrawer,
+  shouldNotIndentOnExport,
   agendaDefaultDeadlineDelayValue,
   agendaDefaultDeadlineDelayUnit,
   hasUnseenChangelog,
@@ -56,6 +57,9 @@ const Settings = ({
     base.setShouldShowTitleInOrgFile(!shouldShowTitleInOrgFile);
 
   const handleShouldLogIntoDrawer = () => base.setShouldLogIntoDrawer(!shouldLogIntoDrawer);
+
+  const handleShouldNotIndentOnExport = () =>
+    base.setShouldNotIndentOnExport(!shouldNotIndentOnExport);
 
   const handleShouldStoreSettingsInSyncBackendChange = () =>
     base.setShouldStoreSettingsInSyncBackend(!shouldStoreSettingsInSyncBackend);
@@ -135,6 +139,21 @@ const Settings = ({
           </div>
         </div>
         <Switch isEnabled={shouldLogIntoDrawer} onToggle={handleShouldLogIntoDrawer} />
+      </div>
+
+      <div className="setting-container">
+        <div className="setting-label">
+          Disable hard indent on Org export
+          <div className="setting-label__description">
+            By default, the body of an exported org heading is indented according to its level. If
+            instead you prefer to keep your body text flush-left, i.e.{' '}
+            <a href="https://orgmode.org/manual/Hard-indentation.html">
+              <code>(setq org-adapt-indentation nil)</code>
+            </a>
+            , then activate this setting.
+          </div>
+        </div>
+        <Switch isEnabled={shouldNotIndentOnExport} onToggle={handleShouldNotIndentOnExport} />
       </div>
 
       <div className="setting-container">
@@ -233,6 +252,7 @@ const mapStateToProps = (state, props) => {
     shouldSyncOnBecomingVisibile: state.base.get('shouldSyncOnBecomingVisibile'),
     shouldShowTitleInOrgFile: state.base.get('shouldShowTitleInOrgFile'),
     shouldLogIntoDrawer: state.base.get('shouldLogIntoDrawer'),
+    shouldNotIndentOnExport: state.base.get('shouldNotIndentOnExport'),
     hasUnseenChangelog: state.base.get('hasUnseenChangelog'),
   };
 };

--- a/src/components/Settings/index.js
+++ b/src/components/Settings/index.js
@@ -145,12 +145,13 @@ const Settings = ({
         <div className="setting-label">
           Disable hard indent on Org export
           <div className="setting-label__description">
-            By default, the body of an exported org heading is indented according to its level. If
-            instead you prefer to keep your body text flush-left, i.e.{' '}
+            By default, the metadata body (including deadlines and drawers) of an exported org
+            heading is indented according to its level. If instead you prefer to keep your body text
+            flush-left, i.e.{' '}
             <a href="https://orgmode.org/manual/Hard-indentation.html">
               <code>(setq org-adapt-indentation nil)</code>
             </a>
-            , then activate this setting.
+            , then activate this setting. The raw content text is left unchanged.
           </div>
         </div>
         <Switch isEnabled={shouldNotIndentOnExport} onToggle={handleShouldNotIndentOnExport} />

--- a/src/lib/export_org.js
+++ b/src/lib/export_org.js
@@ -248,7 +248,8 @@ export const generateTitleLine = (header, includeStars) => {
  * @param {*} todoKeywordSets
  * @param {*} fileConfigLines List of all "#+VAR:" config lines in the file.
  * @param {*} linesBeforeHeadings Text that occurs before the first heading.
- * @param {boolean} dontIndent Default false means indent heading body according to nesting level, else keep everything flush-left.
+ * @param {boolean} dontIndent Default false means indent drawers according to
+ * nesting level, else keep everything flush-left. Description is kept as is.
  */
 export const exportOrg = (
   headers,

--- a/src/lib/export_org.js
+++ b/src/lib/export_org.js
@@ -241,7 +241,22 @@ export const generateTitleLine = (header, includeStars) => {
   return contents;
 };
 
-export const exportOrg = (headers, todoKeywordSets, fileConfigLines, linesBeforeHeadings) => {
+/**
+ * Convert state data into a fully rendered Orgmode file text.
+ *
+ * @param {*} headers Full list of org headings from redux state.
+ * @param {*} todoKeywordSets
+ * @param {*} fileConfigLines List of all "#+VAR:" config lines in the file.
+ * @param {*} linesBeforeHeadings Text that occurs before the first heading.
+ * @param {boolean} dontIndent Default false means indent heading body according to nesting level, else keep everything flush-left.
+ */
+export const exportOrg = (
+  headers,
+  todoKeywordSets,
+  fileConfigLines,
+  linesBeforeHeadings,
+  dontIndent
+) => {
   let configContent = '';
 
   if (fileConfigLines.size > 0) {
@@ -267,18 +282,25 @@ export const exportOrg = (headers, todoKeywordSets, fileConfigLines, linesBefore
     configContent = configContent + '\n';
   }
 
-  const headerContent = headers.map(x => createRawDescriptionText(x, true)).join('');
+  const headerContent = headers.map(x => createRawDescriptionText(x, true, dontIndent)).join('');
 
   return configContent + headerContent;
 };
 
-export const createRawDescriptionText = (header, includeTitle) => {
+/**
+ * Transform state data of complete org element / header into rendered text.
+ *
+ * @param {*} header Immutable map with header data
+ * @param {boolean} includeTitle Render the full orgmode title
+ * @param {boolean} dontIndent If true keep all text flush-left, else (DEFAULT) indent according to nesting level
+ */
+export const createRawDescriptionText = (header, includeTitle, dontIndent) => {
   // To simplify access to properties:
   header = header.toJS();
 
   // Pad things like planning items and tables appropriately
-  // considering the nestingLevel of the header.
-  const indentation = ' '.repeat(header.nestingLevel + 1);
+  // considering the nestingLevel of the header, unless that is explicitly disabled
+  const indentation = dontIndent ? '' : ' '.repeat(header.nestingLevel + 1);
   let contents = '';
 
   if (includeTitle) {

--- a/src/lib/parse_org.unit.test.js
+++ b/src/lib/parse_org.unit.test.js
@@ -20,7 +20,8 @@ function parseAndExportOrgFile(testOrgFile) {
   const todoKeywordSets = parsedFile.get('todoKeywordSets');
   const fileConfigLines = parsedFile.get('fileConfigLines');
   const linesBeforeHeadings = parsedFile.get('linesBeforeHeadings');
-  const exportedFile = exportOrg(headers, todoKeywordSets, fileConfigLines, linesBeforeHeadings);
+  const exportedFile = exportOrg(
+    headers, todoKeywordSets, fileConfigLines, linesBeforeHeadings, false);
   return exportedFile;
 }
 

--- a/src/reducers/base.js
+++ b/src/reducers/base.js
@@ -33,6 +33,14 @@ const setShouldShowTitleInOrgFile = (state, action) =>
 const setShouldLogIntoDrawer = (state, action) =>
   state.set('shouldLogIntoDrawer', action.shouldLogIntoDrawer);
 
+/**
+ * When enabled, keep all heading body text flush-left. When disabled (the
+ * default) indent the body text of headings according to the nesting level of
+ * the heading.
+ */
+const setShouldNotIndentOnExport = (state, action) =>
+  state.set('shouldNotIndentOnExport', action.shouldNotIndentOnExport);
+
 const setHasUnseenChangelog = (state, action) =>
   state.set('hasUnseenChangelog', action.newHasUnseenChangelog);
 
@@ -129,6 +137,8 @@ export default (state = Map(), action) => {
       return setShouldShowTitleInOrgFile(state, action);
     case 'SET_SHOULD_LOG_INTO_DRAWER':
       return setShouldLogIntoDrawer(state, action);
+    case 'SET_SHOULD_NOT_INDENT_ON_EXPORT':
+      return setShouldNotIndentOnExport(state, action);
     case 'SET_HAS_UNSEEN_CHANGELOG':
       return setHasUnseenChangelog(state, action);
     case 'SET_LAST_SEEN_CHANGELOG_HEADER':

--- a/src/util/settings_persister.js
+++ b/src/util/settings_persister.js
@@ -118,6 +118,12 @@ export const persistableFields = [
     shouldStoreInConfig: true,
   },
   {
+    category: 'base',
+    name: 'shouldNotIndentOnExport',
+    type: 'boolean',
+    shouldStoreInConfig: true,
+  },
+  {
     category: 'capture',
     name: 'captureTemplates',
     type: 'json',


### PR DESCRIPTION
This is on top of the yet-to-be-merged PR #271.

Here we add support for an `org-adapt-indentation` compatible setting.

By default (`org-adapt-indentation t`), heading body is indented according to the nesting level of the heading. When this new setting is enabled in the organice UI, we follow `org-adapt-indentation nil` instead, i.e. all text is kept flush left.

Some users prefer this, because then they have the option to switch dynamically between indent / no-indent modes with [`org-indent-mode`](https://orgmode.org/manual/Org-Indent-Mode.html).