### PR TITLE
doc: Add a button on the landing page linking to the docs

### DIFF
--- a/src/components/Landing/index.js
+++ b/src/components/Landing/index.js
@@ -31,6 +31,13 @@ export default () => {
         <Link to="/sign_in">
           <div className="btn landing-button">Sign in</div>
         </Link>
+        <a
+          href="https://organice.200ok.ch/documentation.html"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <div className="btn landing-button">Documentation</div>
+        </a>
       </div>
       <footer>
         <Link to="/privacy-policy">Privacy Policy</Link>

--- a/src/components/Landing/stylesheet.css
+++ b/src/components/Landing/stylesheet.css
@@ -36,7 +36,7 @@ footer a {
   text-align: center;
 
   font-size: 20px;
-  margin-top: 30px;
+  margin-top: 20px;
   width: 200px;
 }
 
@@ -69,7 +69,7 @@ footer a {
 }
 
 .view-sample-button {
-  margin-top: 40px;
+  margin-top: 20px;
 }
 
 .mailing-list-signup-container {


### PR DESCRIPTION
As discussed on Matrix.  Not sure whether to ditch the `.view-sample-button` CSS rule; to me it looks best with the same `margin-top` as the other two buttons.