### PR TITLE
chore: Upgrade date-fns

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "bowser": "^2.7.0",
     "classnames": "^2.2.6",
-    "date-fns": "^2.6.0",
+    "date-fns": "^2.12.0",
     "dotenv": "^8.2.0",
     "dropbox": "^4.0.30",
     "immutable": "^3.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4555,10 +4555,10 @@ data-urls@^1.0.0, data-urls@^1.1.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-date-fns@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.6.0.tgz#a5bc82e6a4c3995ae124b0ba1a71aec7b8cbd666"
-  integrity sha512-F55YxqRdEfP/eYQmQjLN798v0AwLjmZ8nMBjdQvNwEE3N/zWVrlkkqT+9seBlPlsbkybG4JmWg3Ee3dIV9BcGQ==
+date-fns@^2.12.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.12.0.tgz#01754c8a2f3368fc1119cf4625c3dad8c1845ee6"
+  integrity sha512-qJgn99xxKnFgB1qL4jpxU7Q2t0LOn1p8KMIveef3UZD7kqjT3tpFNNdXJelEHhE+rUgffriXriw/sOSU+cS1Hw==
 
 date-now@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
Closes https://github.com/200ok-ch/organice/issues/269

According to the [changelog](https://github.com/date-fns/date-fns/blob/master/CHANGELOG.md#200---2019-08-20), we should be good with the upgrade.

I made quick tests in the UI and didn't see regressions, as well.