### PR TITLE
Allow capture templates to insert at beginning or end of file

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -25,13 +25,13 @@ rules:
   no-case-declarations: off
   no-unused-vars:
     - error
-    -
-      varsIgnorePattern: '_.+'
+    - varsIgnorePattern: '_.+'
       argsIgnorePattern: '_.*|reject'
   react/no-unescaped-entities: off
   react/display-name: off
   react/prop-types: off
   react-redux/prefer-separate-component-file: off
+  jest/no-disabled-tests: off
 settings:
   react:
     version: detect

--- a/README.org
+++ b/README.org
@@ -544,7 +544,7 @@ templates. They should be in the format ~captureVariable_<your custom
 variable>~, and should also be URL encoded. In your capture template
 they'd show up as ~%<your custom variable>~.
 
-Organice allows you to specify where the captured content will be
+organice allows you to specify where the captured content will be
 inserted, via a "header path" which is a list of headers to match.  If
 the list is empty, the content will be inserted at the end of the
 file, or the beginning if the prepend option is selected.

--- a/README.org
+++ b/README.org
@@ -544,8 +544,10 @@ templates. They should be in the format ~captureVariable_<your custom
 variable>~, and should also be URL encoded. In your capture template
 they'd show up as ~%<your custom variable>~.
 
-Important: At this point, organice assumes that you'll capture your
-entries into a header - hence, you'll have to specify a "header path".
+Organice allows you to specify where the captured content will be
+inserted, via a "header path" which is a list of headers to match.  If
+the list is empty, the content will be inserted at the end of the
+file, or the beginning if the prepend option is selected.
 
 ** Examples
 *** Simple: Capture a string

--- a/changelog.org
+++ b/changelog.org
@@ -6,6 +6,11 @@ When there are updates to the changelog, you will be notified and see a 'gift' i
 
 
 
+
+* [2020-06-14 Sun]
+** Added
+   - Allow capture templates to insert at beginning or end of file
+     - Thank you [[https://github.com/aspiers][aspiers]] for your [[https://github.com/200ok-ch/organice/pull/324][PR]] 🙏
 * [2020-06-05 Fri]
 ** Fixed
    - =file:= links are sanity checked before opened

--- a/sample.org
+++ b/sample.org
@@ -205,7 +205,7 @@ organice supports something like org-capture in the form of customizable, quickl
 
 Click the button in the bottom right corner of the screen to see some examples. The first button, the lemon, will create a new entry in the "Groceries" list below this. The second button adds an entry to a more deeply nested header.
 
-Once signed in, you can set up capture templates that specify header paths (and various other configurations). These capture templates can also sync between your devices (if you enable settings sync).
+Once signed in, you can set up capture templates that specify header paths (and various other configurations). If the list is empty, the content will be inserted at the end of the file, or the beginning if the prepend option is selected. These capture templates will sync between your devices if you enable settings sync.
 ** Groceries
 ** Deeply
 *** Nested

--- a/src/components/OrgFile/components/CaptureModal/index.js
+++ b/src/components/OrgFile/components/CaptureModal/index.js
@@ -22,10 +22,13 @@ export default ({ template, onCapture, headers, onClose }) => {
     [template]
   );
 
-  const targetHeader = useMemo(() => headerWithPath(headers, template.get('headerPaths')), [
-    headers,
-    template,
-  ]);
+  const targetHeader = useMemo(
+    () =>
+      template.get('headerPaths').size === 0
+        ? 'FILE'
+        : headerWithPath(headers, template.get('headerPaths')),
+    [headers, template]
+  );
 
   const [textareaValue, setTextareaValue] = useState(substitutedTemplate);
   const [shouldPrepend, setShouldPrepend] = useState(template.get('shouldPrepend'));

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -46,8 +46,14 @@ describe('org reducer', () => {
 
       // "PROJECT Foo" is the 10th item, "A nested header" the 2nd,
       // but we count from 0 not 1.
-      sourceHeaderId = state.org.present.get('headers').get(9).get('id');
-      targetHeaderId = state.org.present.get('headers').get(1).get('id');
+      sourceHeaderId = state.org.present
+        .get('headers')
+        .get(9)
+        .get('id');
+      targetHeaderId = state.org.present
+        .get('headers')
+        .get(1)
+        .get('id');
     });
 
     it('should handle REFILE_SUBTREE', () => {
@@ -171,6 +177,9 @@ describe('org reducer', () => {
       expect(last.get('rawDescription')).toEqual('Some description\n');
     });
 
+    // FIXME: This test works, but only when run with `.only`. There
+    // must be some racing condition or some mutable state involved,
+    // because it does not run together with the other tests.
     it.skip('is undoable', () => {
       const oldState = store.getState().org.present;
       store.dispatch({
@@ -181,7 +190,6 @@ describe('org reducer', () => {
         dirtying: true,
       });
       expect(store.getState().org.present).not.toEqual(oldState);
-      // FIXME: This does not do the undo for some weird reason
       store.dispatch({ type: ActionTypes.UNDO });
       expect(store.getState().org.present).toEqual(oldState);
     });

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -16,6 +16,20 @@ describe('org reducer', () => {
 
   const testOrgFile = readFixture('main_test_file');
 
+  // Given a `header`, return its `title` and `nestingLevel`.
+  function extractTitleAndNesting(header) {
+    return [header.getIn(['titleLine', 'rawTitle']), header.get('nestingLevel')];
+  }
+
+  // Given some `headers`, return their `title`s and `nestingLevel`s.
+  function extractTitlesAndNestings(headers) {
+    return headers
+      .map((header) => {
+        return extractTitleAndNesting(header);
+      })
+      .toJS();
+  }
+
   beforeEach(() => {
     state = fromJS(readInitialState());
     state = state.setIn(['org', 'present'], parseOrg(testOrgFile));
@@ -44,18 +58,9 @@ describe('org reducer', () => {
     });
 
     it('should handle REFILE_SUBTREE', () => {
-      // Given some `headers`, return their `title`s and `nestingLevel`s.
-      function extractTitleAndNesting(headers) {
-        return headers
-          .map((header) => {
-            return [header.getIn(['titleLine', 'rawTitle']), header.get('nestingLevel')];
-          })
-          .toJS();
-      }
-
       // Mapping the headers to their nesting level. This is how the
       // initially parsed file should look like.
-      expect(extractTitleAndNesting(state.getIn(['org', 'present', 'headers']))).toEqual([
+      expect(extractTitlesAndNestings(state.getIn(['org', 'present', 'headers']))).toEqual([
         ['Top level header', 1],
         ['A nested header', 2],
         ['A todo item with schedule and deadline', 2],
@@ -78,7 +83,7 @@ describe('org reducer', () => {
 
       // PROJECT Foo is now beneath "A nested header" and is
       // appropriately indented.
-      expect(extractTitleAndNesting(newState.get('headers'))).toEqual([
+      expect(extractTitlesAndNestings(newState.get('headers'))).toEqual([
         ['Top level header', 1],
         ['A nested header', 2],
         ['PROJECT Foo', 3],

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -6,7 +6,7 @@ import { parseOrg } from '../lib/parse_org';
 import { readInitialState } from '../util/settings_persister';
 
 import { createStore } from 'redux';
-import undoable from 'redux-undo';
+import undoable, { ActionTypes } from 'redux-undo';
 
 import readFixture from '../../test_helpers/index';
 
@@ -101,7 +101,7 @@ describe('org reducer', () => {
       const oldState = store.getState().present;
       store.dispatch({ type: 'REFILE_SUBTREE', sourceHeaderId, targetHeaderId, dirtying: true });
       expect(store.getState().present).not.toEqual(oldState);
-      store.dispatch({ type: '@@redux-undo/UNDO' });
+      store.dispatch({ type: ActionTypes.UNDO });
       expect(store.getState().present).toEqual(oldState);
     });
   });

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -74,10 +74,8 @@ describe('org reducer', () => {
         ['A header with a custom todo sequence in DONE state', 1],
       ]);
 
-      const newState = reducer(
-        state.getIn(['org', 'present']),
-        types.refileSubtree(sourceHeaderId, targetHeaderId)
-      );
+      const action = types.refileSubtree(sourceHeaderId, targetHeaderId);
+      const newState = reducer(state.getIn(['org', 'present']), action);
 
       // PROJECT Foo is now beneath "A nested header" and is
       // appropriately indented.

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -34,8 +34,6 @@ describe('org reducer', () => {
     state = state.setIn(['org', 'present'], parseOrg(testOrgFile));
   });
 
-  describe('undo/redo', () => {});
-
   describe('REFILE_SUBTREE', () => {
     let sourceHeaderId, targetHeaderId;
 

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -12,7 +12,6 @@ import readFixture from '../../test_helpers/index';
 
 describe('org reducer', () => {
   let state;
-  let store;
 
   const testOrgFile = readFixture('main_test_file');
 
@@ -33,7 +32,6 @@ describe('org reducer', () => {
   beforeEach(() => {
     state = fromJS(readInitialState());
     state = state.setIn(['org', 'present'], parseOrg(testOrgFile));
-    store = createStore(undoable(reducer), state.getIn(['org', 'present']));
   });
 
   describe('undo/redo', () => {});
@@ -101,6 +99,7 @@ describe('org reducer', () => {
     });
 
     it('is undoable', () => {
+      const store = createStore(undoable(reducer), state.getIn(['org', 'present']));
       const oldState = store.getState().present;
       store.dispatch({ type: 'REFILE_SUBTREE', sourceHeaderId, targetHeaderId, dirtying: true });
       expect(store.getState().present).not.toEqual(oldState);


### PR DESCRIPTION
~~Currently based on #344 (eslint PR) so that I can use eslint to verify the changes are clean.~~ **Now rebased**

If no headers are in the header path list, insert at the end of the file, or the beginning if the Prepend option is set.

Lightly tested.