### PR TITLE
Add a new option to toggle whether .organice-bak files are pushed

### DIFF
--- a/sample.org
+++ b/sample.org
@@ -297,7 +297,8 @@ file back up.
 
 Generally, when working with distributed Org files, we're recommending
 to put them under version control and to check for bugs and racing
-conditions between clients.
+conditions between clients. There is a setting available to disable
+backups in case you do not need them.
 * organice operates completely client side
 You don't log in to organice directly because organice doesn't have a
 back end - it operates completely client side using Dropbox, Google

--- a/sample.org
+++ b/sample.org
@@ -288,9 +288,9 @@ WebDAV. Click the "Sign in" button in the upper right hand corner to
 sign in with either of them and authenticate organice.
 
 ** Backups
-The first time you push changes from organice back up to your chosen
-sync service, organice will make a backup of the original file first.
-It'll be named {your-file-name}.organice-bak. Dropbox and Google Drive
+Whenever organice loads a file from your chosen sync service, before
+you can make any changes it will first make and push a backup of the
+file, named ={your-file-name}.organice-bak=. Dropbox and Google Drive
 also both keep a full version history of your files for you, but this
 is an additional precaution in case something goes wrong pushing the
 file back up.

--- a/src/actions/base.js
+++ b/src/actions/base.js
@@ -92,6 +92,11 @@ export const setShouldSyncOnBecomingVisibile = (shouldSyncOnBecomingVisibile) =>
   shouldSyncOnBecomingVisibile,
 });
 
+export const setShouldBackup = (shouldBackup) => ({
+  type: 'SET_SHOULD_BACKUP',
+  shouldBackup,
+});
+
 export const setShouldShowTitleInOrgFile = (shouldShowTitleInOrgFile) => ({
   type: 'SET_SHOULD_SHOW_TITLE_IN_ORG_FILE',
   shouldShowTitleInOrgFile,

--- a/src/actions/sync_backend.js
+++ b/src/actions/sync_backend.js
@@ -114,7 +114,9 @@ export const downloadFile = (path) => {
       .then((fileContents) => {
         dispatch(setDirty(false));
         dispatch(hideLoadingMessage());
-        dispatch(pushBackup(path, fileContents));
+        if (getState().base.get('shouldBackup')) {
+          dispatch(pushBackup(path, fileContents));
+        }
         dispatch(setLastSyncAt(addSeconds(new Date(), 5)));
         dispatch(displayFile(path, fileContents));
         dispatch(applyOpennessState());

--- a/src/components/Settings/index.js
+++ b/src/components/Settings/index.js
@@ -19,6 +19,7 @@ const Settings = ({
   shouldStoreSettingsInSyncBackend,
   shouldLiveSync,
   shouldSyncOnBecomingVisibile,
+  shouldBackup,
   shouldShowTitleInOrgFile,
   shouldLogIntoDrawer,
   shouldNotIndentOnExport,
@@ -52,6 +53,8 @@ const Settings = ({
 
   const handleShouldSyncOnBecomingVisibleChange = () =>
     base.setShouldSyncOnBecomingVisibile(!shouldSyncOnBecomingVisibile);
+
+  const handleShouldBackup = () => base.setShouldBackup(!shouldBackup);
 
   const handleShouldShowTitleInOrgFile = () =>
     base.setShouldShowTitleInOrgFile(!shouldShowTitleInOrgFile);
@@ -114,6 +117,19 @@ const Settings = ({
           isEnabled={shouldSyncOnBecomingVisibile}
           onToggle={handleShouldSyncOnBecomingVisibleChange}
         />
+      </div>
+
+      <div className="setting-container">
+        <div className="setting-label">
+          Backup before editing
+          <div className="setting-label__description">
+            If enabled, whenever Organice loads a file from the sync backend,
+            a backup is automatically made by appending{' '}
+            <code>.organice-bak</code> to the filename and pushing it to the
+            backend.
+          </div>
+        </div>
+        <Switch isEnabled={shouldBackup} onToggle={handleShouldBackup} />
       </div>
 
       <div className="setting-container">
@@ -251,6 +267,7 @@ const mapStateToProps = (state, props) => {
     shouldStoreSettingsInSyncBackend: state.base.get('shouldStoreSettingsInSyncBackend'),
     shouldLiveSync: state.base.get('shouldLiveSync'),
     shouldSyncOnBecomingVisibile: state.base.get('shouldSyncOnBecomingVisibile'),
+    shouldBackup: state.base.get('shouldBackup'),
     shouldShowTitleInOrgFile: state.base.get('shouldShowTitleInOrgFile'),
     shouldLogIntoDrawer: state.base.get('shouldLogIntoDrawer'),
     shouldNotIndentOnExport: state.base.get('shouldNotIndentOnExport'),

--- a/src/reducers/base.js
+++ b/src/reducers/base.js
@@ -27,6 +27,8 @@ const setShouldLiveSync = (state, action) => state.set('shouldLiveSync', action.
 const setShouldSyncOnBecomingVisibile = (state, action) =>
   state.set('shouldSyncOnBecomingVisibile', action.shouldSyncOnBecomingVisibile);
 
+const setShouldBackup = (state, action) => state.set('shouldBackup', action.shouldBackup);
+
 const setShouldShowTitleInOrgFile = (state, action) =>
   state.set('shouldShowTitleInOrgFile', action.shouldShowTitleInOrgFile);
 
@@ -133,6 +135,8 @@ export default (state = Map(), action) => {
       return setShouldLiveSync(state, action);
     case 'SET_SHOULD_SYNC_ON_BECOMING_VISIBLE':
       return setShouldSyncOnBecomingVisibile(state, action);
+    case 'SET_SHOULD_BACKUP':
+      return setShouldBackup(state, action);
     case 'SET_SHOULD_SHOW_TITLE_IN_ORG_FILE':
       return setShouldShowTitleInOrgFile(state, action);
     case 'SET_SHOULD_LOG_INTO_DRAWER':

--- a/src/util/settings_persister.js
+++ b/src/util/settings_persister.js
@@ -107,6 +107,13 @@ export const persistableFields = [
   },
   {
     category: 'base',
+    name: 'shouldBackup',
+    type: 'boolean',
+    shouldStoreInConfig: true,
+    default: true,
+  },
+  {
+    category: 'base',
     name: 'shouldShowTitleInOrgFile',
     type: 'boolean',
     shouldStoreInConfig: true,
@@ -209,7 +216,11 @@ export const readInitialState = () => {
         value = null;
       }
     } else if (field.type === 'boolean') {
-      value = value === 'true';
+      if (!value && field.default !== null) {
+        value = field.default;
+      } else {
+        value = value === 'true';
+      }
     } else if (field.type === 'json') {
       if (!value) {
         value = field.default || Map();


### PR DESCRIPTION
Not all users want automatic backup files.  For example, a WebDAV backend which exposes a git repository with external processes handling automatic commit/sync has no need for backups, because there is already full git history.

So add an option to disable this feature.