### PR TITLE
Remove unit tests duplicated in parse_org.unit.test.js

### DIFF
--- a/src/components/OrgFile/OrgFile.unit.test.js
+++ b/src/components/OrgFile/OrgFile.unit.test.js
@@ -366,7 +366,7 @@ ${description}`;
             expect(exportedFile).toEqual(testOrgFile);
           });
 
-          test('For basic files', () => {
+          test('For files with multiple headlines with timestamps', () => {
             const testOrgFile = readFixture('multiple_headlines_with_timestamps');
             const exportedFile = parseAndExportOrgFile(testOrgFile);
             expect(exportedFile).toEqual(testOrgFile);

--- a/src/components/OrgFile/OrgFile.unit.test.js
+++ b/src/components/OrgFile/OrgFile.unit.test.js
@@ -9,6 +9,22 @@ import readFixture from '../../../test_helpers/index';
 import { noLogRepeatEnabledP } from '../../reducers/org';
 import { fromJS } from 'immutable';
 
+/**
+ * This is a convenience wrapper around parsing an org file using
+ * `parseOrg` and then export it using `exportOrg`.
+ * @param {String} testOrgFile - contents of an org file
+ * @param {Boolean} dontIndent - by default false, so indent drawers
+ */
+function parseAndExportOrgFile(testOrgFile, dontIndent = false) {
+  const parsedFile = parseOrg(testOrgFile);
+  const exportedFile = exportOrg({
+    headers: parsedFile.get('headers'),
+    linesBeforeHeadings: parsedFile.get('linesBeforeHeadings'),
+    dontIndent: dontIndent,
+  });
+  return exportedFile;
+}
+
 describe('Tests for export', () => {
   const createSimpleHeaderWithDescription = (description) =>
     fromJS({

--- a/src/components/OrgFile/OrgFile.unit.test.js
+++ b/src/components/OrgFile/OrgFile.unit.test.js
@@ -66,20 +66,6 @@ describe('Tests for export', () => {
 });
 
 describe('Unit Tests for Org file', () => {
-  describe('Test the parser', () => {
-    const expectType = (result) => expect(result.map((x) => x.type));
-    describe('Parsing inline-markup', () => {
-      test('Parses inline-markup where closing delim is followed by ;', () => {
-        const result = parseMarkupAndCookies('*bold*;');
-        expectType(result).toEqual(['inline-markup', 'text']);
-      });
-      test('Parses inline-markup surrounded by text', () => {
-        const result = parseMarkupAndCookies(' *bold*;');
-        expectType(result).toEqual(['text', 'inline-markup', 'text']);
-      });
-    });
-  });
-
   describe('Parsing and export should not alter the description part', () => {
     const expectStrippedDescription = (description) => {
       const {
@@ -244,6 +230,7 @@ ${text}`;
         const exportedFile = parseAndExportOrgFile(testOrgFile);
         expect(exportedFile).toEqual(testOrgFile);
       });
+
       test('Parses all valid URLs starting with www', () => {
         const parsedFile = parseOrg(testOrgFile);
         const firstHeader = parsedFile.get('headers').first();
@@ -349,9 +336,30 @@ ${description}`;
             const exportedFile = parseAndExportOrgFile(testOrgFile);
             expect(exportedFile).toEqual(testOrgFile);
           });
+
+          describe('Parses planning item with following checkmark', () => {
+            it('parses and exports without changes', () => {
+              const testOrgFile = readFixture('planning_item_with_following_checkmark');
+              const exportedFile = parseAndExportOrgFile(testOrgFile);
+              expect(exportedFile).toEqual(testOrgFile);
+            });
+            test('Parsing a planning items followed by a checklist must work', () => {
+              const testDescription = '- [ ] foo\n- [ ] bar';
+              const parsed = _parsePlanningItems(`SCHEDULED: <2019-07-30 Tue>\n${testDescription}`);
+              const parsedPlanningItem = parsed.planningItems.toJS();
+              expect(parsedPlanningItem[0].timestamp.dayName).toEqual('Tue');
+              expect(parsed.strippedDescription).toEqual(testDescription);
+            });
+          });
         });
 
         describe('Planning items are formatted as is default Emacs', () => {
+          test('For files with timestamps in title and description', () => {
+            const testOrgFile = readFixture('schedule_and_timestamps');
+            const exportedFile = parseAndExportOrgFile(testOrgFile);
+            expect(exportedFile).toEqual(testOrgFile);
+          });
+
           test('For basic files', () => {
             const testOrgFile = readFixture('schedule');
             const exportedFile = parseAndExportOrgFile(testOrgFile);

--- a/src/lib/parse_org.unit.test.js
+++ b/src/lib/parse_org.unit.test.js
@@ -6,25 +6,7 @@ import {
   _parsePlanningItems,
   parseMarkupAndCookies,
 } from './parse_org';
-import { exportOrg } from './export_org';
 import readFixture from '../../test_helpers/index';
-
-/**
- * This is a convenience wrapper around parsing an org file using
- * `parseOrg` and then export it using `exportOrg`.
- * @param {String} testOrgFile - contents of an org file
- */
-function parseAndExportOrgFile(testOrgFile) {
-  const parsedFile = parseOrg(testOrgFile);
-  const exportedFile = exportOrg({
-    headers: parsedFile.get('headers'),
-    todoKeywordSets: parsedFile.get('todoKeywordSets'),
-    fileConfigLines: parsedFile.get('fileConfigLines'),
-    linesBeforeHeadings: parsedFile.get('linesBeforeHeadings'),
-    dontIndent: false,
-  });
-  return exportedFile;
-}
 
 describe('Test the parser', () => {
   const expectType = (result) => expect(result.map((x) => x.type));
@@ -65,124 +47,9 @@ describe('Test the parser', () => {
 });
 
 describe('Parsing and exporting should not alter the original file', () => {
-  test("Parsing and exporting shouldn't alter the original file", () => {
-    const testOrgFile = readFixture('indented_list');
-    const exportedFile = parseAndExportOrgFile(testOrgFile);
-
-    // Should have the same amount of lines. Safeguard for the next
-    // expectation.
-    const exportedFileLines = exportedFile.split('\n');
-    const testOrgFileLines = testOrgFile.split('\n');
-    expect(exportedFileLines.length).toEqual(testOrgFileLines.length);
-
-    exportedFileLines.forEach((line, index) => {
-      expect(line).toEqual(testOrgFileLines[index]);
-    });
-  });
-
-  test('Parses and exports a file which contains all features of organice', () => {
-    const testOrgFile = readFixture('all_the_features');
-    const exportedFile = parseAndExportOrgFile(testOrgFile);
-    expect(exportedFile).toEqual(testOrgFile);
-  });
-
-  describe('Boldness', () => {
-    test('Parsing lines with bold text', () => {
-      const testOrgFile = readFixture('bold_text');
-      const exportedFile = parseAndExportOrgFile(testOrgFile);
-      expect(exportedFile).toEqual(testOrgFile);
-    });
-  });
-
-  describe('Parsing inline-markup', () => {
-    test('Parses inline-markup where closing delim is followed by ;', () => {
-      const result = parseMarkupAndCookies('*bold*;');
-      expect(result.length).toEqual(2);
-    });
-  });
-
-  describe('HTTP URLs', () => {
-    test('Parse a line containing an URL but no /italic/ text before the URL', () => {
-      const testOrgFile = readFixture('url');
-      const exportedFile = parseAndExportOrgFile(testOrgFile);
-      expect(exportedFile).toEqual(testOrgFile);
-    });
-  });
-
-  describe('www URLs', () => {
-    const testOrgFile = readFixture('www_url');
-    test('Parse a line containing an URL starting with www', () => {
-      const exportedFile = parseAndExportOrgFile(testOrgFile);
-      expect(exportedFile).toEqual(testOrgFile);
-    });
-    test('Parses all valid URLs starting with www', () => {
-      const parsedFile = parseOrg(testOrgFile);
-      const firstHeader = parsedFile.get('headers').first();
-      const parsedUrls = firstHeader.get('description').filter((x) => x.get('type') === 'www-url');
-      expect(parsedUrls.size).toEqual(2);
-    });
-  });
-
-  describe('E-mail address', () => {
-    test('Parse a line containing an e-mail address', () => {
-      const testOrgFile = readFixture('email');
-      const exportedFile = parseAndExportOrgFile(testOrgFile);
-      expect(exportedFile).toEqual(testOrgFile);
-    });
-  });
-
-  describe('Phone number in canonical format (+xxxxxx)', () => {
-    test('Parse a line containing a phone number but no +striked+ text after the number', () => {
-      const testOrgFile = readFixture('phonenumber');
-      const exportedFile = parseAndExportOrgFile(testOrgFile);
-      expect(exportedFile).toEqual(testOrgFile);
-    });
-  });
-
-  describe('Newlines', () => {
-    test('Newlines in between headers and items are preserved', () => {
-      const testOrgFile = readFixture('newlines');
-      const exportedFile = parseAndExportOrgFile(testOrgFile);
-      expect(exportedFile).toEqual(testOrgFile);
-    });
-  });
-
-  test('Config and content lines before first heading line are kept', () => {
-    const testOrgFile = readFixture('before-first-headline');
-    const exportedFile = parseAndExportOrgFile(testOrgFile);
-    expect(exportedFile).toEqual(testOrgFile);
-  });
-
   describe('Planning items', () => {
     describe('Formatting is the same as in Emacs', () => {
       describe('List formatting', () => {
-        test('Parsing a basic list should not mangle the list', () => {
-          const testDescription = '  - indented list\n     - Foo';
-          const parsedFile = _parsePlanningItems(testDescription);
-          expect(parsedFile.strippedDescription).toEqual(testDescription);
-        });
-
-        test('Parsing a list with planning items should not mangle the list', () => {
-          const testDescription = '  - indented list\n     - Foo';
-          const parsedFile = _parsePlanningItems(`SCHEDULED: <2019-07-30 Tue>\n${testDescription}`);
-          expect(parsedFile.strippedDescription).toEqual(testDescription);
-        });
-
-        describe('Parses planning item with following checkmark', () => {
-          it('parses and exports without changes', () => {
-            const testOrgFile = readFixture('planning_item_with_following_checkmark');
-            const exportedFile = parseAndExportOrgFile(testOrgFile);
-            expect(exportedFile).toEqual(testOrgFile);
-          });
-          test('Parsing a planning items followed by a checklist must work', () => {
-            const testDescription = '- [ ] foo\n- [ ] bar';
-            const parsed = _parsePlanningItems(`SCHEDULED: <2019-07-30 Tue>\n${testDescription}`);
-            const parsedPlanningItem = parsed.planningItems.toJS();
-            expect(parsedPlanningItem[0].timestamp.dayName).toEqual('Tue');
-            expect(parsed.strippedDescription).toEqual(testDescription);
-          });
-        });
-
         test('Planning items should contain active timestamps from title and description as well', () => {
           const testOrgFile = readFixture('schedule_and_timestamps');
           const parsedFile = parseOrg(testOrgFile);
@@ -192,45 +59,6 @@ describe('Parsing and exporting should not alter the original file', () => {
           expect(header.planningItems.length).toEqual(3);
         });
       });
-
-      describe('Planning items are formatted as is default Emacs', () => {
-        test('For basic files', () => {
-          const testOrgFile = readFixture('schedule');
-          const exportedFile = parseAndExportOrgFile(testOrgFile);
-          expect(exportedFile).toEqual(testOrgFile);
-        });
-
-        test('For files with timestamps in title and description', () => {
-          const testOrgFile = readFixture('schedule_and_timestamps');
-          const exportedFile = parseAndExportOrgFile(testOrgFile);
-          expect(exportedFile).toEqual(testOrgFile);
-        });
-
-        test('For files with multiple planning items', () => {
-          const testOrgFile = readFixture('schedule_and_deadline');
-          const exportedFile = parseAndExportOrgFile(testOrgFile);
-          expect(exportedFile).toEqual(testOrgFile);
-        });
-      });
-
-      test('Properties are formatted as is default in Emacs', () => {
-        const testOrgFile = readFixture('properties');
-        const exportedFile = parseAndExportOrgFile(testOrgFile);
-        expect(exportedFile).toEqual(testOrgFile);
-      });
-
-      test('Tags are formatted as is default in Emacs', () => {
-        const testOrgFile = readFixture('tags');
-        const exportedFile = parseAndExportOrgFile(testOrgFile);
-        expect(exportedFile).toEqual(testOrgFile);
-      });
-    });
-  });
-  describe('Logbook entries', () => {
-    test('Logbook entries are formatted as is default in Emacs', () => {
-      const testOrgFile = readFixture('logbook');
-      const exportedFile = parseAndExportOrgFile(testOrgFile);
-      expect(exportedFile).toEqual(testOrgFile);
     });
   });
 });

--- a/src/lib/parse_org.unit.test.js
+++ b/src/lib/parse_org.unit.test.js
@@ -8,22 +8,6 @@ import {
 } from './parse_org';
 import readFixture from '../../test_helpers/index';
 
-/**
- * This is a convenience wrapper around parsing an org file using
- * `parseOrg` and then export it using `exportOrg`.
- * @param {String} testOrgFile - contents of an org file
- * @param {Boolean} dontIndent - by default false, so indent drawers
- */
-function parseAndExportOrgFile(testOrgFile, dontIndent = false) {
-  const parsedFile = parseOrg(testOrgFile);
-  const exportedFile = exportOrg({
-    headers: parsedFile.get('headers'),
-    linesBeforeHeadings: parsedFile.get('linesBeforeHeadings'),
-    dontIndent: dontIndent,
-  });
-  return exportedFile;
-}
-
 describe('Test the parser', () => {
   const expectType = (result) => expect(result.map((x) => x.type));
   describe('Parsing inline-markup', () => {


### PR DESCRIPTION
There were a bunch of tests identically or near identically duplicated between `parse_org.unit.test.js` and `OrgFile.unit.test.js`, so remove them from one of the two files.  The former seems to be a more specific and low-level set of tests; based on the file name presumably it's the best place for testing `parseOrg()`, but probably less suitable for tests which also exercise `exportOrg()`.
