### PR TITLE
Double performance of obtaining header and index for given header id

### DIFF
--- a/src/lib/org_utils.js
+++ b/src/lib/org_utils.js
@@ -31,6 +31,11 @@ export const changelogHash = () => {
   });
 };
 
+export const indexAndHeaderWithId = (headers, headerId) => {
+  const headerIndex = indexOfHeaderWithId(headers, headerId);
+  return { headerIndex, header: headers.get(headerIndex) };
+};
+
 export const indexOfHeaderWithId = (headers, headerId) => {
   return headers.findIndex((header) => header.get('id') === headerId);
 };
@@ -40,8 +45,7 @@ export const headerWithId = (headers, headerId) => {
 };
 
 export const subheadersOfHeaderWithId = (headers, headerId) => {
-  const header = headerWithId(headers, headerId);
-  const headerIndex = indexOfHeaderWithId(headers, headerId);
+  const { header, headerIndex } = indexAndHeaderWithId(headers, headerId);
 
   const afterHeaders = headers.slice(headerIndex + 1);
   const nextSiblingHeaderIndex = afterHeaders.findIndex((siblingHeader) => {
@@ -59,8 +63,7 @@ export const numSubheadersOfHeaderWithId = (headers, headerId) =>
   subheadersOfHeaderWithId(headers, headerId).size;
 
 export const directParentIdOfHeaderWithId = (headers, headerId) => {
-  const header = headerWithId(headers, headerId);
-  const headerIndex = indexOfHeaderWithId(headers, headerId);
+  const { header, headerIndex } = indexAndHeaderWithId(headers, headerId);
 
   for (let i = headerIndex - 1; i >= 0; --i) {
     const previousHeader = headers.get(i);
@@ -78,8 +81,7 @@ export const directParentIdOfHeaderWithId = (headers, headerId) => {
 };
 
 export const parentIdOfHeaderWithId = (headers, headerId) => {
-  const header = headerWithId(headers, headerId);
-  const headerIndex = indexOfHeaderWithId(headers, headerId);
+  const { header, headerIndex } = indexAndHeaderWithId(headers, headerId);
 
   const previousHeaders = headers.slice(0, headerIndex).reverse();
   const parentHeader = previousHeaders.find(

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -24,7 +24,7 @@ import {
 import { attributedStringToRawText } from '../lib/export_org';
 import {
   indexOfHeaderWithId,
-  headerWithId,
+  indexAndHeaderWithId,
   parentIdOfHeaderWithId,
   subheadersOfHeaderWithId,
   numSubheadersOfHeaderWithId,
@@ -78,8 +78,8 @@ const openHeader = (state, action) => {
 const toggleHeaderOpened = (state, action) => {
   const headers = state.get('headers');
 
-  const headerIndex = indexOfHeaderWithId(headers, action.headerId);
-  const isOpened = headerWithId(headers, action.headerId).get('opened');
+  const { header, headerIndex } = indexAndHeaderWithId(headers, action.headerId);
+  const isOpened = header.get('opened');
 
   if (isOpened && state.get('focusedHeaderId') === action.headerId) {
     return state;
@@ -191,8 +191,7 @@ const advanceTodoState = (state, action) => {
   const logIntoDrawer = action.logIntoDrawer;
 
   const headers = state.get('headers');
-  const header = headerWithId(headers, headerId);
-  const headerIndex = indexOfHeaderWithId(headers, headerId);
+  const { header, headerIndex } = indexAndHeaderWithId(headers, headerId);
 
   const currentTodoState = header.getIn(['titleLine', 'todoKeyword']);
   const currentTodoSet = todoKeywordSetForKeyword(state.get('todoKeywordSets'), currentTodoState);
@@ -252,8 +251,7 @@ const updateHeaderDescription = (state, action) => {
 
 const addHeader = (state, action) => {
   const headers = state.get('headers');
-  const header = headerWithId(headers, action.headerId);
-  const headerIndex = indexOfHeaderWithId(headers, action.headerId);
+  const { header, headerIndex } = indexAndHeaderWithId(headers, action.headerId);
 
   const subheaders = subheadersOfHeaderWithId(headers, action.headerId);
 
@@ -276,8 +274,7 @@ const addHeader = (state, action) => {
 
 const selectNextSiblingHeader = (state, action) => {
   const headers = state.get('headers');
-  const header = headerWithId(headers, action.headerId);
-  const headerIndex = indexOfHeaderWithId(headers, action.headerId);
+  const { header, headerIndex } = indexAndHeaderWithId(headers, action.headerId);
   const subheaders = subheadersOfHeaderWithId(headers, action.headerId);
 
   const nextSibling = headers.get(headerIndex + subheaders.size + 1);
@@ -366,8 +363,7 @@ const moveHeaderUp = (state, action) => {
 
 const moveHeaderDown = (state, action) => {
   let headers = state.get('headers');
-  const header = headerWithId(headers, action.headerId);
-  const headerIndex = indexOfHeaderWithId(headers, action.headerId);
+  const { header, headerIndex } = indexAndHeaderWithId(headers, action.headerId);
 
   const subheaders = subheadersOfHeaderWithId(headers, action.headerId);
   const nextSiblingIndex = headerIndex + subheaders.size + 1;
@@ -415,8 +411,7 @@ const moveHeaderRight = (state, action) => {
 
 const moveSubtreeLeft = (state, action) => {
   const headers = state.get('headers');
-  const header = headerWithId(headers, action.headerId);
-  const headerIndex = indexOfHeaderWithId(headers, action.headerId);
+  const { header, headerIndex } = indexAndHeaderWithId(headers, action.headerId);
 
   const previousParentHeaderId = parentIdOfHeaderWithId(headers, action.headerId);
 
@@ -463,8 +458,10 @@ const refileSubtree = (state, action) => {
 
   const { sourceHeaderId, targetHeaderId } = action;
   let headers = state.get('headers');
-  let sourceHeader = headerWithId(headers, sourceHeaderId);
-  const sourceHeaderIndex = indexOfHeaderWithId(headers, sourceHeaderId);
+  let { header: sourceHeader, headerIndex: sourceHeaderIndex } = indexAndHeaderWithId(
+    headers,
+    sourceHeaderId
+  );
   let targetHeaderIndex = indexOfHeaderWithId(headers, targetHeaderId);
 
   // Do not attempt to move a header to itself


### PR DESCRIPTION
Many places in the code had adopted the following pattern:

    const header = headerWithId(headers, headerId);
    const headerIndex = indexOfHeaderWithId(headers, headerId);

However this is twice as slow as necessary, because `headerWithId()` calls `indexOfHeaderWithId()`, and then throws away the result after using it to return the header.

So instead build a single `indexAndHeaderWithId()` function which obtains the index, does an O(1) lookup to obtain the header, then returns an object containing both.

Partially addresses #321.