### PR TITLE
Fix rendering of file: links  (#311)

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -6,6 +6,16 @@ When there are updates to the changelog, you will be notified and see a 'gift' i
 
 
 
+* [2020-06-03 Wed]
+** Added
+   - =TODO= keyword sets can now be anywhere in the file
+     - Thank you [[https://github.com/aspiers][aspiers]] for your [[https://github.com/200ok-ch/organice/pull/310][PR]] 🙏
+** Fixed
+   - =file:= links are sanity checked before opened
+     - Only relative file links are linked and can be opened, since absolute and back-looking (as in starting with =../=) might not be accessible to organice.
+     - =file:= links opened in iOS from the PWA view will not open Mobile Safari
+     - Thank you [[https://github.com/aspiers][aspiers]] for your [[https://github.com/200ok-ch/organice/pull/311][PR]] 🙏
+
 * [2020-05-30 Sat]
 
 ** Added

--- a/src/components/OrgFile/OrgFile.integration.test.js
+++ b/src/components/OrgFile/OrgFile.integration.test.js
@@ -478,6 +478,20 @@ describe('Render all views', () => {
             expect(elem[0]).toHaveTextContent('an existing .org file in the same directory');
           });
 
+          test('relative link to subdir', () => {
+            const elem = getAllByText('subdir');
+            expect(elem.length).toEqual(1);
+            expect(elem[0]).toHaveAttribute('href', '/files/dir1/dir2/subdir');
+            expect(elem[0]).toHaveTextContent('subdir');
+          });
+
+          test('relative link to subdir/', () => {
+            const elem = getAllByText('subdir/');
+            expect(elem.length).toEqual(1);
+            expect(elem[0]).toHaveAttribute('href', '/files/dir1/dir2/subdir/');
+            expect(elem[0]).toHaveTextContent('subdir/');
+          });
+
           test('relative link to fictitious .org file in subdir', () => {
             const elem = getAllByText('a fictitious .org file in a sub-directory');
             expect(elem.length).toEqual(1);
@@ -492,6 +506,20 @@ describe('Render all views', () => {
             expect(elem[0]).toHaveTextContent('a fictitious .org file in a parent directory');
           });
 
+          test('relative link to subdir', () => {
+            const elem = getAllByText('../subdir');
+            expect(elem.length).toEqual(1);
+            expect(elem[0]).toHaveAttribute('href', '/files/dir1/subdir');
+            expect(elem[0]).toHaveTextContent('../subdir');
+          });
+
+          test('relative link to subdir/', () => {
+            const elem = getAllByText('../subdir/');
+            expect(elem.length).toEqual(1);
+            expect(elem[0]).toHaveAttribute('href', '/files/dir1/subdir/');
+            expect(elem[0]).toHaveTextContent('../subdir/');
+          });
+
           test('relative link to fictitious .org file in a grand-parent directory', () => {
             const elem = getAllByText('a fictitious .org file in a grand-parent directory');
             expect(elem.length).toEqual(1);
@@ -504,6 +532,13 @@ describe('Render all views', () => {
             expect(elem.length).toEqual(1);
             expect(elem[0]).toHaveAttribute('href', 'file://../../../../too-high.org');
             expect(elem[0]).toHaveTextContent('a fictitious .org file in a too-high ancestor directory');
+          });
+
+          test('relative link to too-high ancestor directory', () => {
+            const elem = getAllByText('a too-high ancestor directory');
+            expect(elem.length).toEqual(1);
+            expect(elem[0]).toHaveAttribute('href', 'file://../../../../too-high');
+            expect(elem[0]).toHaveTextContent('a too-high ancestor directory');
           });
 
           test('absolute link to fictitious .org file in home directory', () => {

--- a/src/components/OrgFile/OrgFile.integration.test.js
+++ b/src/components/OrgFile/OrgFile.integration.test.js
@@ -77,7 +77,7 @@ describe('Render all views', () => {
       getByPlaceholderText;
     beforeEach(() => {
       let res = render(
-        <MemoryRouter keyLength={0}>
+        <MemoryRouter keyLength={0} initialEntries={["/file/foo/fixtureTestFile.org"]}>
           <Provider store={store}>
             <HeaderBar />
             <OrgFile path="fixtureTestFile.org" />
@@ -462,16 +462,45 @@ describe('Render all views', () => {
           expect(elem[0]).toHaveTextContent('https://foo.bar.baz/xyz?a=b&d#foo');
         });
 
-        test('recognizes file: links', () => {
-          fireEvent.click(
-            queryByText('A header with a link to a local .org file as content')
-          );
-          const elem = getAllByText('a local .org file');
-          // There's exactly one such URL
-          expect(elem.length).toEqual(1);
-          // And it renders as such
-          expect(elem[0]).toHaveAttribute('href', 'schedule_and_timestamps.org');
-          expect(elem[0]).toHaveTextContent('a local .org file');
+        describe('recognizes file: links', () => {
+          beforeEach(() => {
+            fireEvent.click(
+              queryByText('A header with various links as content')
+            );
+          });
+
+          test('relative link to .org file', () => {
+            const elem = getAllByText('an existing .org file in the same directory');
+            // There's exactly one such URL
+            expect(elem.length).toEqual(1);
+            // And it renders as such
+            expect(elem[0]).toHaveAttribute('href', '/file/foo/schedule_and_timestamps.org');
+            expect(elem[0]).toHaveTextContent('an existing .org file in the same directory');
+          });
+
+          test('relative link to fictitious .org file in subdir', () => {
+            const elem = getAllByText('a fictitious .org file in a sub-directory');
+            // There's exactly one such URL
+            expect(elem.length).toEqual(1);
+            // And it renders as such
+            expect(elem[0]).toHaveAttribute('href', '/file/foo/subdir/foo.org');
+            expect(elem[0]).toHaveTextContent('a fictitious .org file in a sub-directory');
+          });
+
+          test('absolute link to fictitious .org file in a parent directory', () => {
+            const elem = queryByText('a fictitious .org file in a parent directory');
+            expect(elem).toBeNull();
+          });
+
+          test('absolute link to fictitious .org file in home directory', () => {
+            const elem = queryByText('a fictitious .org file in home directory');
+            expect(elem).toBeNull();
+          });
+
+          test('absolute link to fictitious .org file', () => {
+            const elem = queryByText('a fictitious .org file');
+            expect(elem).toBeNull();
+          });
         });
 
         test('recognizes email addresses', () => {

--- a/src/components/OrgFile/OrgFile.integration.test.js
+++ b/src/components/OrgFile/OrgFile.integration.test.js
@@ -77,7 +77,7 @@ describe('Render all views', () => {
       getByPlaceholderText;
     beforeEach(() => {
       let res = render(
-        <MemoryRouter keyLength={0} initialEntries={["/file/foo/fixtureTestFile.org"]}>
+        <MemoryRouter keyLength={0} initialEntries={["/file/dir1/dir2/fixtureTestFile.org"]}>
           <Provider store={store}>
             <HeaderBar />
             <OrgFile path="fixtureTestFile.org" />
@@ -474,32 +474,50 @@ describe('Render all views', () => {
             // There's exactly one such URL
             expect(elem.length).toEqual(1);
             // And it renders as such
-            expect(elem[0]).toHaveAttribute('href', '/file/foo/schedule_and_timestamps.org');
+            expect(elem[0]).toHaveAttribute('href', '/file/dir1/dir2/schedule_and_timestamps.org');
             expect(elem[0]).toHaveTextContent('an existing .org file in the same directory');
           });
 
           test('relative link to fictitious .org file in subdir', () => {
             const elem = getAllByText('a fictitious .org file in a sub-directory');
-            // There's exactly one such URL
             expect(elem.length).toEqual(1);
-            // And it renders as such
-            expect(elem[0]).toHaveAttribute('href', '/file/foo/subdir/foo.org');
+            expect(elem[0]).toHaveAttribute('href', '/file/dir1/dir2/subdir/foo.org');
             expect(elem[0]).toHaveTextContent('a fictitious .org file in a sub-directory');
           });
 
-          test('absolute link to fictitious .org file in a parent directory', () => {
-            const elem = queryByText('a fictitious .org file in a parent directory');
-            expect(elem).toBeNull();
+          test('relative link to fictitious .org file in a parent directory', () => {
+            const elem = getAllByText('a fictitious .org file in a parent directory');
+            expect(elem.length).toEqual(1);
+            expect(elem[0]).toHaveAttribute('href', '/file/dir1/foo.org');
+            expect(elem[0]).toHaveTextContent('a fictitious .org file in a parent directory');
+          });
+
+          test('relative link to fictitious .org file in a grand-parent directory', () => {
+            const elem = getAllByText('a fictitious .org file in a grand-parent directory');
+            expect(elem.length).toEqual(1);
+            expect(elem[0]).toHaveAttribute('href', '/file/foo.org');
+            expect(elem[0]).toHaveTextContent('a fictitious .org file in a grand-parent directory');
+          });
+
+          test('relative link to fictitious .org file in a too-high ancestor directory', () => {
+            const elem = getAllByText('a fictitious .org file in a too-high ancestor directory');
+            expect(elem.length).toEqual(1);
+            expect(elem[0]).toHaveAttribute('href', 'file://../../../../too-high.org');
+            expect(elem[0]).toHaveTextContent('a fictitious .org file in a too-high ancestor directory');
           });
 
           test('absolute link to fictitious .org file in home directory', () => {
-            const elem = queryByText('a fictitious .org file in home directory');
-            expect(elem).toBeNull();
+            const elem = getAllByText('a fictitious .org file in home directory');
+            expect(elem.length).toEqual(1);
+            expect(elem[0]).toHaveAttribute('href', 'file://~/foo/bar/baz.org');
+            expect(elem[0]).toHaveTextContent('a fictitious .org file in home directory');
           });
 
           test('absolute link to fictitious .org file', () => {
-            const elem = queryByText('a fictitious .org file');
-            expect(elem).toBeNull();
+            const elem = getAllByText('a fictitious .org file');
+            expect(elem.length).toEqual(1);
+            expect(elem[0]).toHaveAttribute('href', 'file:///foo/bar/baz.org');
+            expect(elem[0]).toHaveTextContent('a fictitious .org file');
           });
         });
 

--- a/src/components/OrgFile/OrgFile.integration.test.js
+++ b/src/components/OrgFile/OrgFile.integration.test.js
@@ -502,7 +502,7 @@ describe('Render all views', () => {
           test('relative link to fictitious .org file in a parent directory', () => {
             const elem = getAllByText('a fictitious .org file in a parent directory');
             expect(elem.length).toEqual(1);
-            expect(elem[0]).toHaveAttribute('href', '/file/dir1/foo.org');
+            expect(elem[0]).toHaveAttribute('href', '/file/dir1/foo.org_archive');
             expect(elem[0]).toHaveTextContent('a fictitious .org file in a parent directory');
           });
 

--- a/src/components/OrgFile/__snapshots__/OrgFile.integration.test.js.snap
+++ b/src/components/OrgFile/__snapshots__/OrgFile.integration.test.js.snap
@@ -240,24 +240,21 @@ exports[`Render all views Org Functionality Renders everything starting from an 
 exports[`Render all views Org Functionality Renders everything starting from an Org file renders an Org file 1`] = `
 <div>
   <div
-    class="header-bar header-bar--with-logo"
+    class="header-bar"
   >
-    <div
-      class="header-bar__logo-container"
+    <a
+      class="header-bar__back-button"
+      href="/files/foo"
     >
-      <img
-        alt="Logo"
-        class="header-bar__logo"
-        height="30"
-        src="organice.svg"
-        width="30"
+      <i
+        class="fas fa-chevron-left"
       />
-      <h2
-        class="header-bar__app-name"
+      <span
+        class="header-bar__back-button__directory-path"
       >
-        organice
-      </h2>
-    </div>
+        File browser
+      </span>
+    </a>
     <div
       class="header-bar__title"
     />
@@ -539,7 +536,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
                 style="word-break: break-word;"
               >
                 <span>
-                  A header with a link to a local .org file as content
+                  A header with various links as content
                 </span>
                 ...
               </span>

--- a/src/components/OrgFile/__snapshots__/OrgFile.integration.test.js.snap
+++ b/src/components/OrgFile/__snapshots__/OrgFile.integration.test.js.snap
@@ -244,7 +244,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
   >
     <a
       class="header-bar__back-button"
-      href="/files/foo"
+      href="/files/dir1/dir2"
     >
       <i
         class="fas fa-chevron-left"

--- a/src/components/OrgFile/components/AttributedString/index.js
+++ b/src/components/OrgFile/components/AttributedString/index.js
@@ -8,6 +8,8 @@ import TablePart from './components/TablePart';
 import ListPart from './components/ListPart';
 import TimestampPart from './components/TimestampPart';
 
+import { orgFileExtensions } from '../../../../lib/org_utils';
+
 import classNames from 'classnames';
 
 export default ({ parts, subPartDataAndHandlers }) => {
@@ -19,13 +21,13 @@ export default ({ parts, subPartDataAndHandlers }) => {
     const id = part.get('id');
     const uri = part.getIn(['contents', 'uri']);
     const title = part.getIn(['contents', 'title']) || uri;
-    if (uri.startsWith("file:")) {
+    if (uri.startsWith('file:')) {
       const target = uri.substr(5);
       const isRelativeOrgFileLink =
-        !target.startsWith("/") &&
-        !target.startsWith("~") &&
-        !target.startsWith("../") &&
-        uri.endsWith(".org");
+        !target.startsWith('/') &&
+        !target.startsWith('~') &&
+        !target.startsWith('../') &&
+        uri.match(orgFileExtensions);
       if (isRelativeOrgFileLink) {
         const dir = location.pathname.match(/.*\//);
         return (

--- a/src/components/OrgFile/components/AttributedString/index.js
+++ b/src/components/OrgFile/components/AttributedString/index.js
@@ -24,14 +24,22 @@ export default ({ parts, subPartDataAndHandlers }) => {
     let target = uri;
     if (uri.startsWith('file:')) {
       target = uri.substr(5);
-      const isRelativeOrgFileLink =
+      const isRelativeFileLink =
         !target.startsWith('/') &&
-        !target.startsWith('~') &&
-        uri.match(orgFileExtensions);
-      if (isRelativeOrgFileLink) {
+        !target.startsWith('~');
+      if (isRelativeFileLink) {
+        // N.B. Later on we may improve this conditional by performing
+        // an existence check on the backend if it allows that
+        // operation.
+
         target = normalisePath(target);
         if (!target.includes('/../')) {
           // Normalisation succeeded, so we can safely return a <Link>
+          if (!uri.match(orgFileExtensions)) {
+            // Optimistically assume that the link is pointing to a
+            // directory.
+            target = target.replace(/^\/file\//, '/files/');
+          }
           return (
               <Link key={id} to={target}>{title}</Link>
           );

--- a/src/components/OrgFile/components/AttributedString/index.js
+++ b/src/components/OrgFile/components/AttributedString/index.js
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { Link, useLocation } from 'react-router-dom';
+
 import './stylesheet.css';
 
 import TablePart from './components/TablePart';
@@ -11,6 +13,38 @@ import classNames from 'classnames';
 export default ({ parts, subPartDataAndHandlers }) => {
   let className;
 
+  let location = useLocation();
+
+  const renderLink = (part) => {
+    const id = part.get('id');
+    const uri = part.getIn(['contents', 'uri']);
+    const title = part.getIn(['contents', 'title']) || uri;
+    if (uri.startsWith("file:")) {
+      const target = uri.substr(5);
+      const isRelativeOrgFileLink =
+        !target.startsWith("/") &&
+        !target.startsWith("~") &&
+        !target.startsWith("../") &&
+        uri.endsWith(".org");
+      if (isRelativeOrgFileLink) {
+        const dir = location.pathname.match(/.*\//);
+        return (
+          <Link key={id} to={dir + target}>
+            {title}
+          </Link>
+        );
+      } else {
+        return title;
+      }
+    } else {
+      return (
+        <a key={id} href={uri} target="_blank" rel="noopener noreferrer">
+          {title}
+        </a>
+      );
+    }
+  };
+
   return (
     <span>
       {parts.map((part) => {
@@ -18,19 +52,7 @@ export default ({ parts, subPartDataAndHandlers }) => {
           case 'text':
             return part.get('contents');
           case 'link':
-            const uri = part.getIn(['contents', 'uri']);
-            const title = part.getIn(['contents', 'title']) || uri;
-            const isFileLink = uri.startsWith("file:");
-            return (
-              <a
-                key={part.get('id')} 
-                href={isFileLink ? uri.substr(5) : uri}
-                target={isFileLink ? "" : "_blank"}
-                rel="noopener noreferrer"
-              >
-                {title}
-              </a>
-            );
+            return renderLink(part);
           case 'percentage-cookie':
             className = classNames('attributed-string__cookie-part', {
               'attributed-string__cookie-part--complete':

--- a/src/components/OrgFile/index.js
+++ b/src/components/OrgFile/index.js
@@ -114,10 +114,15 @@ class OrgFile extends PureComponent {
     }
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
     const { headers, pendingCapture } = this.props;
     if (!!pendingCapture && !!headers && headers.size > 0) {
       this.props.org.insertPendingCapture();
+    }
+
+    const { path } = this.props;
+    if (!_.isEmpty(path) && path !== prevProps.path) {
+      this.props.syncBackend.downloadFile(path);
     }
   }
 

--- a/src/lib/org_utils.js
+++ b/src/lib/org_utils.js
@@ -659,4 +659,4 @@ export const getTodoKeywordSetsAsFlattenedArray = (state) => {
 };
 
 /** Regular expression of file extensions to validate a filename. */
-export const orgFileExtensions = /org$|org_archive$/;
+export const orgFileExtensions = /\.org(_archive)?$/;

--- a/src/lib/org_utils.js
+++ b/src/lib/org_utils.js
@@ -657,3 +657,6 @@ export const getTodoKeywordSetsAsFlattenedArray = (state) => {
     .toSet()
     .toJS();
 };
+
+/** Regular expression of file extensions to validate a filename. */
+export const orgFileExtensions = /org$|org_archive$/;

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -63,7 +63,7 @@ describe('org reducer', () => {
         ['A repeating todo', 2],
         ['A header with tags                                              ', 1],
         ['A header with [[https://organice.200ok.ch][a link]]', 1],
-        ['A header with a link to a local .org file as content', 1],
+        ['A header with various links as content', 1],
         ['A header with a URL, mail address and phone number as content', 1],
         ['PROJECT Foo', 2],
         ["A headline that's done since a loong time", 3],
@@ -89,7 +89,7 @@ describe('org reducer', () => {
         ['A repeating todo', 2],
         ['A header with tags                                              ', 1],
         ['A header with [[https://organice.200ok.ch][a link]]', 1],
-        ['A header with a link to a local .org file as content', 1],
+        ['A header with various links as content', 1],
         ['A header with a URL, mail address and phone number as content', 1],
         ['A header with a custom todo sequence in DONE state', 1],
       ]);

--- a/src/sync_backend_clients/dropbox_sync_backend_client.js
+++ b/src/sync_backend_clients/dropbox_sync_backend_client.js
@@ -1,5 +1,6 @@
 import { Dropbox } from 'dropbox';
 import { isEmpty } from 'lodash';
+import { orgFileExtensions } from '../lib/org_utils';
 
 import { fromJS, Map } from 'immutable';
 
@@ -15,7 +16,7 @@ export const filterAndSortDirectoryListing = (listing) => {
     // Show all folders
     if (file['.tag'] === 'folder') return true;
     // Filter out all non-org files
-    return file.name.match(/org$|org_archive$/);
+    return file.name.match(orgFileExtensions);
   });
   return filteredListing.sort((a, b) => {
     // Folders before files

--- a/test_helpers/fixtures/main_test_file.org
+++ b/test_helpers/fixtures/main_test_file.org
@@ -15,8 +15,10 @@ Some description content
 * A header with various links as content
   Relative link to [[file:schedule_and_timestamps.org][an existing .org file in the same directory]]
   Relative link to [[file:subdir/foo.org][a fictitious .org file in a sub-directory]]
-  Relative link to [[file:~/.GIT/3rd-party/organice/test_helpers/foo.org][a fictitious .org file in a parent directory]]
-  Absolute link to [[file:/foo/bar/baz.org][a fictitious .org file in home directory]]
+  Relative link to [[file:../foo.org][a fictitious .org file in a parent directory]]
+  Relative link to [[file:../../foo.org][a fictitious .org file in a grand-parent directory]]
+  Relative link to [[file:../../../../too-high.org][a fictitious .org file in a too-high ancestor directory]]
+  Absolute link to [[file:~/foo/bar/baz.org][a fictitious .org file in home directory]]
   Absolute link to [[file:/foo/bar/baz.org][a fictitious .org file]]
 * A header with a URL, mail address and phone number as content
 

--- a/test_helpers/fixtures/main_test_file.org
+++ b/test_helpers/fixtures/main_test_file.org
@@ -14,10 +14,15 @@ Some description content
 * A header with [[https://organice.200ok.ch][a link]]
 * A header with various links as content
   Relative link to [[file:schedule_and_timestamps.org][an existing .org file in the same directory]]
+  Relative link to [[file:subdir][subdir]]
+  Relative link to [[file:subdir/][subdir/]]
   Relative link to [[file:subdir/foo.org][a fictitious .org file in a sub-directory]]
   Relative link to [[file:../foo.org][a fictitious .org file in a parent directory]]
+  Relative link to [[file:../subdir][../subdir]]
+  Relative link to [[file:../subdir/][../subdir/]]
   Relative link to [[file:../../foo.org][a fictitious .org file in a grand-parent directory]]
   Relative link to [[file:../../../../too-high.org][a fictitious .org file in a too-high ancestor directory]]
+  Relative link to [[file:../../../../too-high][a too-high ancestor directory]]
   Absolute link to [[file:~/foo/bar/baz.org][a fictitious .org file in home directory]]
   Absolute link to [[file:/foo/bar/baz.org][a fictitious .org file]]
 * A header with a URL, mail address and phone number as content

--- a/test_helpers/fixtures/main_test_file.org
+++ b/test_helpers/fixtures/main_test_file.org
@@ -12,9 +12,12 @@ Some description content
 
 * A header with tags                                              :tag1:tag2:
 * A header with [[https://organice.200ok.ch][a link]]
-* A header with a link to a local .org file as content
-
-  [[file:schedule_and_timestamps.org][a local .org file]]
+* A header with various links as content
+  Relative link to [[file:schedule_and_timestamps.org][an existing .org file in the same directory]]
+  Relative link to [[file:subdir/foo.org][a fictitious .org file in a sub-directory]]
+  Relative link to [[file:~/.GIT/3rd-party/organice/test_helpers/foo.org][a fictitious .org file in a parent directory]]
+  Absolute link to [[file:/foo/bar/baz.org][a fictitious .org file in home directory]]
+  Absolute link to [[file:/foo/bar/baz.org][a fictitious .org file]]
 * A header with a URL, mail address and phone number as content
 
   This is a URL https://foo.bar.baz/xyz?a=b&d#foo in a line of text.

--- a/test_helpers/fixtures/main_test_file.org
+++ b/test_helpers/fixtures/main_test_file.org
@@ -17,7 +17,7 @@ Some description content
   Relative link to [[file:subdir][subdir]]
   Relative link to [[file:subdir/][subdir/]]
   Relative link to [[file:subdir/foo.org][a fictitious .org file in a sub-directory]]
-  Relative link to [[file:../foo.org][a fictitious .org file in a parent directory]]
+  Relative link to [[file:../foo.org_archive][a fictitious .org file in a parent directory]]
   Relative link to [[file:../subdir][../subdir]]
   Relative link to [[file:../subdir/][../subdir/]]
   Relative link to [[file:../../foo.org][a fictitious .org file in a grand-parent directory]]


### PR DESCRIPTION
The new logic for rendering `file:` links introduced by #307 had a number of issues:

- It created links for absolute paths, which does not make sense since there is no fully general mapping between the filesystem and any of the sync backends.

- It created links for relative paths pointing outside the backend (e.g. `../../../../foo.org`),

- It used `<a href="...">` rather than `<Link to=...>`, which meant the PWA treated them as external links.

So create a `<Link>` for relative `file:` paths pointing to `.org` files, don't link other `file:` paths, and render all other links with `<a ...>` as before.

Fixes #311.