### PR TITLE
Make local file:... links navigate to the relevant file

### DIFF
--- a/src/components/OrgFile/OrgFile.integration.test.js
+++ b/src/components/OrgFile/OrgFile.integration.test.js
@@ -216,7 +216,7 @@ describe('Render all views', () => {
 
     describe('Renders everything starting from an Org file', () => {
       test('renders an Org file', () => {
-        expect(getAllByText(/\*/)).toHaveLength(6);
+        expect(getAllByText(/\*/)).toHaveLength(7);
         expect(container).toMatchSnapshot();
       });
 
@@ -449,6 +449,7 @@ describe('Render all views', () => {
           expect(elem[0]).toHaveAttribute('href', 'tel:+498025123456789');
           expect(elem[0]).toHaveTextContent('+498025123456789');
         });
+
         test('recognizes URLs', () => {
           fireEvent.click(
             queryByText('A header with a URL, mail address and phone number as content')
@@ -460,6 +461,19 @@ describe('Render all views', () => {
           expect(elem[0]).toHaveAttribute('href', 'https://foo.bar.baz/xyz?a=b&d#foo');
           expect(elem[0]).toHaveTextContent('https://foo.bar.baz/xyz?a=b&d#foo');
         });
+
+        test('recognizes file: links', () => {
+          fireEvent.click(
+            queryByText('A header with a link to a local .org file as content')
+          );
+          const elem = getAllByText('a local .org file');
+          // There's exactly one such URL
+          expect(elem.length).toEqual(1);
+          // And it renders as such
+          expect(elem[0]).toHaveAttribute('href', 'schedule_and_timestamps.org');
+          expect(elem[0]).toHaveTextContent('a local .org file');
+        });
+
         test('recognizes email addresses', () => {
           fireEvent.click(
             queryByText('A header with a URL, mail address and phone number as content')

--- a/src/components/OrgFile/__snapshots__/OrgFile.integration.test.js.snap
+++ b/src/components/OrgFile/__snapshots__/OrgFile.integration.test.js.snap
@@ -539,6 +539,52 @@ exports[`Render all views Org Functionality Renders everything starting from an 
                 style="word-break: break-word;"
               >
                 <span>
+                  A header with a link to a local .org file as content
+                </span>
+                ...
+              </span>
+            </div>
+          </div>
+          <div />
+        </div>
+        <div
+          class="header"
+          style="padding-left: 20px; margin-left: 0px;"
+        >
+          <div
+            class="left-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
+              style="display: none; color: rgb(0, 0, 0);"
+            />
+          </div>
+          <div
+            class="right-swipe-action-container"
+            style="width: 0px; background-color: rgb(211, 211, 211);"
+          >
+            <i
+              class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
+              style="display: none; color: rgb(0, 0, 0);"
+            />
+          </div>
+          <div
+            class="header__bullet"
+            style="margin-left: -16px;"
+          >
+            *
+          </div>
+          <div
+            class="title-line"
+            style="width: 0px;"
+          >
+            
+            <div>
+              <span
+                style="word-break: break-word;"
+              >
+                <span>
                   A header with a URL, mail address and phone number as content
                 </span>
                 ...

--- a/src/components/OrgFile/components/AttributedString/index.js
+++ b/src/components/OrgFile/components/AttributedString/index.js
@@ -20,9 +20,14 @@ export default ({ parts, subPartDataAndHandlers }) => {
           case 'link':
             const uri = part.getIn(['contents', 'uri']);
             const title = part.getIn(['contents', 'title']) || uri;
-
+            const isFileLink = uri.startsWith("file:");
             return (
-              <a key={part.get('id')} href={uri} target="_blank" rel="noopener noreferrer">
+              <a
+                key={part.get('id')} 
+                href={isFileLink ? uri.substr(5) : uri}
+                target={isFileLink ? "" : "_blank"}
+                rel="noopener noreferrer"
+              >
                 {title}
               </a>
             );

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -31,10 +31,11 @@ describe('org reducer', () => {
       // The target is to refile "PROJECT Foo" into "A nested header".
       // They have both subheadlines, so it's not the trivial case.
 
-      // "PROJECT Foo" is the 9th item, "A nested header" the 2nd.
+      // "PROJECT Foo" is the 10th item, "A nested header" the 2nd,
+      // but we count from 0 not 1.
       sourceHeaderId = state
         .getIn(['org', 'present', 'headers'])
-        .get(8)
+        .get(9)
         .get('id');
       targetHeaderId = state
         .getIn(['org', 'present', 'headers'])
@@ -62,6 +63,7 @@ describe('org reducer', () => {
         ['A repeating todo', 2],
         ['A header with tags                                              ', 1],
         ['A header with [[https://organice.200ok.ch][a link]]', 1],
+        ['A header with a link to a local .org file as content', 1],
         ['A header with a URL, mail address and phone number as content', 1],
         ['PROJECT Foo', 2],
         ["A headline that's done since a loong time", 3],
@@ -87,6 +89,7 @@ describe('org reducer', () => {
         ['A repeating todo', 2],
         ['A header with tags                                              ', 1],
         ['A header with [[https://organice.200ok.ch][a link]]', 1],
+        ['A header with a link to a local .org file as content', 1],
         ['A header with a URL, mail address and phone number as content', 1],
         ['A header with a custom todo sequence in DONE state', 1],
       ]);

--- a/test_helpers/fixtures/main_test_file.org
+++ b/test_helpers/fixtures/main_test_file.org
@@ -12,6 +12,9 @@ Some description content
 
 * A header with tags                                              :tag1:tag2:
 * A header with [[https://organice.200ok.ch][a link]]
+* A header with a link to a local .org file as content
+
+  [[file:schedule_and_timestamps.org][a local .org file]]
 * A header with a URL, mail address and phone number as content
 
   This is a URL https://foo.bar.baz/xyz?a=b&d#foo in a line of text.


### PR DESCRIPTION
Make a link like `[[file:foo/bar.org][bar]]` into `href="foo/bar.org"` without `target="_blank"`, so that it opens in the same organice window.  This allows more convenient navigation around a network of `.org` files, and in particular an `index.org` file which facilitates quick jumping to the most commonly used other `.org` files.