### PR TITLE
Parse TODO keyword sets correctly from anywhere in the file (#151)

### DIFF
--- a/src/actions/org.js
+++ b/src/actions/org.js
@@ -110,8 +110,6 @@ const doSync = ({
               path,
               exportOrg({
                 headers: getState().org.present.get('headers'),
-                todoKeywordSets: getState().org.present.get('todoKeywordSets'),
-                fileConfigLines: getState().org.present.get('fileConfigLines'),
                 linesBeforeHeadings: getState().org.present.get('linesBeforeHeadings'),
                 dontIndent: getState().base.get('shouldNotIndentOnExport'),
               })

--- a/src/components/OrgFile/OrgFile.unit.test.js
+++ b/src/components/OrgFile/OrgFile.unit.test.js
@@ -19,8 +19,6 @@ function parseAndExportOrgFile(testOrgFile, dontIndent = false) {
   const parsedFile = parseOrg(testOrgFile);
   const exportedFile = exportOrg({
     headers: parsedFile.get('headers'),
-    todoKeywordSets: parsedFile.get('todoKeywordSets'),
-    fileConfigLines: parsedFile.get('fileConfigLines'),
     linesBeforeHeadings: parsedFile.get('linesBeforeHeadings'),
     dontIndent: dontIndent,
   });
@@ -175,8 +173,7 @@ ${text}`;
     test('Parse file with one empty line', () => {
       const testOrgFile = '\n';
       const exportedFile = parseAndExportOrgFile(testOrgFile);
-      // if the exporter produces no output at all, the single newline character is discarded
-      expect(exportedFile).toEqual('');
+      expect(exportedFile).toEqual('\n');
     });
 
     test('Parse very basic file with description', () => {
@@ -436,6 +433,14 @@ ${description}`;
         expect(noLogRepeatEnabledP({ state, headerIndex: 5 })).toBe(false);
         expect(noLogRepeatEnabledP({ state, headerIndex: 7 })).toBe(true);
       });
+    });
+  });
+
+  describe('TODO keywords at EOF', () => {
+    test('formatted as in default emacs', () => {
+      const testOrgFile = readFixture('todo_keywords_interspersed');
+      const exportedFile = parseAndExportOrgFile(testOrgFile);
+      expect(exportedFile).toEqual(testOrgFile);
     });
   });
 });

--- a/src/lib/export_org.js
+++ b/src/lib/export_org.js
@@ -253,46 +253,17 @@ export const generateTitleLine = (header, includeStars) => {
  * Convert state data into a fully rendered Orgmode file text.
  *
  * @param {*} headers Full list of org headings from redux state.
- * @param {*} todoKeywordSets
- * @param {*} fileConfigLines List of all "#+VAR:" config lines in the file.
  * @param {*} linesBeforeHeadings Text that occurs before the first heading.
  * @param {boolean} dontIndent Default false means indent drawers according to
  * nesting level, else keep everything flush-left. Description is kept as is.
  */
 export const exportOrg = ({
   headers,
-  todoKeywordSets,
-  fileConfigLines,
   linesBeforeHeadings,
   dontIndent,
 }) => {
-  let configContent = '';
-
-  if (fileConfigLines.size > 0) {
-    configContent = fileConfigLines.join('\n') + '\n';
-  }
-
-  if (!todoKeywordSets.get(0).get('default')) {
-    configContent =
-      configContent +
-      todoKeywordSets
-        .map((todoKeywordSet) => {
-          return todoKeywordSet.get('configLine');
-        })
-        .join('\n') +
-      '\n';
-  }
-
-  if (linesBeforeHeadings.size > 0) {
-    configContent = configContent + linesBeforeHeadings.join('\n');
-  }
-
-  if (configContent.length > 0) {
-    configContent = configContent + '\n';
-  }
-
+  let configContent = linesBeforeHeadings.map(x => x + '\n').join('');
   const headerContent = headers.map((x) => createRawDescriptionText(x, true, dontIndent)).join('');
-
   return configContent + headerContent;
 };
 

--- a/src/lib/parse_org.unit.test.js
+++ b/src/lib/parse_org.unit.test.js
@@ -18,8 +18,6 @@ function parseAndExportOrgFile(testOrgFile) {
   const parsedFile = parseOrg(testOrgFile);
   const exportedFile = exportOrg({
     headers: parsedFile.get('headers'),
-    todoKeywordSets: parsedFile.get('todoKeywordSets'),
-    fileConfigLines: parsedFile.get('fileConfigLines'),
     linesBeforeHeadings: parsedFile.get('linesBeforeHeadings'),
     dontIndent: false,
   });
@@ -304,5 +302,22 @@ describe('Parse in-buffer TODO keyword settings', () => {
         expectNewSetFromLine(line);
       });
     });
+  });
+
+  describe('TODO keywords at EOF parsed correctly', () => {
+    const testOrgFile = readFixture('todo_keywords_interspersed');
+    const parsedFile = parseOrg(testOrgFile);
+    const headers = parsedFile.get('headers').toJS();
+    expect(headers.length).toEqual(15);
+    expect(headers[7].titleLine.rawTitle).toEqual('orgmode settings in middle of file');
+    expect(headers[14].titleLine.rawTitle).toEqual('orgmode settings at end of file');
+    const todoKeywordSets = parsedFile.get('todoKeywordSets').toJS();
+    expect(todoKeywordSets.length).toEqual(3);
+    expect(todoKeywordSets[0].keywords).toEqual(['NEXT', 'DONE']);
+    expect(todoKeywordSets[0].completedKeywords).toEqual(['DONE']);
+    expect(todoKeywordSets[1].keywords).toEqual(['START', 'FINISHED']);
+    expect(todoKeywordSets[1].completedKeywords).toEqual(['FINISHED']);
+    expect(todoKeywordSets[2].keywords).toEqual(['PROJECT', 'PROJDONE']);
+    expect(todoKeywordSets[2].completedKeywords).toEqual(['PROJDONE']);
   });
 });

--- a/test_helpers/fixtures/todo_keywords_interspersed.org
+++ b/test_helpers/fixtures/todo_keywords_interspersed.org
@@ -1,0 +1,32 @@
+#+TODO: NEXT | DONE
+* Top level header
+** A nested header
+** TODO A todo item with schedule and deadline
+   DEADLINE: <2018-10-05 Fri> SCHEDULED: <2019-09-19 Thu>
+* Another top level header
+Some description content
+** TODO A repeating todo
+   SCHEDULED: <2020-04-05 Sun +1d>
+
+* A header with tags                                              :tag1:tag2:
+* A header with [[https://organice.200ok.ch][a link]]
+* orgmode settings in middle of file
+#+TYP_TODO: START(s!/!) | FINISHED(f@)
+* A header with a link to a local .org file as content
+
+  [[file:schedule_and_timestamps.org][a local .org file]]
+* A header with a URL, mail address and phone number as content
+
+  This is a URL https://foo.bar.baz/xyz?a=b&d#foo in a line of text.
+
+  This is an e-mail foo.bar@baz.org in a line of text.
+
+  +Don't+ call me on: +498025123456789.
+** PROJECT Foo
+*** DONE A headline that's done since a loong time
+    SCHEDULED: <2001-01-03 Wed>
+*** DONE A headline that's done a day earlier even
+    SCHEDULED: <2001-01-02 Tue>
+* FINISHED A header with a custom todo sequence in DONE state
+* orgmode settings at end of file
+#+SEQ_TODO: PROJECT(p) | PROJDONE


### PR DESCRIPTION
~~**N.B. This PR is currently stacked on top of #309, so a) please do not merge yet, and b) you only need to review the last commit of the three.  Once #309 is merged, I can rebase this on top of the merge, and it will become a single commit.**~~

Move parsing of TODO keyword sets (i.e. `#+TODO:` and `#+TYP_TODO:` lines) and other `#+...` config lines into a separate pass which happens before the main parsing loop.  This means that these lines can appear anywhere in the file and will still take effect, just like they do in emacs.  Also add support for `#+SEQ_TODO:` which means the same thing.

Since these lines can now appear anywhere, after collecting them into `todoKeywordSets`, it no longer makes sense to use `todoKeywordSets` to regenerate them in the export.  So in order for `exportOrg()` to preserve the exact original file, store all lines before the first header in `linesBeforeHeadings` in the order they appeared, without filtering out TODO keyword sets or other config lines, and use this in the export.  This has a nice side effect of significantly simplifying the `exportOrg()` function.

However, other config lines beginning with `#+...` are still collected in `fileConfigLines`, to allow other types of config to have an effect in organice as before.

Fixes #151.