### PR TITLE
Fix "Visibile" typo

### DIFF
--- a/src/actions/base.js
+++ b/src/actions/base.js
@@ -87,9 +87,9 @@ export const setShouldLiveSync = (shouldLiveSync) => ({
   shouldLiveSync,
 });
 
-export const setShouldSyncOnBecomingVisibile = (shouldSyncOnBecomingVisibile) => ({
+export const setShouldSyncOnBecomingVisible = (shouldSyncOnBecomingVisible) => ({
   type: 'SET_SHOULD_SYNC_ON_BECOMING_VISIBLE',
-  shouldSyncOnBecomingVisibile,
+  shouldSyncOnBecomingVisible,
 });
 
 export const setShouldShowTitleInOrgFile = (shouldShowTitleInOrgFile) => ({

--- a/src/components/Settings/index.js
+++ b/src/components/Settings/index.js
@@ -18,7 +18,7 @@ const Settings = ({
   shouldTapTodoToAdvance,
   shouldStoreSettingsInSyncBackend,
   shouldLiveSync,
-  shouldSyncOnBecomingVisibile,
+  shouldSyncOnBecomingVisible,
   shouldShowTitleInOrgFile,
   shouldLogIntoDrawer,
   shouldNotIndentOnExport,
@@ -51,7 +51,7 @@ const Settings = ({
   const handleShouldLiveSyncChange = () => base.setShouldLiveSync(!shouldLiveSync);
 
   const handleShouldSyncOnBecomingVisibleChange = () =>
-    base.setShouldSyncOnBecomingVisibile(!shouldSyncOnBecomingVisibile);
+    base.setShouldSyncOnBecomingVisible(!shouldSyncOnBecomingVisible);
 
   const handleShouldShowTitleInOrgFile = () =>
     base.setShouldShowTitleInOrgFile(!shouldShowTitleInOrgFile);
@@ -111,7 +111,7 @@ const Settings = ({
           </div>
         </div>
         <Switch
-          isEnabled={shouldSyncOnBecomingVisibile}
+          isEnabled={shouldSyncOnBecomingVisible}
           onToggle={handleShouldSyncOnBecomingVisibleChange}
         />
       </div>
@@ -250,7 +250,7 @@ const mapStateToProps = (state, props) => {
     agendaDefaultDeadlineDelayUnit: state.base.get('agendaDefaultDeadlineDelayUnit') || 'd',
     shouldStoreSettingsInSyncBackend: state.base.get('shouldStoreSettingsInSyncBackend'),
     shouldLiveSync: state.base.get('shouldLiveSync'),
-    shouldSyncOnBecomingVisibile: state.base.get('shouldSyncOnBecomingVisibile'),
+    shouldSyncOnBecomingVisible: state.base.get('shouldSyncOnBecomingVisible'),
     shouldShowTitleInOrgFile: state.base.get('shouldShowTitleInOrgFile'),
     shouldLogIntoDrawer: state.base.get('shouldLogIntoDrawer'),
     shouldNotIndentOnExport: state.base.get('shouldNotIndentOnExport'),

--- a/src/middleware/sync_on_becoming_visible.js
+++ b/src/middleware/sync_on_becoming_visible.js
@@ -31,7 +31,7 @@ export default (store) => (next) => (action) => {
     document.addEventListener(evtname, () => {
       if (
         store.getState().syncBackend.get('client') &&
-        store.getState().base.get('shouldSyncOnBecomingVisibile')
+        store.getState().base.get('shouldSyncOnBecomingVisible')
       ) {
         debouncedDispatchSync(store);
       }

--- a/src/reducers/base.js
+++ b/src/reducers/base.js
@@ -24,8 +24,8 @@ const setShouldStoreSettingsInSyncBackend = (state, action) =>
 
 const setShouldLiveSync = (state, action) => state.set('shouldLiveSync', action.shouldLiveSync);
 
-const setShouldSyncOnBecomingVisibile = (state, action) =>
-  state.set('shouldSyncOnBecomingVisibile', action.shouldSyncOnBecomingVisibile);
+const setShouldSyncOnBecomingVisible = (state, action) =>
+  state.set('shouldSyncOnBecomingVisible', action.shouldSyncOnBecomingVisible);
 
 const setShouldShowTitleInOrgFile = (state, action) =>
   state.set('shouldShowTitleInOrgFile', action.shouldShowTitleInOrgFile);
@@ -132,7 +132,7 @@ export default (state = Map(), action) => {
     case 'SET_SHOULD_LIVE_SYNC':
       return setShouldLiveSync(state, action);
     case 'SET_SHOULD_SYNC_ON_BECOMING_VISIBLE':
-      return setShouldSyncOnBecomingVisibile(state, action);
+      return setShouldSyncOnBecomingVisible(state, action);
     case 'SET_SHOULD_SHOW_TITLE_IN_ORG_FILE':
       return setShouldShowTitleInOrgFile(state, action);
     case 'SET_SHOULD_LOG_INTO_DRAWER':

--- a/src/util/settings_persister.js
+++ b/src/util/settings_persister.js
@@ -101,7 +101,7 @@ export const persistableFields = [
   },
   {
     category: 'base',
-    name: 'shouldSyncOnBecomingVisibile',
+    name: 'shouldSyncOnBecomingVisible',
     type: 'boolean',
     shouldStoreInConfig: true,
   },


### PR DESCRIPTION
This will presumably drop any existing value for this setting (in the store and/or `.organice-config.json`), so I'm leaving it as a draft for now.  I'd need help on how to handle a safe migration from the typo to the correctly spelt version.