### PR TITLE
Use findLast() instead of reverse() and find()

### DIFF
--- a/src/lib/org_utils.js
+++ b/src/lib/org_utils.js
@@ -81,8 +81,8 @@ export const parentIdOfHeaderWithId = (headers, headerId) => {
   const header = headerWithId(headers, headerId);
   const headerIndex = indexOfHeaderWithId(headers, headerId);
 
-  const previousHeaders = headers.slice(0, headerIndex).reverse();
-  const parentHeader = previousHeaders.find(
+  const previousHeaders = headers.slice(0, headerIndex);
+  const parentHeader = previousHeaders.findLast(
     (previousHeader) => previousHeader.get('nestingLevel') < header.get('nestingLevel')
   );
 


### PR DESCRIPTION
Doing a `reverse()` just to `find()` the last header matching some predicate is needlessly expensive; so just use `findLast()` instead:

https://immutable-js.github.io/immutable-js/docs/#/List/findLast

Partially addresses #321.