### PR TITLE
Use a more robust approach to enabling CORS pre-flight checks

### DIFF
--- a/README.org
+++ b/README.org
@@ -485,6 +485,9 @@ In the [[https://organice.200ok.ch/documentation.html#faq_webdav][FAQ]], you'll 
   - Documentation on Nextcloud sharing
 
 ** Routing
+   :PROPERTIES:
+   :CUSTOM_ID: routing
+   :END:
 
 Whilst organice is a true [[https://developer.mozilla.org/en-US/docs/Glossary/SPA][Single Page Application]] (SPA) and therefore
 has no back-end whatsoever, this does have an implication for
@@ -514,7 +517,29 @@ RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} -f [OR]
 RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} -d
 RewriteRule ^ - [L]
 
+# N.B. If this next rule is allowed to apply to a WebDAV directory, it
+# will break PUT requests to upload new files!
 RewriteRule ^ /index.html [L]
+#+END_EXAMPLE
+
+If your WebDAV directory happens to be not only on the same webserver,
+but also within a subdirectory of the directory containing this
+=.htaccess= file, then you will need to create another =.htaccess=
+file in the top-level WebDAV directory containing this:
+
+#+BEGIN_EXAMPLE
+RewriteEngine Off
+#+END_EXAMPLE
+
+Otherwise any attempts to use WebDAV to upload new files via =HTTP
+PUT= requests will fall foul of the =/index.html= rewrite rule above,
+resulting in a =403 Forbidden= response.
+
+Another way to avoid this more selectively is to precede that rule
+with:
+
+#+BEGIN_EXAMPLE
+RewriteCond %{REQUEST_METHOD} !PUT
 #+END_EXAMPLE
 
 * Capture templates

--- a/README.org
+++ b/README.org
@@ -474,7 +474,7 @@ like [[https://httpd.apache.org/docs/2.4/mod/mod_dav.html][Apache]] or [[https:/
 
 **** More information
 
-In the [[https://github.com/200ok-ch/organice/wiki#webdav][Wiki]], you'll find lots more information regarding WebDAV:
+In the [[https://organice.200ok.ch/documentation.html#faq_webdav][FAQ]], you'll find lots more information regarding WebDAV:
 
   - A screencast of how organice works when logging in to a WebDAV
     server

--- a/README.org
+++ b/README.org
@@ -517,30 +517,13 @@ RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} -f [OR]
 RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} -d
 RewriteRule ^ - [L]
 
-# N.B. If this next rule is allowed to apply to a WebDAV directory, it
-# will break PUT requests to upload new files!
 RewriteRule ^ /index.html [L]
 #+END_EXAMPLE
 
-If your WebDAV directory happens to be not only on the same webserver,
-but also within a subdirectory of the directory containing this
-=.htaccess= file, then you will need to create another =.htaccess=
-file in the top-level WebDAV directory containing this:
-
-#+BEGIN_EXAMPLE
-RewriteEngine Off
-#+END_EXAMPLE
-
-Otherwise any attempts to use WebDAV to upload new files via =HTTP
-PUT= requests will fall foul of the =/index.html= rewrite rule above,
-resulting in a =403 Forbidden= response.
-
-Another way to avoid this more selectively is to precede that rule
-with:
-
-#+BEGIN_EXAMPLE
-RewriteCond %{REQUEST_METHOD} !PUT
-#+END_EXAMPLE
+N.B.: If you're using WebDAV as a sync back-end, and the =RewriteRule= is
+allowed to apply to a WebDAV directory, it will break PUT requests to
+upload new files! [[#webdav_apache_rewrite_engine][Here's documentation]] on how to configure both
+features together correctly.
 
 * Capture templates
   :PROPERTIES:

--- a/WIKI.org
+++ b/WIKI.org
@@ -146,12 +146,16 @@ about that - here's a screencast showing you how to do it:
  whether a CORS preflight check is returning the right headers via:
 
  #+BEGIN_EXAMPLE
- curl -v -X OPTIONS https://my.server/webdav
+ curl -v -X OPTIONS https://my.server/webdav/
+
+ # For the official organice Apache2 WebDAV test server:
+ # curl -v -X OPTIONS http://localhost:8080/webdav/
  #+END_EXAMPLE
 
  The output should include lines like this:
 
  #+BEGIN_EXAMPLE
+ ...
  < HTTP/1.1 200 OK
  ...
  < Access-Control-Allow-Origin: *
@@ -167,6 +171,33 @@ about that - here's a screencast showing you how to do it:
 
  - https://stackoverflow.com/questions/27703871/return-empty-response-from-apache/
  - https://serverfault.com/questions/231766/returning-200-ok-in-apache-on-http-options-requests/
+
+**** Using Apache =RewriteEngine=
+     :PROPERTIES:
+     :CUSTOM_ID: webdav_apache_rewrite_engine
+     :END:
+
+If your WebDAV directory happens to be not only on the same webserver,
+but also within a subdirectory of the directory containing a
+=.htaccess= file containing a =RewriteRule= that also applies to the
+WebDAV directory (for example like [[#routing][this]]), then you will need to create
+another =.htaccess= file in the top-level WebDAV directory containing
+this:
+
+#+BEGIN_EXAMPLE
+RewriteEngine Off
+#+END_EXAMPLE
+
+Otherwise any attempts to use WebDAV to upload new files via =HTTP
+PUT= requests will fall foul of the =/index.html= rewrite rule above,
+resulting in a =403 Forbidden= response.
+
+Another way to avoid this more selectively is to precede that rule
+with:
+
+#+BEGIN_EXAMPLE
+RewriteCond %{REQUEST_METHOD} !PUT
+#+END_EXAMPLE
 
 **** Symlinks don't work
 

--- a/WIKI.org
+++ b/WIKI.org
@@ -181,6 +181,12 @@ about that - here's a screencast showing you how to do it:
  file]], and Linux prevents renaming to bind mounts with a =Device or
  resource busy= error.
 
+**** =HTTP PUT= requests fail with =403 Forbidden=
+
+ As mentioned in [[#routing][the section routing]], you should avoid having
+ =mod_rewrite= rules apply to (=PUT=) requests in the WebDAV
+ directories.
+
 *** Configuring Nextcloud behind haproxy to allow WebDAV
  If you're running Nextcloud behind [[https://www.haproxy.com/][haproxy]] it's entirely possible to use it with
  organice using WebDAV. ...it's just a little bit convoluted.

--- a/WIKI.org
+++ b/WIKI.org
@@ -142,7 +142,31 @@ about that - here's a screencast showing you how to do it:
  have HTTP ok status.
  #+END_EXAMPLE
 
- then the =RewriteRule= in the above example is either missing from, or ineffective in your webserver config.
+ then something is wrong with your webserver config.  You can check
+ whether a CORS preflight check is returning the right headers via:
+
+ #+BEGIN_EXAMPLE
+ curl -v -X OPTIONS https://my.server/webdav
+ #+END_EXAMPLE
+
+ The output should include lines like this:
+
+ #+BEGIN_EXAMPLE
+ < HTTP/1.1 200 OK
+ ...
+ < Access-Control-Allow-Origin: *
+ < Access-Control-Allow-Methods: GET,POST,OPTIONS,DELETE,PUT,PROPFIND
+ < Access-Control-Allow-Headers: Origin,Accept,X-Requested-With,Content-Type,Access-Control-Request-Method,Access-Control-Request-Headers,Authorization,X-CSRF-Token,Depth
+ < Access-Control-Allow-Credentials: true
+ < Allow: OPTIONS,GET,HEAD,POST,DELETE,TRACE,PROPFIND,PROPPATCH,COPY,MOVE,LOCK,UNLOCK
+ #+END_EXAMPLE
+
+ If your server doesn't give a =200 OK= response, or if the
+ =Access-Control-Allow-*= headers are missing, you may find these
+ articles helpful:
+
+ - https://stackoverflow.com/questions/27703871/return-empty-response-from-apache/
+ - https://serverfault.com/questions/231766/returning-200-ok-in-apache-on-http-options-requests/
 
 **** Symlinks don't work
 

--- a/bin/compile_doc.sh
+++ b/bin/compile_doc.sh
@@ -11,7 +11,10 @@ if ! which pandoc >/dev/null 2>&1; then
 fi
 
 echo "#+SETUPFILE: https://fniessen.github.io/org-html-themes/setup/theme-readtheorg.setup" > documentation.org
-cat README.org | grep -v api.codeclimate | grep -v "https://organice.200ok.ch/documentation.html" >> documentation.org
+cat README.org | \
+    grep -v api.codeclimate | \
+    grep -v "^Documentation: https://organice.200ok.ch/documentation.html" \
+    >> documentation.org
 sed -i 's/# REPO_PLACEHOLDER/Code repository: https:\/\/github.com\/200ok-ch\/organice/' documentation.org
 cat WIKI.org >> documentation.org
 cat CONTRIBUTING.org >> documentation.org

--- a/doc/webdav/webdav.conf
+++ b/doc/webdav/webdav.conf
@@ -1,16 +1,14 @@
 Alias /webdav /srv/dav/
 
-RewriteEngine On
-RewriteCond %{REQUEST_METHOD} OPTIONS
-RewriteRule ^(.*)$ $1 [R=200,L]
-
 <Location "/webdav">
     Options Indexes
     DAV On
     # AuthType Basic
     # AuthName "Restricted Content"
     # AuthUserFile /srv/dav/.htpasswd
-    # Require valid-user
+    # <LimitExcept OPTIONS>
+    #   Require valid-user
+    # </LimitExcept>
 
     Header always set Access-Control-Allow-Origin "*"
     Header always set Access-Control-Allow-Methods "GET,POST,OPTIONS,DELETE,PUT,PROPFIND"


### PR DESCRIPTION
Using the `R=200` trick in mod_rewrite seems problematic, because it can cause Apache to return a `200 OK` response with a very unhelpful message body including:

    The server encountered an internal error or misconfiguration and
    was unable to complete your request.

This SO answer suggests that the internal error is due to Apache not having an `ErrorDocument` configured for `200` responses by default:

- https://stackoverflow.com/a/48529566/179332

Apparently a `204` code (`No Content`) is a more appropriate response:

- https://stackoverflow.com/questions/27703871/return-empty-response-from-apache/

and indeed my experiments confirm that changing the `RewriteRule` to use `R=204` eliminates this error.

However, this approach doesn't guarantee that the CORS headers are included in the response.  A better approach is to revisit the original motivation for this rewrite rule, which was presumably to get around the fact that the browser doesn't send credentials with the CORS preflight check, therefore the server would typically give a `401` response.  So we can simply follow an alternative approach:

- https://serverfault.com/a/431718/79729

where we do not require authorization for `OPTIONS` requests.