### PR TITLE
Allow Bitwarden to auto-populate the WebDAV URL sign-in field

### DIFF
--- a/src/components/SyncServiceSignIn/index.js
+++ b/src/components/SyncServiceSignIn/index.js
@@ -44,6 +44,7 @@ function WebDAVForm() {
         <p>
           <label>Url:</label>
           <input
+            name="url"
             type="url"
             value={url}
             className="textfield"


### PR DESCRIPTION
The Bitwarden password manager has a nice feature where you can configure it to auto-populate certain form fields if they have the right attributes set:

- https://bitwarden.com/help/article/custom-fields/

It was already successfully auto-populating the Username and Password fields on the WebDAV sign-in form, so add a name attribute to the URL sign-in field in order to allow it to populate the Url field too.