### PR TITLE
doc: WebDAV test setup

### DIFF
--- a/README.org
+++ b/README.org
@@ -460,22 +460,6 @@ of synchronization backends: Client/Server services [[https://doc.owncloud.com/s
 [[https://docs.nextcloud.com/server/stable/user_manual/files/access_webdav.html?highlight=webdav][Nextcloud]] and [[https://download.seafile.com/published/seafile-manual/extension/webdav.md][Seafile]], but also self hosted dedicated WebDAV servers
 like [[https://httpd.apache.org/docs/2.4/mod/mod_dav.html][Apache]] or [[https://nginx.org/en/docs/http/ngx_http_dav_module.html][Nginx]].
 
-Since organice is a front-end application, it will login with
-JavaScript from within the browser - in turn the [[https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS][Cross-Origin Resource
-Sharing (CORS)]] headers must be set appropriately. If they are not set,
-you will not be able to login to your service from a browser.
-Alternatively, if you're using a server like Apache or Nginx, you can
-simply get around CORS by hosting organice on the same domain as your
-service.
-
-Please note, that when your back-end does not set the correct CORS
-headers, organice cannot show you a really semantic error message on
-that. The reason is that browsers [[https://www.w3.org/TR/cors/#handling-a-response-to-a-cross-origin-request][hide this information]] from
-JavaScript. You will simply get a network error. However, you can
-easily debug it yourself by looking into the JavaScript console. No
-worries, you don't have to be a (JavaScript) developer to find out
-about that - here's a [[https://github.com/200ok-ch/organice/wiki#missing-cors-headers][screencast in the Wiki]] to show you how to do it.
-
 **** More information
 
 In the [[https://github.com/200ok-ch/organice/wiki#webdav][Wiki]], you'll find lots more information regarding WebDAV:

--- a/WIKI.org
+++ b/WIKI.org
@@ -52,79 +52,80 @@ to your Dropbox, here are your options:
 
  [[https://github.com/200ok-ch/organice/wiki/videos/demo-webdav.gif]]
 
-*** Missing CORS headers
+*** WebDAV test server
 
- If your back-end doesn't have the necessary CORS headers set (more
- info in the [[https://github.com/200ok-ch/organice/blob/master/README.org][README]], this is what the error will look like:
+For testing purposes, we use a Docker image with a proven and well
+documented server: Apache2 running on Debian. You can build the Docker
+image yourself - and customize the Apache configuration to your needs:
 
- [[https://github.com/200ok-ch/organice/wiki/videos/demo-webdav-failing-cors.gif]]
+#+BEGIN_SRC shell
+docker build -f doc/webdav/Dockerfile -t apache-webdav .
+#+END_SRC
 
-*** Setup your own WebDAV Server with Apache2 on Debian
+Then run the Apache2 WebDAV server with:
 
- For testing purposes, here are the instructions to setup WebDAV
- locally on your machine using Apache2 using Debian. These instructions
- are not meant to be used in production, though.
+#+BEGIN_SRC shell
+docker run -dit --name apache-webdav-app -p 8080:80 apache-webdav
+#+END_SRC
 
- *Initial package installation*
+On your host machine, you can now login with any WebDAV client using
+the URL =http://localhost:8080/webdav=. There is no authentication
+configuration, so any user account works (including omitted user
+accounts). It goes without saying that if you wanted to use this for
+production, please enable authentication. Within the test image,
+you'll find the [[file:sample.org][sample.org]] file, so you can get started developing and
+testing right away.
 
- #+BEGIN_SRC shell
- sudo apt -y install apache2-utils apache2
- #+END_SRC
+For testing WebDAV outside of organice, and you're an Emacs user, you
+can open [[/dav:localhost#8080:/webdav/][this]] link (=C-c C-o=). Then, you will get a [[https://www.gnu.org/software/tramp/][TRAMP]] session
+with [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Dired.html][dired]] open and you'll see the sample file. You can interact with
+it like in any other dired buffer.
 
- *Set up a new vhost for webdav*
+If you prefer a command line client, you could use [[https://linux.die.net/man/1/cadaver][cadaver]]. Install and use
+it like this:
 
- =/etc/apache2/sites-available/webdav.conf=
+#+BEGIN_SRC shell
+sudo apt -y install cadaver
+cadaver http://localhost:8080/webdav/
+#+END_SRC
 
- #+BEGIN_EXAMPLE
- Alias /webdav /srv/dav/
+**** Bug reports
+     :PROPERTIES:
+     :CUSTOM_ID: webdav_bug_reports
+     :END:
 
- RewriteEngine On
- RewriteCond %{REQUEST_METHOD} OPTIONS
- RewriteRule ^(.*)$ $1 [R=200,L]
+If you have any trouble connecting to WebDAV using organice, it could
+be your setup (please consult [[#webdav_cors][CORS]] and [[#webdav_gotchas][Gotchas with WebDAV]]). In any
+case, if you want to open a bug report, please document your issue by
+referencing how it doesn't work using the official WebDAV test server.
 
- <Location /webdav>
-     Options Indexes
-     DAV On
-     AuthType Basic
-     AuthName "webdav"
-     AuthUserFile /srv/dav/.htpasswd
-     Require valid-user
+*** CORS
+    :PROPERTIES:
+    :CUSTOM_ID: webdav_cors
+    :END:
 
-     Header always set Access-Control-Allow-Origin "*"
-     Header always set Access-Control-Allow-Methods "GET,POST,OPTIONS,DELETE,PUT,PROPFIND"
-     Header always set Access-Control-Allow-Headers "Origin,Accept,X-Requested-With,Content-Type,Access-Control-Request-Method,Access-Control-Request-Headers,Authorization,X-CSRF-Token,Depth"
-     Header always set Access-Control-Allow-Credentials true
+Since organice is a front-end application, it will login with
+JavaScript from within the browser - in turn the [[https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS][Cross-Origin Resource
+Sharing (CORS)]] headers must be set appropriately. If they are not set,
+you will not be able to login to your service from a browser.
+Alternatively, if you're using a server like Apache or Nginx, you can
+simply get around CORS by hosting organice on the same domain as your
+service.
 
-     Require all granted
- </location>
- #+END_EXAMPLE
+Please note, that when your back-end does not set the correct CORS
+headers, organice cannot show you a really semantic error message on
+that. The reason is that browsers [[https://www.w3.org/TR/cors/#handling-a-response-to-a-cross-origin-request][hide this information]] from
+JavaScript. You will simply get a network error. However, you can
+easily debug it yourself by looking into the JavaScript console. No
+worries, you don't have to be a (JavaScript) developer to find out
+about that - here's a screencast showing you how to do it:
 
- *Enable Apache modules*
-
- #+BEGIN_SRC shell
- sudo a2enmod headers
- sudo a2enmod dav*
- sudo a2enmod rewrite
- sudo a2ensite webdav
- #+END_SRC
-
- *Setup folder, password and rights*
-
- #+BEGIN_SRC shell
- sudo mkdir /srv/dav
- sudo htpasswd -c /srv/dav/.htpasswd webdav
- sudo chmod 770 /srv/dav; sudo chown www-data. /srv/dav
- sudo service apache2 restart
- #+END_SRC
-
- *Test webdav access using a commandline tool*
-
- #+BEGIN_SRC shell
- sudo apt -y install cadaver
- cadaver http://localhost/webdav/
- #+END_SRC
+[[https://github.com/200ok-ch/organice/wiki/videos/demo-webdav-failing-cors.gif]]
 
 *** Gotchas with WebDAV
+    :PROPERTIES:
+    :CUSTOM_ID: webdav_gotchas
+    :END:
 
 **** =preflight request doesn't pass access control check= error
 

--- a/doc/webdav/Dockerfile
+++ b/doc/webdav/Dockerfile
@@ -1,0 +1,24 @@
+FROM debian:buster-slim
+
+RUN apt-get update -y -qq && \
+        apt-get install -y -qq \
+        apache2-utils \
+        apache2
+
+ADD doc/webdav/webdav.conf /etc/apache2/sites-available/webdav.conf
+
+RUN a2enmod headers
+RUN a2enmod dav*
+RUN a2enmod rewrite
+RUN a2ensite webdav
+
+
+RUN mkdir /srv/dav
+# RUN echo demo | htpasswd -ci /srv/dav/.htpasswd demo
+RUN chmod 770 /srv/dav
+RUN chown www-data. /srv/dav
+
+COPY sample.org /srv/dav
+
+CMD apachectl -D FOREGROUND
+EXPOSE 80

--- a/doc/webdav/webdav.conf
+++ b/doc/webdav/webdav.conf
@@ -1,0 +1,21 @@
+Alias /webdav /srv/dav/
+
+RewriteEngine On
+RewriteCond %{REQUEST_METHOD} OPTIONS
+RewriteRule ^(.*)$ $1 [R=200,L]
+
+<Location "/webdav">
+    Options Indexes
+    DAV On
+    # AuthType Basic
+    # AuthName "Restricted Content"
+    # AuthUserFile /srv/dav/.htpasswd
+    # Require valid-user
+
+    Header always set Access-Control-Allow-Origin "*"
+    Header always set Access-Control-Allow-Methods "GET,POST,OPTIONS,DELETE,PUT,PROPFIND"
+    Header always set Access-Control-Allow-Headers "Origin,Accept,X-Requested-With,Content-Type,Access-Control-Request-Method,Access-Control-Request-Headers,Authorization,X-CSRF-Token,Depth"
+    Header always set Access-Control-Allow-Credentials true
+
+    Require all granted
+</Location>


### PR DESCRIPTION
At this time, I cannot test any new proposed WebDAV configuration. When I wrote the original docs, I did set this up locally, so that I could test WebDAV. Since then, I have switched computers and haven't set this up, again.


The best way to move forward would likely be to create this Apache setup in a `Dockerfile`. I've been thinking of doing that for some time now. It would ease a lot of discussions on the topic of WebDAV. Right now, everyone is using some very specific setup (NextCloud, HA Proxy, Apache, etc) and it's not really possible to give support for that. Such Ops topics are way out of scope of a SPA project. If we had an official example Docker container that works for us and we use in development, we can always point to that one.