### PR TITLE
Ensure non-zero exit code if compile_doc.sh fails

### DIFF
--- a/bin/compile_doc_and_upload.sh
+++ b/bin/compile_doc_and_upload.sh
@@ -6,4 +6,5 @@ if $here/compile_doc.sh; then
     lftp -e "put documentation.html; exit" -u $FTP_USER,$FTP_PASSWD $FTP_HOST
 else
     echo >&2 "compile_doc.sh failed; skipping upload"
+    exit 1
 fi


### PR DESCRIPTION
This is particularly important for CircleCI's deploy phase, otherwise it incorrectly thinks that `compile_doc_and_upload.sh` has succeeded when it hasn't.