### PR TITLE
Increase the test coverage for src/reducer/org.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "start": "./bin/compile_search_parser.sh && react-scripts start",
     "build": "./bin/compile_search_parser.sh && react-scripts build",
     "test": "./bin/compile_search_parser.sh && react-scripts test --env=jsdom",
+    "coverage": "./bin/compile_search_parser.sh && react-scripts test --env=jsdom --coverage --watchAll=false",
     "eslint": "./node_modules/.bin/eslint --cache .",
     "nibble": "./node_modules/.bin/eslint-nibble --cache .",
     "prettier": "./node_modules/.bin/prettier \"**/*.js\"",
@@ -54,6 +55,11 @@
     "prettier-eslint-cli": "^5.0.0",
     "raw.macro": "0.3.1",
     "react-test-renderer": "^16.13.1"
+  },
+  "jest": {
+    "coverageReporters": [
+      "text"
+    ]
   },
   "browserslist": [
     ">0.2%",

--- a/src/actions/org.js
+++ b/src/actions/org.js
@@ -485,6 +485,13 @@ export const reorderPropertyList = (fromIndex, toIndex) => (dispatch, getState) 
     dirtying: true,
   });
 
+/**
+ * Action to change the timestamp using a cross-cutting id.
+ *
+ * @param {*} timestampId cross-cutting id of the timestamp (might be in the title or description).
+ * @param {*} newTimestamp the new value for the timestamp;
+ *                         must have the form: {id:, type:, firstTimestamp:, secondTimestamp:}.
+ */
 export const updateTimestampWithId = (timestampId, newTimestamp) => ({
   type: 'UPDATE_TIMESTAMP_WITH_ID',
   timestampId,

--- a/src/lib/timestamps.js
+++ b/src/lib/timestamps.js
@@ -48,8 +48,10 @@ export const renderAsText = (timestamp) => {
 };
 
 export const getCurrentTimestamp = ({ isActive = true, withStartTime = false } = {}) => {
-  const time = new Date();
+  return timestampForDate(new Date(), { isActive, withStartTime });
+};
 
+export const timestampForDate = (time, { isActive = true, withStartTime = false } = {}) => {
   const timestamp = {
     isActive,
     year: format(time, 'yyyy'),

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -816,6 +816,8 @@ const updateParentListCheckboxes = (state, itemPath) => {
           return false;
         case 'partial':
           return false;
+        default:
+          return false;
       }
     })
     .toJS();

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -368,7 +368,7 @@ const moveHeaderDown = (state, action) => {
   const subheaders = subheadersOfHeaderWithId(headers, action.headerId);
   const nextSiblingIndex = headerIndex + subheaders.size + 1;
   const nextSibling = headers.get(nextSiblingIndex);
-  if (nextSibling.get('nestingLevel') < header.get('nestingLevel')) {
+  if (!nextSibling || nextSibling.get('nestingLevel') < header.get('nestingLevel')) {
     return state;
   }
 

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -785,7 +785,7 @@ const clearPendingCapture = (state) => state.set('pendingCapture', null);
 const updateParentListCheckboxes = (state, itemPath) => {
   const parentListItemPath = itemPath.slice(0, itemPath.length - 4);
   const parentListItem = state.getIn(parentListItemPath);
-  if (!parentListItem.has('checkboxState')) {
+  if (!parentListItem.get('isCheckbox')) {
     return state;
   }
 
@@ -816,8 +816,6 @@ const updateParentListCheckboxes = (state, itemPath) => {
           return false;
         case 'partial':
           return false;
-        default:
-          return false;
       }
     })
     .toJS();
@@ -826,11 +824,7 @@ const updateParentListCheckboxes = (state, itemPath) => {
     updateCookiesInAttributedStringWithChildCompletionStates(titleLine, childCompletionStates)
   );
 
-  if (parentListItem.get('isCheckbox')) {
-    return updateParentListCheckboxes(state, parentListItemPath);
-  } else {
-    return state;
-  }
+  return updateParentListCheckboxes(state, parentListItemPath);
 };
 
 const advanceCheckboxState = (state, action) => {

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -1095,4 +1095,90 @@ describe('org reducer', () => {
       check_is_undoable_on_table(store, cellId, types.moveTableColumnLeft());
     });
   });
+
+  describe('MOVE_TABLE_ROW_UP', () => {
+    let state;
+    let store;
+    let cellId;
+    const testOrgFile = readFixture('table');
+
+    beforeEach(() => {
+      state = readInitialState();
+      state.org.present = parseOrg(testOrgFile);
+      cellId = firstTable(state.org.present.getIn(['headers', 0, 'description'])).getIn([
+        'contents',
+        1,
+        'contents',
+        1,
+        'id',
+      ]);
+      store = createStore(undoable(reducer), state.org.present);
+    });
+
+    it('should handle MOVE_TABLE_ROW_UP', () => {
+      const oldState = store.getState().present;
+      store.dispatch({ type: 'SET_SELECTED_TABLE_CELL_ID', cellId });
+      const stateCellSelected = store.getState().present;
+      const newState = reducer(stateCellSelected, types.moveTableRowUp());
+      const check_kept = check_kept_factory(state.org.present, newState);
+
+      expect(
+        firstTable(newState.getIn(['headers', 0, 'description'])).getIn(['contents', 0])
+      ).toEqual(firstTable(oldState.getIn(['headers', 0, 'description'])).getIn(['contents', 1]));
+      expect(
+        firstTable(newState.getIn(['headers', 0, 'description'])).getIn(['contents', 1])
+      ).toEqual(firstTable(oldState.getIn(['headers', 0, 'description'])).getIn(['contents', 0]));
+      check_kept((st) =>
+        firstTable(st.getIn(['headers', 0, 'description'])).getIn(['contents', 2])
+      );
+      check_kept((st) => firstTable(st.getIn(['headers', 0, 'description'])).get('size'));
+    });
+
+    it('is undoable', () => {
+      check_is_undoable_on_table(store, cellId, types.moveTableRowUp());
+    });
+  });
+
+  describe('MOVE_TABLE_ROW_DOWN', () => {
+    let state;
+    let store;
+    let cellId;
+    const testOrgFile = readFixture('table');
+
+    beforeEach(() => {
+      state = readInitialState();
+      state.org.present = parseOrg(testOrgFile);
+      cellId = firstTable(state.org.present.getIn(['headers', 0, 'description'])).getIn([
+        'contents',
+        1,
+        'contents',
+        1,
+        'id',
+      ]);
+      store = createStore(undoable(reducer), state.org.present);
+    });
+
+    it('should handle MOVE_TABLE_ROW_DOWN', () => {
+      const oldState = store.getState().present;
+      store.dispatch({ type: 'SET_SELECTED_TABLE_CELL_ID', cellId });
+      const stateCellSelected = store.getState().present;
+      const newState = reducer(stateCellSelected, types.moveTableRowDown());
+      const check_kept = check_kept_factory(state.org.present, newState);
+
+      expect(
+        firstTable(newState.getIn(['headers', 0, 'description'])).getIn(['contents', 2])
+      ).toEqual(firstTable(oldState.getIn(['headers', 0, 'description'])).getIn(['contents', 1]));
+      expect(
+        firstTable(newState.getIn(['headers', 0, 'description'])).getIn(['contents', 1])
+      ).toEqual(firstTable(oldState.getIn(['headers', 0, 'description'])).getIn(['contents', 2]));
+      check_kept((st) =>
+        firstTable(st.getIn(['headers', 0, 'description'])).getIn(['contents', 0])
+      );
+      check_kept((st) => firstTable(st.getIn(['headers', 0, 'description'])).get('size'));
+    });
+
+    it('is undoable', () => {
+      check_is_undoable_on_table(store, cellId, types.moveTableRowDown());
+    });
+  });
 });

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -67,6 +67,12 @@ describe('org reducer', () => {
     expect(store.getState().present).toEqual(oldState);
   }
 
+  function check_just_dirtying(oldState, action) {
+    const justDirty = reducer(oldState, types.setDirty(true));
+    const newState = reducer(oldState, action);
+    expect(newState).toEqual(justDirty);
+  }
+
   function check_kept_factory(oldState, newState) {
     return (query) => {
       expect(query(oldState)).toEqual(query(newState));
@@ -383,11 +389,8 @@ describe('org reducer', () => {
       ]);
     });
 
-    it('should do nothing if already on the bottom', () => {
-      const justDirty = reducer(state.org.present, types.setDirty(true));
-      const action = types.moveHeaderDown(nestedHeader2Id);
-      const newState = reducer(state.org.present, action);
-      expect(newState).toEqual(justDirty);
+    it('should just dirty if already on the bottom', () => {
+      check_just_dirtying(state.org.present, types.moveHeaderDown(nestedHeader2Id));
     });
 
     it('is undoable', () => {
@@ -434,11 +437,8 @@ describe('org reducer', () => {
       ]);
     });
 
-    it('should do nothing if already at the top', () => {
-      const justDirty = reducer(state.org.present, types.setDirty(true));
-      const action = types.moveHeaderUp(nestedHeaderId);
-      const newState = reducer(state.org.present, action);
-      expect(newState).toEqual(justDirty);
+    it('should just dirty if already at the top', () => {
+      check_just_dirtying(state.org.present, types.moveHeaderUp(nestedHeaderId));
     });
 
     it('is undoable', () => {
@@ -872,10 +872,7 @@ describe('org reducer', () => {
     });
 
     it('should just dirty when trying to update invalid id', () => {
-      const oldState = state.org.present;
-      const justDirty = reducer(oldState, types.setDirty(true));
-      const newState = reducer(oldState, types.updateTimestampWithId(invalidId, 'dummy'));
-      expect(newState).toEqual(justDirty);
+      check_just_dirtying(state.org.present, types.updateTimestampWithId(invalidId, 'dummy'));
     });
   });
 
@@ -921,16 +918,13 @@ describe('org reducer', () => {
     });
 
     it('should just dirty when working with invalid header id', () => {
-      const oldState = state.org.present;
-      const justDirty = reducer(oldState, types.setDirty(true));
-      const newState = reducer(oldState, {
+      check_just_dirtying(state.org.present, {
         type: 'REORDER_PROPERTY_LIST',
         fromIndex,
         toIndex,
         invalidId,
         dirtying: true,
       });
-      expect(newState).toEqual(justDirty);
     });
   });
 
@@ -968,10 +962,8 @@ describe('org reducer', () => {
     });
 
     it('should just dirty when working with invalid header id', () => {
-      const oldState = reducer(state.org.present, { type: 'SELECT_HEADER', invalidId });
-      const justDirty = reducer(oldState, types.setDirty(true));
-      const newState = reducer(oldState, types.reorderTags(fromIndex, toIndex));
-      expect(newState).toEqual(justDirty);
+      const selectedState = reducer(state.org.present, { type: 'SELECT_HEADER', invalidId });
+      check_just_dirtying(selectedState, types.reorderTags(fromIndex, toIndex));
     });
   });
 
@@ -1002,10 +994,7 @@ describe('org reducer', () => {
     });
 
     it('should just dirty when working with invalid header id', () => {
-      const oldState = state.org.present;
-      const justDirty = reducer(oldState, types.setDirty(true));
-      const newState = reducer(oldState, types.setHeaderTags(invalidId, tags));
-      expect(newState).toEqual(justDirty);
+      check_just_dirtying(state.org.present, types.setHeaderTags(invalidId, tags));
     });
   });
 
@@ -1122,10 +1111,7 @@ describe('org reducer', () => {
     });
 
     it('should just dirty when checkbox is a nest header', () => {
-      const oldState = state.org.present;
-      const justDirty = reducer(oldState, types.setDirty(true));
-      const newState = reducer(oldState, types.advanceCheckboxState(compoundBoxE));
-      expect(newState).toEqual(justDirty);
+      check_just_dirtying(state.org.present, types.advanceCheckboxState(compoundBoxE));
     });
 
     it('should check the parent boxes and update cookies when complete', () => {
@@ -1248,6 +1234,10 @@ describe('org reducer', () => {
       check_kept((st) => firstTable(st).get('contents').size);
     });
 
+    it('should just dirty on move with no cell selected', () => {
+      check_just_dirtying(store.getState().present, types.moveTableColumnRight());
+    });
+
     it('is undoable', () => {
       check_is_undoable_on_table(store, cellId, types.moveTableColumnRight());
     });
@@ -1286,6 +1276,10 @@ describe('org reducer', () => {
       check_kept((st) => firstTable(st).get('contents').size);
     });
 
+    it('should just dirty on move with no cell selected', () => {
+      check_just_dirtying(store.getState().present, types.moveTableColumnLeft());
+    });
+
     it('is undoable', () => {
       check_is_undoable_on_table(store, cellId, types.moveTableColumnLeft());
     });
@@ -1321,6 +1315,10 @@ describe('org reducer', () => {
       check_kept((st) => firstTable(st).get('contents').size);
     });
 
+    it('should just dirty on move with no cell selected', () => {
+      check_just_dirtying(store.getState().present, types.moveTableRowUp());
+    });
+
     it('is undoable', () => {
       check_is_undoable_on_table(store, cellId, types.moveTableRowUp());
     });
@@ -1354,6 +1352,10 @@ describe('org reducer', () => {
       );
       check_kept((st) => firstTable(st).getIn(['contents', 0]));
       check_kept((st) => firstTable(st).get('contents').size);
+    });
+
+    it('should just dirty on move with no cell selected', () => {
+      check_just_dirtying(store.getState().present, types.moveTableRowDown());
     });
 
     it('is undoable', () => {
@@ -1392,6 +1394,11 @@ describe('org reducer', () => {
       });
       check_kept((st) => firstTable(st).get('contents').size);
     });
+
+    it('should just dirty on remove with no cell selected', () => {
+      check_just_dirtying(store.getState().present, types.removeTableColumn());
+    });
+
     it('is undoable', () => {
       check_is_undoable_on_table(store, cellId, types.removeTableColumn());
     });
@@ -1426,6 +1433,10 @@ describe('org reducer', () => {
       );
 
       check_kept((st) => firstTable(st).getIn(['contents', 0]));
+    });
+
+    it('should just dirty on remove with no cell selected', () => {
+      check_just_dirtying(store.getState().present, types.removeTableRow());
     });
 
     it('is undoable', () => {
@@ -1466,6 +1477,10 @@ describe('org reducer', () => {
       check_kept((st) => firstTable(st).get('contents').size);
     });
 
+    it('should just dirty on add with no cell selected', () => {
+      check_just_dirtying(store.getState().present, types.addNewTableColumn());
+    });
+
     it('is undoable', () => {
       check_is_undoable_on_table(store, cellId, types.addNewTableColumn());
     });
@@ -1500,6 +1515,10 @@ describe('org reducer', () => {
       expect(firstTable(newState).getIn(['contents']).size).toEqual(
         firstTable(oldState).getIn(['contents']).size + 1
       );
+    });
+
+    it('should just dirty on add with no cell selected', () => {
+      check_just_dirtying(store.getState().present, types.addNewTableRow());
     });
 
     it('is undoable', () => {

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -609,4 +609,43 @@ describe('org reducer', () => {
       check_kept((st) => headerWithId(st.get('headers'), headerId).get('logBookEntries'));
     });
   });
+
+  describe('UPDATE_PLANING_ITEM_TIMESTAMP', () => {
+    let headerId;
+    let state;
+    const testOrgFile = readFixture('schedule');
+    const date = new Date(98, 1);
+    const ts = timestampForDate(date, { isActive: true, withStartTime: true });
+
+    beforeEach(() => {
+      state = readInitialState();
+      state.org.present = parseOrg(testOrgFile);
+      headerId = state.org.present.get('headers').get(0).get('id');
+    });
+
+    it('should handle UPDATE_PLANING_ITEM_TIMESTAMP', () => {
+      const newState = reducer(
+        state.org.present,
+        types.updatePlanningItemTimestamp(headerId, 0, ts)
+      );
+      expect(
+        headerWithId(newState.get('headers'), headerId).get('planningItems').get(0).get('type')
+      ).toEqual('SCHEDULED');
+
+      expect(
+        headerWithId(newState.get('headers'), headerId).get('planningItems').get(0).get('timestamp')
+      ).toEqual(ts);
+
+      const check_kept = check_kept_factory(state.org.present, newState);
+      check_kept((st) => st.get('headers').size);
+      check_kept((st) => headerWithId(st.get('headers'), headerId).get('planningItems').size);
+      check_kept((st) =>
+        headerWithId(st.get('headers'), headerId).getIn(['titleLine', 'rawTitle'])
+      );
+      check_kept((st) =>
+        headerWithId(st.get('headers'), headerId).getIn(['titleLine', 'todoKeyword'])
+      );
+      check_kept((st) => headerWithId(st.get('headers'), headerId).get('logBookEntries'));
+    });
+  });
 });

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -1212,4 +1212,18 @@ describe('org reducer', () => {
       check_is_undoable_on_table(store, cellId, types.addNewTableRow());
     });
   });
+
+  describe('FOCUS_HEADER', () => {
+    let state;
+    const headerId = generateId();
+
+    beforeEach(() => {
+      state = readInitialState();
+    });
+
+    it('should handle FOCUS_HEADER', () => {
+      const newState = reducer(state.org.present, types.focusHeader(headerId));
+      expect(newState.get('focusedHeaderId')).toEqual(headerId);
+    });
+  });
 });

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -780,4 +780,30 @@ describe('org reducer', () => {
       check_kept((st) => headerWithId(st.get('headers'), headerId).get('description'));
     });
   });
+
+  describe('SET_HEADER_TAGS', () => {
+    let irrelevantHeaderId;
+    let state;
+    const testOrgFile = readFixture('more_tags');
+    const tags = fromJS(['ta', 't1', 'spec_tag']);
+
+    beforeEach(() => {
+      state = readInitialState();
+      state.org.present = parseOrg(testOrgFile);
+      irrelevantHeaderId = state.org.present.get('headers').get(0).get('id');
+    });
+
+    it('should handle SET_HEADER_TAGS', () => {
+      const stateInserted = reducer(state.org.present, types.addHeader(0));
+      const headerId = stateInserted.get('headers').get(0).get('id');
+      const newState = reducer(stateInserted, types.setHeaderTags(headerId, tags));
+
+      expect(headerWithId(newState.get('headers'), headerId).getIn(['titleLine', 'tags'])).toEqual(
+        tags
+      );
+
+      const check_kept = check_kept_factory(state.org.present, newState);
+      check_kept((st) => headerWithId(st.get('headers'), irrelevantHeaderId));
+    });
+  });
 });

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -861,4 +861,17 @@ describe('org reducer', () => {
       check_kept((st) => headerWithId(st.get('headers'), irrelevantHeaderId));
     });
   });
+
+  describe('CLEAR_PENDING_CAPTURE', () => {
+    let state;
+
+    beforeEach(() => {
+      state = readInitialState();
+    });
+
+    it('should handle CLEAR_PENDING_CAPTURE', () => {
+      const newState = reducer(state.org.present, types.clearPendingCapture());
+      expect(newState.get('pendingCapture')).toBeNull();
+    });
+  });
 });

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -1738,6 +1738,12 @@ describe('org reducer', () => {
     });
 
     describe('SELECT_NEXT_VISIBLE_HEADER', () => {
+      it('start from the first', () => {
+        expect(state.org.present.get('selectedHeaderId')).toBeUndefined();
+        const newState = reducer(state.org.present, types.selectNextVisibleHeader());
+        expect(newState.get('selectedHeaderId')).toEqual(topHeaderId);
+      });
+
       it('should skip invisible header', () => {
         const stateSelected = selectHeader(
           openHeaders(state.org.present, openOnlyTop),

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -522,4 +522,27 @@ describe('org reducer', () => {
       );
     });
   });
+
+  describe('SET_ORG_FILE_ERROR_MESSAGE', () => {
+    let state;
+    const testOrgFile = readFixture('nested_header');
+    const message = 'It’s Does Not Compute';
+
+    beforeEach(() => {
+      state = readInitialState();
+      state.org.present = parseOrg(testOrgFile);
+    });
+
+    function check_kept_factory(oldState, newState) {
+      return (query) => {
+        expect(query(oldState)).toEqual(query(newState));
+      };
+    }
+
+    it('should handle SET_ORG_FILE_ERROR_MESSAGE', () => {
+      const newState = reducer(state.org.present, types.setOrgFileErrorMessage(message));
+      expect(newState.get('orgFileErrorMessage')).toEqual(message);
+      expect(newState.get('headers')).toEqual(state.org.present.get('headers'));
+    });
+  });
 });

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -874,4 +874,65 @@ describe('org reducer', () => {
       expect(newState.get('pendingCapture')).toBeNull();
     });
   });
+
+  describe('UPDATE_TABLE_CELL_VALUE', () => {
+    let state;
+    let cellId;
+    const newValue = 'Murakami';
+    const testOrgFile = readFixture('table');
+
+    function firstTable(contents) {
+      return contents.find((item) => item.get('type') === 'table');
+    }
+
+    beforeEach(() => {
+      state = readInitialState();
+      state.org.present = parseOrg(testOrgFile);
+      cellId = firstTable(state.org.present.getIn(['headers', 0, 'description'])).getIn([
+        'contents',
+        1,
+        'contents',
+        1,
+        'id',
+      ]);
+    });
+
+    it('should handle SET_HEADER_TAGS', () => {
+      const newState = reducer(state.org.present, types.updateTableCellValue(cellId, newValue));
+      expect(
+        firstTable(newState.getIn(['headers', 0, 'description'])).getIn([
+          'contents',
+          1,
+          'contents',
+          1,
+          'contents',
+          0,
+          'contents',
+        ])
+      ).toEqual(newValue);
+      expect(
+        firstTable(newState.getIn(['headers', 0, 'description'])).getIn([
+          'contents',
+          1,
+          'contents',
+          1,
+          'rawContents',
+        ])
+      ).toEqual(newValue);
+      const check_kept = check_kept_factory(state.org.present, newState);
+      check_kept((st) => st.getIn('headers', 0, 'titleLine'));
+      check_kept((st) =>
+        firstTable(st.getIn(['headers', 0, 'description'])).getIn(['contents', 0, 'contents'])
+      );
+      check_kept((st) =>
+        firstTable(st.getIn(['headers', 0, 'description'])).getIn(['contents', 2, 'contents'])
+      );
+      check_kept((st) =>
+        firstTable(st.getIn(['headers', 0, 'description'])).getIn(['contents', 1, 'contents', 0])
+      );
+      check_kept((st) =>
+        firstTable(st.getIn(['headers', 0, 'description'])).getIn(['contents', 1, 'contents', 2])
+      );
+    });
+  });
 });

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -277,4 +277,82 @@ describe('org reducer', () => {
       check_is_undoable(state, types.moveHeaderRight(nestedHeaderId));
     });
   });
+
+  describe('MOVE_SUBTREE_LEFT', () => {
+    let nestedHeaderId;
+    let state;
+    const testOrgFile = readFixture('nested_header');
+
+    beforeEach(() => {
+      state = readInitialState();
+      state.org.present = parseOrg(testOrgFile);
+      // The target is to move "A nested header" to the top level.
+
+      // "A nested header" the 2nd item but we count from 0 not 1.
+      nestedHeaderId = state.org.present.get('headers').get(1).get('id');
+    });
+
+    it('should handle MOVE_SUBTREE_LEFT', () => {
+      // Mapping the headers to their nesting level. This is how the
+      // initially parsed file should look like.
+      expect(extractTitlesAndNestings(state.org.present.get('headers'))).toEqual([
+        ['Top level header', 1],
+        ['A nested header', 2],
+        ['A deep nested header', 3],
+      ]);
+
+      const action = types.moveSubtreeLeft(nestedHeaderId);
+      const newState = reducer(state.org.present, action);
+
+      // "A nested header" is not at the top level.
+      expect(extractTitlesAndNestings(newState.get('headers'))).toEqual([
+        ['Top level header', 1],
+        ['A nested header', 1],
+        ['A deep nested header', 2],
+      ]);
+    });
+
+    it('is undoable', () => {
+      check_is_undoable(state, types.moveSubtreeLeft(nestedHeaderId));
+    });
+  });
+
+  describe('MOVE_SUBTREE_RIGHT', () => {
+    let nestedHeaderId;
+    let state;
+    const testOrgFile = readFixture('nested_header');
+
+    beforeEach(() => {
+      state = readInitialState();
+      state.org.present = parseOrg(testOrgFile);
+      // The target is to move "A nested header" to the top level.
+
+      // "A nested header" the 2nd item but we count from 0 not 1.
+      nestedHeaderId = state.org.present.get('headers').get(1).get('id');
+    });
+
+    it('should handle MOVE_SUBTREE_RIGHT', () => {
+      // Mapping the headers to their nesting level. This is how the
+      // initially parsed file should look like.
+      expect(extractTitlesAndNestings(state.org.present.get('headers'))).toEqual([
+        ['Top level header', 1],
+        ['A nested header', 2],
+        ['A deep nested header', 3],
+      ]);
+
+      const action = types.moveSubtreeRight(nestedHeaderId);
+      const newState = reducer(state.org.present, action);
+
+      // "A nested header" is not at the top level.
+      expect(extractTitlesAndNestings(newState.get('headers'))).toEqual([
+        ['Top level header', 1],
+        ['A nested header', 3],
+        ['A deep nested header', 4],
+      ]);
+    });
+
+    it('is undoable', () => {
+      check_is_undoable(state, types.moveSubtreeRight(nestedHeaderId));
+    });
+  });
 });

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -1124,13 +1124,9 @@ describe('org reducer', () => {
     });
   });
 
-  function firstTable(state) {
-    let hdrContents = state.getIn(['headers', 0, 'description']);
-    return hdrContents.find((item) => item.get('type') === 'table');
-  }
-
-  describe('UPDATE_TABLE_CELL_VALUE', () => {
+  describe('table', () => {
     let state;
+    let store;
     let cellId;
     const newValue = 'Murakami';
     const testOrgFile = readFixture('table');
@@ -1139,347 +1135,259 @@ describe('org reducer', () => {
       state = readInitialState();
       state.org.present = parseOrg(testOrgFile);
       cellId = firstTable(state.org.present).getIn(['contents', 1, 'contents', 1, 'id']);
-    });
-
-    it('should handle UPDATE_TABLE_CELL_VALUE', () => {
-      const newState = reducer(state.org.present, types.updateTableCellValue(cellId, newValue));
-      expect(
-        firstTable(newState).getIn(['contents', 1, 'contents', 1, 'contents', 0, 'contents'])
-      ).toEqual(newValue);
-      expect(firstTable(newState).getIn(['contents', 1, 'contents', 1, 'rawContents'])).toEqual(
-        newValue
-      );
-      const check_kept = check_kept_factory(state.org.present, newState);
-      check_kept((st) => st.getIn('headers', 0, 'titleLine'));
-      check_kept((st) => firstTable(st).getIn(['contents', 0, 'contents']));
-      check_kept((st) => firstTable(st).getIn(['contents', 2, 'contents']));
-      check_kept((st) => firstTable(st).getIn(['contents', 1, 'contents', 0]));
-      check_kept((st) => firstTable(st).getIn(['contents', 1, 'contents', 2]));
-    });
-  });
-
-  describe('MOVE_TABLE_COLUMN_RIGHT', () => {
-    let state;
-    let store;
-    let cellId;
-    const testOrgFile = readFixture('table');
-
-    beforeEach(() => {
-      state = readInitialState();
-      state.org.present = parseOrg(testOrgFile);
-      cellId = firstTable(state.org.present).getIn(['contents', 1, 'contents', 1, 'id']);
       store = createStore(undoable(reducer), state.org.present);
     });
 
-    it('should handle MOVE_TABLE_COLUMN_RIGHT', () => {
-      const oldState = store.getState().present;
-      store.dispatch({ type: 'SET_SELECTED_TABLE_CELL_ID', cellId });
-      const stateCellSelected = store.getState().present;
-      const newState = reducer(stateCellSelected, types.moveTableColumnRight());
-      const check_kept = check_kept_factory(state.org.present, newState);
+    function firstTable(state) {
+      let hdrContents = state.getIn(['headers', 0, 'description']);
+      return hdrContents.find((item) => item.get('type') === 'table');
+    }
 
-      [0, 1, 2].forEach((i) => {
-        expect(firstTable(newState).getIn(['contents', i, 'contents', 1])).toEqual(
-          firstTable(oldState).getIn(['contents', i, 'contents', 2])
+    describe('UPDATE_TABLE_CELL_VALUE', () => {
+      it('should handle UPDATE_TABLE_CELL_VALUE', () => {
+        const newState = reducer(state.org.present, types.updateTableCellValue(cellId, newValue));
+        expect(
+          firstTable(newState).getIn(['contents', 1, 'contents', 1, 'contents', 0, 'contents'])
+        ).toEqual(newValue);
+        expect(firstTable(newState).getIn(['contents', 1, 'contents', 1, 'rawContents'])).toEqual(
+          newValue
         );
-        expect(firstTable(newState).getIn(['contents', i, 'contents', 2])).toEqual(
-          firstTable(oldState).getIn(['contents', i, 'contents', 1])
-        );
-        check_kept((st) => firstTable(st).getIn(['contents', i, 'contents', 0]));
-        check_kept((st) => firstTable(st).getIn(['contents', i, 'contents']).size);
+        const check_kept = check_kept_factory(state.org.present, newState);
+        check_kept((st) => st.getIn('headers', 0, 'titleLine'));
+        check_kept((st) => firstTable(st).getIn(['contents', 0, 'contents']));
+        check_kept((st) => firstTable(st).getIn(['contents', 2, 'contents']));
+        check_kept((st) => firstTable(st).getIn(['contents', 1, 'contents', 0]));
+        check_kept((st) => firstTable(st).getIn(['contents', 1, 'contents', 2]));
       });
-      check_kept((st) => firstTable(st).get('contents').size);
     });
 
-    it('should just dirty on move with no cell selected', () => {
-      check_just_dirtying(store.getState().present, types.moveTableColumnRight());
-    });
+    describe('MOVE_TABLE_COLUMN_RIGHT', () => {
+      it('should handle MOVE_TABLE_COLUMN_RIGHT', () => {
+        const oldState = store.getState().present;
+        store.dispatch({ type: 'SET_SELECTED_TABLE_CELL_ID', cellId });
+        const stateCellSelected = store.getState().present;
+        const newState = reducer(stateCellSelected, types.moveTableColumnRight());
+        const check_kept = check_kept_factory(state.org.present, newState);
 
-    it('is undoable', () => {
-      check_is_undoable_on_table(store, cellId, types.moveTableColumnRight());
-    });
-  });
-
-  describe('MOVE_TABLE_COLUMN_LEFT', () => {
-    let state;
-    let store;
-    let cellId;
-    const testOrgFile = readFixture('table');
-
-    beforeEach(() => {
-      state = readInitialState();
-      state.org.present = parseOrg(testOrgFile);
-      cellId = firstTable(state.org.present).getIn(['contents', 1, 'contents', 1, 'id']);
-      store = createStore(undoable(reducer), state.org.present);
-    });
-
-    it('should handle MOVE_TABLE_COLUMN_LEFT', () => {
-      const oldState = store.getState().present;
-      store.dispatch({ type: 'SET_SELECTED_TABLE_CELL_ID', cellId });
-      const stateCellSelected = store.getState().present;
-      const newState = reducer(stateCellSelected, types.moveTableColumnLeft());
-      const check_kept = check_kept_factory(state.org.present, newState);
-
-      [0, 1, 2].forEach((i) => {
-        expect(firstTable(newState).getIn(['contents', i, 'contents', 1])).toEqual(
-          firstTable(oldState).getIn(['contents', i, 'contents', 0])
-        );
-        expect(firstTable(newState).getIn(['contents', i, 'contents', 0])).toEqual(
-          firstTable(oldState).getIn(['contents', i, 'contents', 1])
-        );
-        check_kept((st) => firstTable(st).getIn(['contents', i, 'contents', 2]));
-        check_kept((st) => firstTable(st).getIn(['contents', i, 'contents']).size);
+        [0, 1, 2].forEach((i) => {
+          expect(firstTable(newState).getIn(['contents', i, 'contents', 1])).toEqual(
+            firstTable(oldState).getIn(['contents', i, 'contents', 2])
+          );
+          expect(firstTable(newState).getIn(['contents', i, 'contents', 2])).toEqual(
+            firstTable(oldState).getIn(['contents', i, 'contents', 1])
+          );
+          check_kept((st) => firstTable(st).getIn(['contents', i, 'contents', 0]));
+          check_kept((st) => firstTable(st).getIn(['contents', i, 'contents']).size);
+        });
+        check_kept((st) => firstTable(st).get('contents').size);
       });
-      check_kept((st) => firstTable(st).get('contents').size);
-    });
 
-    it('should just dirty on move with no cell selected', () => {
-      check_just_dirtying(store.getState().present, types.moveTableColumnLeft());
-    });
-
-    it('is undoable', () => {
-      check_is_undoable_on_table(store, cellId, types.moveTableColumnLeft());
-    });
-  });
-
-  describe('MOVE_TABLE_ROW_UP', () => {
-    let state;
-    let store;
-    let cellId;
-    const testOrgFile = readFixture('table');
-
-    beforeEach(() => {
-      state = readInitialState();
-      state.org.present = parseOrg(testOrgFile);
-      cellId = firstTable(state.org.present).getIn(['contents', 1, 'contents', 1, 'id']);
-      store = createStore(undoable(reducer), state.org.present);
-    });
-
-    it('should handle MOVE_TABLE_ROW_UP', () => {
-      const oldState = store.getState().present;
-      store.dispatch({ type: 'SET_SELECTED_TABLE_CELL_ID', cellId });
-      const stateCellSelected = store.getState().present;
-      const newState = reducer(stateCellSelected, types.moveTableRowUp());
-      const check_kept = check_kept_factory(state.org.present, newState);
-
-      expect(firstTable(newState).getIn(['contents', 0])).toEqual(
-        firstTable(oldState).getIn(['contents', 1])
-      );
-      expect(firstTable(newState).getIn(['contents', 1])).toEqual(
-        firstTable(oldState).getIn(['contents', 0])
-      );
-      check_kept((st) => firstTable(st).getIn(['contents', 2]));
-      check_kept((st) => firstTable(st).get('contents').size);
-    });
-
-    it('should just dirty on move with no cell selected', () => {
-      check_just_dirtying(store.getState().present, types.moveTableRowUp());
-    });
-
-    it('is undoable', () => {
-      check_is_undoable_on_table(store, cellId, types.moveTableRowUp());
-    });
-  });
-
-  describe('MOVE_TABLE_ROW_DOWN', () => {
-    let state;
-    let store;
-    let cellId;
-    const testOrgFile = readFixture('table');
-
-    beforeEach(() => {
-      state = readInitialState();
-      state.org.present = parseOrg(testOrgFile);
-      cellId = firstTable(state.org.present).getIn(['contents', 1, 'contents', 1, 'id']);
-      store = createStore(undoable(reducer), state.org.present);
-    });
-
-    it('should handle MOVE_TABLE_ROW_DOWN', () => {
-      const oldState = store.getState().present;
-      store.dispatch({ type: 'SET_SELECTED_TABLE_CELL_ID', cellId });
-      const stateCellSelected = store.getState().present;
-      const newState = reducer(stateCellSelected, types.moveTableRowDown());
-      const check_kept = check_kept_factory(state.org.present, newState);
-
-      expect(firstTable(newState).getIn(['contents', 2])).toEqual(
-        firstTable(oldState).getIn(['contents', 1])
-      );
-      expect(firstTable(newState).getIn(['contents', 1])).toEqual(
-        firstTable(oldState).getIn(['contents', 2])
-      );
-      check_kept((st) => firstTable(st).getIn(['contents', 0]));
-      check_kept((st) => firstTable(st).get('contents').size);
-    });
-
-    it('should just dirty on move with no cell selected', () => {
-      check_just_dirtying(store.getState().present, types.moveTableRowDown());
-    });
-
-    it('is undoable', () => {
-      check_is_undoable_on_table(store, cellId, types.moveTableRowDown());
-    });
-  });
-
-  describe('REMOVE_TABLE_COLUMN', () => {
-    let state;
-    let store;
-    let cellId;
-    const testOrgFile = readFixture('table');
-
-    beforeEach(() => {
-      state = readInitialState();
-      state.org.present = parseOrg(testOrgFile);
-      cellId = firstTable(state.org.present).getIn(['contents', 1, 'contents', 1, 'id']);
-      store = createStore(undoable(reducer), state.org.present);
-    });
-
-    it('should handle REMOVE_TABLE_COLUMN', () => {
-      const oldState = store.getState().present;
-      store.dispatch({ type: 'SET_SELECTED_TABLE_CELL_ID', cellId });
-      const stateCellSelected = store.getState().present;
-      const newState = reducer(stateCellSelected, types.removeTableColumn());
-      const check_kept = check_kept_factory(state.org.present, newState);
-
-      [0, 1, 2].forEach((i) => {
-        expect(firstTable(newState).getIn(['contents', i, 'contents']).size).toEqual(
-          firstTable(oldState).getIn(['contents', i, 'contents']).size - 1
-        );
-        expect(firstTable(newState).getIn(['contents', i, 'contents', 1])).toEqual(
-          firstTable(oldState).getIn(['contents', i, 'contents', 2])
-        );
-        check_kept((st) => firstTable(st).getIn(['contents', i, 'contents', 0]));
+      it('should just dirty on move with no cell selected', () => {
+        check_just_dirtying(store.getState().present, types.moveTableColumnRight());
       });
-      check_kept((st) => firstTable(st).get('contents').size);
-    });
 
-    it('should just dirty on remove with no cell selected', () => {
-      check_just_dirtying(store.getState().present, types.removeTableColumn());
-    });
-
-    it('is undoable', () => {
-      check_is_undoable_on_table(store, cellId, types.removeTableColumn());
-    });
-  });
-
-  describe('REMOVE_TABLE_ROW', () => {
-    let state;
-    let store;
-    let cellId;
-    const testOrgFile = readFixture('table');
-
-    beforeEach(() => {
-      state = readInitialState();
-      state.org.present = parseOrg(testOrgFile);
-      cellId = firstTable(state.org.present).getIn(['contents', 1, 'contents', 1, 'id']);
-      store = createStore(undoable(reducer), state.org.present);
-    });
-
-    it('should handle REMOVE_TABLE_ROW', () => {
-      const oldState = store.getState().present;
-      store.dispatch({ type: 'SET_SELECTED_TABLE_CELL_ID', cellId });
-      const stateCellSelected = store.getState().present;
-      const newState = reducer(stateCellSelected, types.removeTableRow());
-      const check_kept = check_kept_factory(state.org.present, newState);
-
-      expect(firstTable(newState).getIn(['contents']).size).toEqual(
-        firstTable(oldState).getIn(['contents']).size - 1
-      );
-
-      expect(firstTable(newState).getIn(['contents', 1])).toEqual(
-        firstTable(oldState).getIn(['contents', 2])
-      );
-
-      check_kept((st) => firstTable(st).getIn(['contents', 0]));
-    });
-
-    it('should just dirty on remove with no cell selected', () => {
-      check_just_dirtying(store.getState().present, types.removeTableRow());
-    });
-
-    it('is undoable', () => {
-      check_is_undoable_on_table(store, cellId, types.removeTableRow());
-    });
-  });
-
-  describe('ADD_NEW_TABLE_COLUMN', () => {
-    let state;
-    let store;
-    let cellId;
-    const testOrgFile = readFixture('table');
-
-    beforeEach(() => {
-      state = readInitialState();
-      state.org.present = parseOrg(testOrgFile);
-      cellId = firstTable(state.org.present).getIn(['contents', 1, 'contents', 1, 'id']);
-      store = createStore(undoable(reducer), state.org.present);
-    });
-
-    it('should handle ADD_NEW_TABLE_COLUMN', () => {
-      const oldState = store.getState().present;
-      store.dispatch({ type: 'SET_SELECTED_TABLE_CELL_ID', cellId });
-      const stateCellSelected = store.getState().present;
-      const newState = reducer(stateCellSelected, types.addNewTableColumn());
-      const check_kept = check_kept_factory(state.org.present, newState);
-
-      [0, 1, 2].forEach((i) => {
-        expect(firstTable(newState).getIn(['contents', i, 'contents']).size).toEqual(
-          firstTable(oldState).getIn(['contents', i, 'contents']).size + 1
-        );
-        expect(firstTable(newState).getIn(['contents', i, 'contents', 3])).toEqual(
-          firstTable(oldState).getIn(['contents', i, 'contents', 2])
-        );
-        check_kept((st) => firstTable(st).getIn(['contents', i, 'contents', 0]));
-        check_kept((st) => firstTable(st).getIn(['contents', i, 'contents', 1]));
+      it('is undoable', () => {
+        check_is_undoable_on_table(store, cellId, types.moveTableColumnRight());
       });
-      check_kept((st) => firstTable(st).get('contents').size);
     });
 
-    it('should just dirty on add with no cell selected', () => {
-      check_just_dirtying(store.getState().present, types.addNewTableColumn());
+    describe('MOVE_TABLE_COLUMN_LEFT', () => {
+      it('should handle MOVE_TABLE_COLUMN_LEFT', () => {
+        const oldState = store.getState().present;
+        store.dispatch({ type: 'SET_SELECTED_TABLE_CELL_ID', cellId });
+        const stateCellSelected = store.getState().present;
+        const newState = reducer(stateCellSelected, types.moveTableColumnLeft());
+        const check_kept = check_kept_factory(state.org.present, newState);
+
+        [0, 1, 2].forEach((i) => {
+          expect(firstTable(newState).getIn(['contents', i, 'contents', 1])).toEqual(
+            firstTable(oldState).getIn(['contents', i, 'contents', 0])
+          );
+          expect(firstTable(newState).getIn(['contents', i, 'contents', 0])).toEqual(
+            firstTable(oldState).getIn(['contents', i, 'contents', 1])
+          );
+          check_kept((st) => firstTable(st).getIn(['contents', i, 'contents', 2]));
+          check_kept((st) => firstTable(st).getIn(['contents', i, 'contents']).size);
+        });
+        check_kept((st) => firstTable(st).get('contents').size);
+      });
+
+      it('should just dirty on move with no cell selected', () => {
+        check_just_dirtying(store.getState().present, types.moveTableColumnLeft());
+      });
+
+      it('is undoable', () => {
+        check_is_undoable_on_table(store, cellId, types.moveTableColumnLeft());
+      });
     });
 
-    it('is undoable', () => {
-      check_is_undoable_on_table(store, cellId, types.addNewTableColumn());
-    });
-  });
+    describe('MOVE_TABLE_ROW_UP', () => {
+      it('should handle MOVE_TABLE_ROW_UP', () => {
+        const oldState = store.getState().present;
+        store.dispatch({ type: 'SET_SELECTED_TABLE_CELL_ID', cellId });
+        const stateCellSelected = store.getState().present;
+        const newState = reducer(stateCellSelected, types.moveTableRowUp());
+        const check_kept = check_kept_factory(state.org.present, newState);
 
-  describe('ADD_NEW_TABLE_ROW', () => {
-    let state;
-    let store;
-    let cellId;
-    const testOrgFile = readFixture('table');
+        expect(firstTable(newState).getIn(['contents', 0])).toEqual(
+          firstTable(oldState).getIn(['contents', 1])
+        );
+        expect(firstTable(newState).getIn(['contents', 1])).toEqual(
+          firstTable(oldState).getIn(['contents', 0])
+        );
+        check_kept((st) => firstTable(st).getIn(['contents', 2]));
+        check_kept((st) => firstTable(st).get('contents').size);
+      });
 
-    beforeEach(() => {
-      state = readInitialState();
-      state.org.present = parseOrg(testOrgFile);
-      cellId = firstTable(state.org.present).getIn(['contents', 1, 'contents', 1, 'id']);
-      store = createStore(undoable(reducer), state.org.present);
-    });
+      it('should just dirty on move with no cell selected', () => {
+        check_just_dirtying(store.getState().present, types.moveTableRowUp());
+      });
 
-    it('should handle ADD_NEW_TABLE_ROW', () => {
-      const oldState = store.getState().present;
-      store.dispatch({ type: 'SET_SELECTED_TABLE_CELL_ID', cellId });
-      const stateCellSelected = store.getState().present;
-      const newState = reducer(stateCellSelected, types.addNewTableRow());
-      const check_kept = check_kept_factory(state.org.present, newState);
-
-      [0, 1].forEach((i) => {});
-      check_kept((st) => firstTable(st).getIn(['contents', 0]));
-      check_kept((st) => firstTable(st).getIn(['contents', 1]));
-      expect(firstTable(newState).getIn(['contents', 3])).toEqual(
-        firstTable(oldState).getIn(['contents', 2])
-      );
-      expect(firstTable(newState).getIn(['contents']).size).toEqual(
-        firstTable(oldState).getIn(['contents']).size + 1
-      );
+      it('is undoable', () => {
+        check_is_undoable_on_table(store, cellId, types.moveTableRowUp());
+      });
     });
 
-    it('should just dirty on add with no cell selected', () => {
-      check_just_dirtying(store.getState().present, types.addNewTableRow());
+    describe('MOVE_TABLE_ROW_DOWN', () => {
+      it('should handle MOVE_TABLE_ROW_DOWN', () => {
+        const oldState = store.getState().present;
+        store.dispatch({ type: 'SET_SELECTED_TABLE_CELL_ID', cellId });
+        const stateCellSelected = store.getState().present;
+        const newState = reducer(stateCellSelected, types.moveTableRowDown());
+        const check_kept = check_kept_factory(state.org.present, newState);
+
+        expect(firstTable(newState).getIn(['contents', 2])).toEqual(
+          firstTable(oldState).getIn(['contents', 1])
+        );
+        expect(firstTable(newState).getIn(['contents', 1])).toEqual(
+          firstTable(oldState).getIn(['contents', 2])
+        );
+        check_kept((st) => firstTable(st).getIn(['contents', 0]));
+        check_kept((st) => firstTable(st).get('contents').size);
+      });
+
+      it('should just dirty on move with no cell selected', () => {
+        check_just_dirtying(store.getState().present, types.moveTableRowDown());
+      });
+
+      it('is undoable', () => {
+        check_is_undoable_on_table(store, cellId, types.moveTableRowDown());
+      });
     });
 
-    it('is undoable', () => {
-      check_is_undoable_on_table(store, cellId, types.addNewTableRow());
+    describe('REMOVE_TABLE_COLUMN', () => {
+      it('should handle REMOVE_TABLE_COLUMN', () => {
+        const oldState = store.getState().present;
+        store.dispatch({ type: 'SET_SELECTED_TABLE_CELL_ID', cellId });
+        const stateCellSelected = store.getState().present;
+        const newState = reducer(stateCellSelected, types.removeTableColumn());
+        const check_kept = check_kept_factory(state.org.present, newState);
+
+        [0, 1, 2].forEach((i) => {
+          expect(firstTable(newState).getIn(['contents', i, 'contents']).size).toEqual(
+            firstTable(oldState).getIn(['contents', i, 'contents']).size - 1
+          );
+          expect(firstTable(newState).getIn(['contents', i, 'contents', 1])).toEqual(
+            firstTable(oldState).getIn(['contents', i, 'contents', 2])
+          );
+          check_kept((st) => firstTable(st).getIn(['contents', i, 'contents', 0]));
+        });
+        check_kept((st) => firstTable(st).get('contents').size);
+      });
+
+      it('should just dirty on remove with no cell selected', () => {
+        check_just_dirtying(store.getState().present, types.removeTableColumn());
+      });
+
+      it('is undoable', () => {
+        check_is_undoable_on_table(store, cellId, types.removeTableColumn());
+      });
+    });
+
+    describe('REMOVE_TABLE_ROW', () => {
+      it('should handle REMOVE_TABLE_ROW', () => {
+        const oldState = store.getState().present;
+        store.dispatch({ type: 'SET_SELECTED_TABLE_CELL_ID', cellId });
+        const stateCellSelected = store.getState().present;
+        const newState = reducer(stateCellSelected, types.removeTableRow());
+        const check_kept = check_kept_factory(state.org.present, newState);
+
+        expect(firstTable(newState).getIn(['contents']).size).toEqual(
+          firstTable(oldState).getIn(['contents']).size - 1
+        );
+
+        expect(firstTable(newState).getIn(['contents', 1])).toEqual(
+          firstTable(oldState).getIn(['contents', 2])
+        );
+
+        check_kept((st) => firstTable(st).getIn(['contents', 0]));
+      });
+
+      it('should just dirty on remove with no cell selected', () => {
+        check_just_dirtying(store.getState().present, types.removeTableRow());
+      });
+
+      it('is undoable', () => {
+        check_is_undoable_on_table(store, cellId, types.removeTableRow());
+      });
+    });
+
+    describe('ADD_NEW_TABLE_COLUMN', () => {
+      it('should handle ADD_NEW_TABLE_COLUMN', () => {
+        const oldState = store.getState().present;
+        store.dispatch({ type: 'SET_SELECTED_TABLE_CELL_ID', cellId });
+        const stateCellSelected = store.getState().present;
+        const newState = reducer(stateCellSelected, types.addNewTableColumn());
+        const check_kept = check_kept_factory(state.org.present, newState);
+
+        [0, 1, 2].forEach((i) => {
+          expect(firstTable(newState).getIn(['contents', i, 'contents']).size).toEqual(
+            firstTable(oldState).getIn(['contents', i, 'contents']).size + 1
+          );
+          expect(firstTable(newState).getIn(['contents', i, 'contents', 3])).toEqual(
+            firstTable(oldState).getIn(['contents', i, 'contents', 2])
+          );
+          check_kept((st) => firstTable(st).getIn(['contents', i, 'contents', 0]));
+          check_kept((st) => firstTable(st).getIn(['contents', i, 'contents', 1]));
+        });
+        check_kept((st) => firstTable(st).get('contents').size);
+      });
+
+      it('should just dirty on add with no cell selected', () => {
+        check_just_dirtying(store.getState().present, types.addNewTableColumn());
+      });
+
+      it('is undoable', () => {
+        check_is_undoable_on_table(store, cellId, types.addNewTableColumn());
+      });
+    });
+
+    describe('ADD_NEW_TABLE_ROW', () => {
+      it('should handle ADD_NEW_TABLE_ROW', () => {
+        const oldState = store.getState().present;
+        store.dispatch({ type: 'SET_SELECTED_TABLE_CELL_ID', cellId });
+        const stateCellSelected = store.getState().present;
+        const newState = reducer(stateCellSelected, types.addNewTableRow());
+        const check_kept = check_kept_factory(state.org.present, newState);
+
+        [0, 1].forEach((i) => {});
+        check_kept((st) => firstTable(st).getIn(['contents', 0]));
+        check_kept((st) => firstTable(st).getIn(['contents', 1]));
+        expect(firstTable(newState).getIn(['contents', 3])).toEqual(
+          firstTable(oldState).getIn(['contents', 2])
+        );
+        expect(firstTable(newState).getIn(['contents']).size).toEqual(
+          firstTable(oldState).getIn(['contents']).size + 1
+        );
+      });
+
+      it('should just dirty on add with no cell selected', () => {
+        check_just_dirtying(store.getState().present, types.addNewTableRow());
+      });
+
+      it('is undoable', () => {
+        check_is_undoable_on_table(store, cellId, types.addNewTableRow());
+      });
     });
   });
 

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -1597,6 +1597,18 @@ describe('org reducer', () => {
         ).get('opened')
       ).toEqual(true);
     });
+
+    it('should do nothing when no openness state is set', () => {
+      const oldState = state.org.present;
+      const newState = reducer(oldState, types.applyOpennessState());
+      expect(newState).toEqual(oldState);
+    });
+
+    it('should do nothing when no openness state is set for the file', () => {
+      const stateWithOpenness = state.org.present.set('opennessState', fromJS({}));
+      const newState = reducer(stateWithOpenness, types.applyOpennessState());
+      expect(newState).toEqual(stateWithOpenness);
+    });
   });
 
   describe('REMOVE_HEADER', () => {

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -706,4 +706,45 @@ describe('org reducer', () => {
       check_kept((st) => headerWithId(st.get('headers'), headerId).get('titleLine'));
     });
   });
+
+  describe('REORDER_PROPERTY_LIST', () => {
+    let headerId;
+    let irrelevantHeaderId;
+    let state;
+    const testOrgFile = readFixture('properties_extended');
+    const fromIndex = 1;
+    const toIndex = 3;
+
+    beforeEach(() => {
+      state = readInitialState();
+      state.org.present = parseOrg(testOrgFile);
+      headerId = state.org.present.get('headers').get(0).get('id');
+      irrelevantHeaderId = state.org.present.get('headers').get(1).get('id');
+    });
+
+    it('should handle REORDER_PROPERTY_LIST', () => {
+      const newState = reducer(state.org.present, {
+        type: 'REORDER_PROPERTY_LIST',
+        fromIndex,
+        toIndex,
+        headerId,
+        dirtying: true,
+      });
+
+      expect(
+        headerWithId(newState.get('headers'), headerId)
+          .get('propertyListItems')
+          .toJS()
+          .map((x) => x.property)
+      ).toEqual(['foo', 'baz', 'bay', 'bar']);
+
+      const check_kept = check_kept_factory(state.org.present, newState);
+      check_kept((st) => st.get('headers').size);
+      check_kept((st) => headerWithId(st.get('headers'), irrelevantHeaderId));
+      check_kept((st) =>
+        headerWithId(st.get('headers'), headerId).getIn(['titleLine', 'rawTitle'])
+      );
+      check_kept((st) => headerWithId(st.get('headers'), headerId).get('logBookEntries'));
+    });
+  });
 });

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -378,7 +378,7 @@ describe('org reducer', () => {
       // "This is done" is the 1st header,
       // "Header with repeater" is the 2nd,
       // "This is not a todo" is 3rd item, and
-      // "Repeating task" is 4th item; we cound from 1.
+      // "Repeating task" is 4th item; we count from 1.
       doneHeaderId = state.org.present.get('headers').get(0).get('id');
       todoHeaderId = state.org.present.get('headers').get(1).get('id');
       regularHeaderId = state.org.present.get('headers').get(2).get('id');
@@ -803,6 +803,61 @@ describe('org reducer', () => {
       );
 
       const check_kept = check_kept_factory(state.org.present, newState);
+      check_kept((st) => headerWithId(st.get('headers'), irrelevantHeaderId));
+    });
+  });
+
+  describe('ADVANCE_CHECKBOX_STATE', () => {
+    let headerId;
+    let checkedBoxId;
+    let uncheckedBoxId;
+    let irrelevantHeaderId;
+    let state;
+    const testOrgFile = readFixture('checkboxes');
+
+    beforeEach(() => {
+      state = readInitialState();
+      state.org.present = parseOrg(testOrgFile);
+      let headers = state.org.present.get('headers');
+      headerId = headers.get(0).get('id');
+      irrelevantHeaderId = headers.get(1).get('id');
+      checkedBoxId = headerWithId(headers, headerId).getIn(['description', 0, 'items', 2, 'id']);
+      uncheckedBoxId = headerWithId(headers, headerId).getIn(['description', 0, 'items', 1, 'id']);
+    });
+
+    it('should check the box', () => {
+      const oldState = state.org.present;
+      const newState = reducer(oldState, types.advanceCheckboxState(uncheckedBoxId));
+
+      expect(
+        headerWithId(newState.get('headers'), headerId)
+          .getIn(['description', 0, 'items'])
+          .toJS()
+          .map((x) => x.checkboxState)
+      ).toEqual(['unchecked', 'checked', 'checked']);
+
+      const check_kept = check_kept_factory(oldState, newState);
+      check_kept((st) =>
+        headerWithId(st.get('headers'), headerId).getIn(['description', 0, 'items', 0])
+      );
+      check_kept((st) => headerWithId(st.get('headers'), irrelevantHeaderId));
+    });
+
+    it('should uncheck the box', () => {
+      const oldState = state.org.present;
+      const newState = reducer(oldState, types.advanceCheckboxState(checkedBoxId));
+
+      expect(
+        headerWithId(newState.get('headers'), headerId)
+          .getIn(['description', 0, 'items'])
+          .toJS()
+          .map((x) => x.checkboxState)
+      ).toEqual(['unchecked', 'unchecked', 'unchecked']);
+
+      const check_kept = check_kept_factory(oldState, newState);
+      check_kept((st) =>
+        headerWithId(st.get('headers'), headerId).getIn(['description', 0, 'items', 0])
+      );
       check_kept((st) => headerWithId(st.get('headers'), irrelevantHeaderId));
     });
   });

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -973,11 +973,12 @@ describe('org reducer', () => {
 
   describe('ADVANCE_CHECKBOX_STATE', () => {
     let topHeaderId;
+    let bottomHeaderId;
     let checkedBoxId;
     let uncheckedBoxId;
-    let bottomHeaderId;
     let nestId;
     let deepNestedId;
+    let bottomNestedId;
     let state;
     const testOrgFile = readFixture('checkboxes');
 
@@ -1005,6 +1006,17 @@ describe('org reducer', () => {
         0,
         'items',
         0,
+        'contents',
+        0,
+        'items',
+        0,
+        'id',
+      ]);
+      bottomNestedId = headerWithId(headers, bottomHeaderId).getIn([
+        'description',
+        0,
+        'items',
+        2,
         'contents',
         0,
         'items',
@@ -1065,12 +1077,23 @@ describe('org reducer', () => {
           .getIn(['description', 0, 'items'])
           .toJS()
           .map((x) => x.checkboxState)
-      ).toEqual(['checked', 'checked', 'checked']);
+      ).toEqual(['checked', 'checked', 'partial', null]);
       expect(
         headerWithId(newState.get('headers'), bottomHeaderId)
           .getIn(['titleLine', 'title', 1, 'fraction'])
           .toJS()
-      ).toEqual([3, 3]);
+      ).toEqual([2, 3]);
+    });
+
+    it('should ', () => {
+      const oldState = state.org.present;
+      const newState = reducer(oldState, types.advanceCheckboxState(bottomNestedId));
+      expect(
+        headerWithId(newState.get('headers'), bottomHeaderId)
+          .getIn(['description', 0, 'items'])
+          .toJS()
+          .map((x) => x.checkboxState)
+      ).toEqual(['checked', 'partial', 'partial', null]);
     });
   });
 

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -1788,6 +1788,18 @@ describe('org reducer', () => {
         expect(newState.get('selectedHeaderId')).toEqual(topHeaderId);
       });
     });
+
+    describe('SELECT_NEXT_SIBLING_HEADER', () => {
+      it('ignore when on the last sibling', () => {
+        const oldState = selectHeader(state.org.present, topHeaderId);
+        const newState = reducer(oldState, types.selectNextSiblingHeader(nestedHeader2Id));
+        expect(newState.get('selectedHeaderId')).toEqual(topHeaderId);
+
+        const oldState2 = selectHeader(state.org.present, nestedHeader2Id);
+        const newState2 = reducer(oldState2, types.selectNextSiblingHeader(nestedHeader2Id));
+        expect(newState2.get('selectedHeaderId')).toEqual(nestedHeader2Id);
+      });
+    });
   });
 
   describe('UPDATE_HEADER_DESCRIPTION', () => {

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -1142,15 +1142,17 @@ describe('org reducer', () => {
           .toJS()
       ).toEqual([2, 3]);
 
-      expect(headerWithId(newState.get('headers'), bottomHeaderId).getIn([
-        'description',
-        0,
-        'items', // compoundBoxE
-        1,
-        'titleLine',
-        1,
-        'percentage'
-      ])).toEqual(100);
+      expect(
+        headerWithId(newState.get('headers'), bottomHeaderId).getIn([
+          'description',
+          0,
+          'items', // compoundBoxE
+          1,
+          'titleLine',
+          1,
+          'percentage',
+        ])
+      ).toEqual(100);
     });
 
     it('should keep the partial state when some children are not checked', () => {
@@ -1959,6 +1961,34 @@ describe('org reducer', () => {
       expect(newState.getIn(['search', 'searchFilterValid'])).toEqual(false);
       const check_kept = check_kept_factory(oldState, newState);
       check_kept((st) => st.get('headers'));
+    });
+  });
+
+  describe('TOGGLE_HEADER_OPENED', () => {
+    let topHeaderId, nestedHeaderId;
+    let state;
+    const testOrgFile = readFixture('nested_header');
+
+    beforeEach(() => {
+      state = readInitialState();
+      state.org.present = parseOrg(testOrgFile);
+
+      topHeaderId = state.org.present.get('headers').get(0).get('id');
+      nestedHeaderId = state.org.present.get('headers').get(1).get('id');
+    });
+
+    it('should open only the header on the first toggle', () => {
+      const newState = reducer(state.org.present, types.toggleHeaderOpened(topHeaderId));
+      expect(headerWithId(newState.get('headers'), topHeaderId).get('opened')).toEqual(true);
+      expect(headerWithId(newState.get('headers'), nestedHeaderId).get('opened')).toEqual(false);
+    });
+
+    it('should ignore if focused and open', () => {
+      expect(state.org.present.get('headers').every((hdr) => !hdr.get('opened'))).toEqual(true);
+      const openState = reducer(state.org.present, types.toggleHeaderOpened(topHeaderId));
+      const focusedState = reducer(openState, types.focusHeader(topHeaderId));
+      const newState = reducer(focusedState, types.toggleHeaderOpened(topHeaderId));
+      expect(newState).toEqual(focusedState);
     });
   });
 });

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -155,19 +155,19 @@ describe('org reducer', () => {
     }
 
     function expectOrigLastHeader(headers) {
-      expect(extractTitleAndNesting(headers.last())).toEqual(['A nested header', 2]);
+      expect(extractTitleAndNesting(headers.last())).toEqual(['A deep nested header', 3]);
     }
 
     function insertCapture(shouldPrepend) {
       // Check initially parsed file looks as expected
       let headers = store.getState().org.present.get('headers');
-      expect(headers.size).toEqual(2);
+      expect(headers.size).toEqual(3);
       expectOrigFirstHeader(headers);
       expectOrigLastHeader(headers);
       const action = types.insertCapture(template.id, content, shouldPrepend);
       store.dispatch(action);
       const newHeaders = store.getState().org.present.get('headers');
-      expect(newHeaders.size).toEqual(3);
+      expect(newHeaders.size).toEqual(4);
       return newHeaders;
     }
 
@@ -220,6 +220,7 @@ describe('org reducer', () => {
       expect(extractTitlesAndNestings(state.org.present.get('headers'))).toEqual([
         ['Top level header', 1],
         ['A nested header', 2],
+        ['A deep nested header', 3],
       ]);
 
       const action = types.moveHeaderLeft(nestedHeaderId);
@@ -229,6 +230,7 @@ describe('org reducer', () => {
       expect(extractTitlesAndNestings(newState.get('headers'))).toEqual([
         ['Top level header', 1],
         ['A nested header', 1],
+        ['A deep nested header', 3],
       ]);
     });
 
@@ -257,6 +259,7 @@ describe('org reducer', () => {
       expect(extractTitlesAndNestings(state.org.present.get('headers'))).toEqual([
         ['Top level header', 1],
         ['A nested header', 2],
+        ['A deep nested header', 3],
       ]);
 
       const action = types.moveHeaderRight(nestedHeaderId);
@@ -266,6 +269,7 @@ describe('org reducer', () => {
       expect(extractTitlesAndNestings(newState.get('headers'))).toEqual([
         ['Top level header', 1],
         ['A nested header', 3],
+        ['A deep nested header', 3],
       ]);
     });
 

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -448,6 +448,7 @@ describe('org reducer', () => {
 
   describe('MOVE_SUBTREE_LEFT', () => {
     let nestedHeaderId;
+    let topLevelHeaderId;
     let state;
     const testOrgFile = readFixture('nested_header');
 
@@ -458,6 +459,8 @@ describe('org reducer', () => {
 
       // "A nested header" the 2nd item but we count from 0 not 1.
       nestedHeaderId = state.org.present.get('headers').get(1).get('id');
+
+      topLevelHeaderId = state.org.present.get('headers').get(0).get('id');
     });
 
     it('should handle MOVE_SUBTREE_LEFT', () => {
@@ -480,6 +483,10 @@ describe('org reducer', () => {
         ['A deep nested header', 2],
         ['A second nested header', 2],
       ]);
+    });
+
+    it('should just dirty when trying to move left a toplevel subtree', () => {
+      check_just_dirtying(state.org.present, types.moveSubtreeLeft(topLevelHeaderId));
     });
 
     it('is undoable', () => {

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -494,7 +494,6 @@ describe('org reducer', () => {
       });
 
       it('should reset header focus', () => {
-        const action = types.removeHeader(nestedHeaderId);
         const focusedState = reducer(state.org.present, types.focusHeader(nestedHeaderId));
         expect(focusedState.get('focusedHeaderId')).toEqual(nestedHeaderId);
         const newState = reducer(focusedState, types.removeHeader(nestedHeaderId));
@@ -532,7 +531,6 @@ describe('org reducer', () => {
       });
 
       it('should reset header focus', () => {
-        const action = types.removeHeader(nestedHeaderId);
         const focusedState = reducer(state.org.present, types.focusHeader(nestedHeaderId));
         expect(focusedState.get('focusedHeaderId')).toEqual(nestedHeaderId);
         const newState = reducer(focusedState, types.removeHeader(nestedHeaderId));
@@ -1611,7 +1609,6 @@ describe('org reducer', () => {
         const newState = reducer(stateCellSelected, types.addNewTableRow());
         const check_kept = check_kept_factory(state.org.present, newState);
 
-        [0, 1].forEach((i) => {});
         check_kept((st) => firstTable(st).getIn(['contents', 0]));
         check_kept((st) => firstTable(st).getIn(['contents', 1]));
         expect(firstTable(newState).getIn(['contents', 3])).toEqual(

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -1593,4 +1593,19 @@ describe('org reducer', () => {
       check_is_undoable(state, types.updateHeaderDescription(nestedHeaderId, newDescription));
     });
   });
+
+  describe('EXIT_EDIT_MODE', () => {
+    let state;
+
+    beforeEach(() => {
+      state = readInitialState();
+    });
+
+    it('should handle EXIT_EDIT_MODE', () => {
+      const editState = reducer(state.org.present, types.enterEditMode('description'));
+      expect(editState.get('editMode')).toEqual('description');
+      const nonEditState = reducer(editState, types.exitEditMode());
+      expect(nonEditState.get('editMode')).toBeNull();
+    });
+  });
 });

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -1226,4 +1226,19 @@ describe('org reducer', () => {
       expect(newState.get('focusedHeaderId')).toEqual(headerId);
     });
   });
+
+  describe('SET_DIRTY', () => {
+    let state;
+
+    beforeEach(() => {
+      state = readInitialState();
+    });
+
+    it('should handle SET_DIRTY', () => {
+      const dirtyState = reducer(state.org.present, types.setDirty(true));
+      expect(dirtyState.get('isDirty')).toEqual(true);
+      const cleanState = reducer(dirtyState, types.setDirty(false));
+      expect(cleanState.get('isDirty')).toEqual(false);
+    });
+  });
 });

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -646,6 +646,10 @@ describe('org reducer', () => {
       expect(extractTitlesAndNestings(intermHeaders)).toEqual(extractTitlesAndNestings(newHeaders));
     });
 
+    it('should just dirty when applied to no header', () => {
+      check_just_dirtying(state.org.present, types.advanceTodoState(undefined));
+    });
+
     it('is undoable', () => {
       check_is_undoable(state, types.advanceTodoState(todoHeaderId, true));
       check_is_undoable(state, types.advanceTodoState(doneHeaderId, false));

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -1395,4 +1395,43 @@ describe('org reducer', () => {
       ).toEqual(true);
     });
   });
+
+  describe('REMOVE_HEADER', () => {
+    let nestedHeaderId;
+    let state;
+    const testOrgFile = readFixture('nested_header');
+
+    beforeEach(() => {
+      state = readInitialState();
+      state.org.present = parseOrg(testOrgFile);
+      // The target is to remove "A nested header".
+
+      // "A nested header" the 2nd item but we count from 0 not 1.
+      nestedHeaderId = state.org.present.get('headers').get(1).get('id');
+    });
+
+    it('should handle REMOVE_HEADER', () => {
+      // Mapping the headers to their nesting level. This is how the
+      // initially parsed file should look like.
+      expect(extractTitlesAndNestings(state.org.present.get('headers'))).toEqual([
+        ['Top level header', 1],
+        ['A nested header', 2],
+        ['A deep nested header', 3],
+        ['A second nested header', 2],
+      ]);
+
+      const action = types.removeHeader(nestedHeaderId);
+      const newState = reducer(state.org.present, action);
+
+      // "A nested header" is not at the top level.
+      expect(extractTitlesAndNestings(newState.get('headers'))).toEqual([
+        ['Top level header', 1],
+        ['A second nested header', 2],
+      ]);
+    });
+
+    it('is undoable', () => {
+      check_is_undoable(state, types.moveHeaderLeft(nestedHeaderId));
+    });
+  });
 });

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -576,4 +576,37 @@ describe('org reducer', () => {
       check_kept((st) => headerWithId(st.get('headers'), headerId).get('logBookEntries'));
     });
   });
+
+  describe('ADD_NEW_PLANNING_ITEM', () => {
+    let headerId;
+    let state;
+    const testOrgFile = readFixture('schedule');
+
+    beforeEach(() => {
+      state = readInitialState();
+      state.org.present = parseOrg(testOrgFile);
+      headerId = state.org.present.get('headers').get(0).get('id');
+    });
+
+    it('should handle ADD_NEW_PLANNING_ITEM', () => {
+      const newState = reducer(state.org.present, types.addNewPlanningItem(headerId, 'DEADLINE'));
+      expect(headerWithId(newState.get('headers'), headerId).get('planningItems').size).toEqual(2);
+      expect(
+        headerWithId(newState.get('headers'), headerId).get('planningItems').get(0).get('type')
+      ).toEqual('SCHEDULED');
+      expect(
+        headerWithId(newState.get('headers'), headerId).get('planningItems').get(1).get('type')
+      ).toEqual('DEADLINE');
+
+      const check_kept = check_kept_factory(state.org.present, newState);
+      check_kept((st) => st.get('headers').size);
+      check_kept((st) =>
+        headerWithId(st.get('headers'), headerId).getIn(['titleLine', 'rawTitle'])
+      );
+      check_kept((st) =>
+        headerWithId(st.get('headers'), headerId).getIn(['titleLine', 'todoKeyword'])
+      );
+      check_kept((st) => headerWithId(st.get('headers'), headerId).get('logBookEntries'));
+    });
+  });
 });

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -887,8 +887,9 @@ describe('org reducer', () => {
     });
   });
 
-  function firstTable(contents) {
-    return contents.find((item) => item.get('type') === 'table');
+  function firstTable(state) {
+    let hdrContents = state.getIn(['headers', 0, 'description']);
+    return hdrContents.find((item) => item.get('type') === 'table');
   }
 
   describe('UPDATE_TABLE_CELL_VALUE', () => {
@@ -897,58 +898,26 @@ describe('org reducer', () => {
     const newValue = 'Murakami';
     const testOrgFile = readFixture('table');
 
-    function firstTable(contents) {
-      return contents.find((item) => item.get('type') === 'table');
-    }
-
     beforeEach(() => {
       state = readInitialState();
       state.org.present = parseOrg(testOrgFile);
-      cellId = firstTable(state.org.present.getIn(['headers', 0, 'description'])).getIn([
-        'contents',
-        1,
-        'contents',
-        1,
-        'id',
-      ]);
+      cellId = firstTable(state.org.present).getIn(['contents', 1, 'contents', 1, 'id']);
     });
 
     it('should handle UPDATE_TABLE_CELL_VALUE', () => {
       const newState = reducer(state.org.present, types.updateTableCellValue(cellId, newValue));
       expect(
-        firstTable(newState.getIn(['headers', 0, 'description'])).getIn([
-          'contents',
-          1,
-          'contents',
-          1,
-          'contents',
-          0,
-          'contents',
-        ])
+        firstTable(newState).getIn(['contents', 1, 'contents', 1, 'contents', 0, 'contents'])
       ).toEqual(newValue);
-      expect(
-        firstTable(newState.getIn(['headers', 0, 'description'])).getIn([
-          'contents',
-          1,
-          'contents',
-          1,
-          'rawContents',
-        ])
-      ).toEqual(newValue);
+      expect(firstTable(newState).getIn(['contents', 1, 'contents', 1, 'rawContents'])).toEqual(
+        newValue
+      );
       const check_kept = check_kept_factory(state.org.present, newState);
       check_kept((st) => st.getIn('headers', 0, 'titleLine'));
-      check_kept((st) =>
-        firstTable(st.getIn(['headers', 0, 'description'])).getIn(['contents', 0, 'contents'])
-      );
-      check_kept((st) =>
-        firstTable(st.getIn(['headers', 0, 'description'])).getIn(['contents', 2, 'contents'])
-      );
-      check_kept((st) =>
-        firstTable(st.getIn(['headers', 0, 'description'])).getIn(['contents', 1, 'contents', 0])
-      );
-      check_kept((st) =>
-        firstTable(st.getIn(['headers', 0, 'description'])).getIn(['contents', 1, 'contents', 2])
-      );
+      check_kept((st) => firstTable(st).getIn(['contents', 0, 'contents']));
+      check_kept((st) => firstTable(st).getIn(['contents', 2, 'contents']));
+      check_kept((st) => firstTable(st).getIn(['contents', 1, 'contents', 0]));
+      check_kept((st) => firstTable(st).getIn(['contents', 1, 'contents', 2]));
     });
   });
 
@@ -961,13 +930,7 @@ describe('org reducer', () => {
     beforeEach(() => {
       state = readInitialState();
       state.org.present = parseOrg(testOrgFile);
-      cellId = firstTable(state.org.present.getIn(['headers', 0, 'description'])).getIn([
-        'contents',
-        1,
-        'contents',
-        1,
-        'id',
-      ]);
+      cellId = firstTable(state.org.present).getIn(['contents', 1, 'contents', 1, 'id']);
       store = createStore(undoable(reducer), state.org.present);
     });
 
@@ -979,46 +942,16 @@ describe('org reducer', () => {
       const check_kept = check_kept_factory(state.org.present, newState);
 
       [0, 1, 2].forEach((i) => {
-        expect(
-          firstTable(newState.getIn(['headers', 0, 'description'])).getIn([
-            'contents',
-            i,
-            'contents',
-            1,
-          ])
-        ).toEqual(
-          firstTable(oldState.getIn(['headers', 0, 'description'])).getIn([
-            'contents',
-            i,
-            'contents',
-            2,
-          ])
+        expect(firstTable(newState).getIn(['contents', i, 'contents', 1])).toEqual(
+          firstTable(oldState).getIn(['contents', i, 'contents', 2])
         );
-        expect(
-          firstTable(newState.getIn(['headers', 0, 'description'])).getIn([
-            'contents',
-            i,
-            'contents',
-            2,
-          ])
-        ).toEqual(
-          firstTable(oldState.getIn(['headers', 0, 'description'])).getIn([
-            'contents',
-            i,
-            'contents',
-            1,
-          ])
+        expect(firstTable(newState).getIn(['contents', i, 'contents', 2])).toEqual(
+          firstTable(oldState).getIn(['contents', i, 'contents', 1])
         );
-        check_kept((st) =>
-          firstTable(st.getIn(['headers', 0, 'description'])).getIn(['contents', i, 'contents', 0])
-        );
-        check_kept(
-          (st) =>
-            firstTable(st.getIn(['headers', 0, 'description'])).getIn(['contents', i, 'contents'])
-              .size
-        );
+        check_kept((st) => firstTable(st).getIn(['contents', i, 'contents', 0]));
+        check_kept((st) => firstTable(st).getIn(['contents', i, 'contents']).size);
       });
-      check_kept((st) => firstTable(st.getIn(['headers', 0, 'description'])).get('contents').size);
+      check_kept((st) => firstTable(st).get('contents').size);
     });
 
     it('is undoable', () => {
@@ -1035,13 +968,7 @@ describe('org reducer', () => {
     beforeEach(() => {
       state = readInitialState();
       state.org.present = parseOrg(testOrgFile);
-      cellId = firstTable(state.org.present.getIn(['headers', 0, 'description'])).getIn([
-        'contents',
-        1,
-        'contents',
-        1,
-        'id',
-      ]);
+      cellId = firstTable(state.org.present).getIn(['contents', 1, 'contents', 1, 'id']);
       store = createStore(undoable(reducer), state.org.present);
     });
 
@@ -1053,46 +980,16 @@ describe('org reducer', () => {
       const check_kept = check_kept_factory(state.org.present, newState);
 
       [0, 1, 2].forEach((i) => {
-        expect(
-          firstTable(newState.getIn(['headers', 0, 'description'])).getIn([
-            'contents',
-            i,
-            'contents',
-            1,
-          ])
-        ).toEqual(
-          firstTable(oldState.getIn(['headers', 0, 'description'])).getIn([
-            'contents',
-            i,
-            'contents',
-            0,
-          ])
+        expect(firstTable(newState).getIn(['contents', i, 'contents', 1])).toEqual(
+          firstTable(oldState).getIn(['contents', i, 'contents', 0])
         );
-        expect(
-          firstTable(newState.getIn(['headers', 0, 'description'])).getIn([
-            'contents',
-            i,
-            'contents',
-            0,
-          ])
-        ).toEqual(
-          firstTable(oldState.getIn(['headers', 0, 'description'])).getIn([
-            'contents',
-            i,
-            'contents',
-            1,
-          ])
+        expect(firstTable(newState).getIn(['contents', i, 'contents', 0])).toEqual(
+          firstTable(oldState).getIn(['contents', i, 'contents', 1])
         );
-        check_kept((st) =>
-          firstTable(st.getIn(['headers', 0, 'description'])).getIn(['contents', i, 'contents', 2])
-        );
-        check_kept(
-          (st) =>
-            firstTable(st.getIn(['headers', 0, 'description'])).getIn(['contents', i, 'contents'])
-              .size
-        );
+        check_kept((st) => firstTable(st).getIn(['contents', i, 'contents', 2]));
+        check_kept((st) => firstTable(st).getIn(['contents', i, 'contents']).size);
       });
-      check_kept((st) => firstTable(st.getIn(['headers', 0, 'description'])).get('contents').size);
+      check_kept((st) => firstTable(st).get('contents').size);
     });
 
     it('is undoable', () => {
@@ -1109,13 +1006,7 @@ describe('org reducer', () => {
     beforeEach(() => {
       state = readInitialState();
       state.org.present = parseOrg(testOrgFile);
-      cellId = firstTable(state.org.present.getIn(['headers', 0, 'description'])).getIn([
-        'contents',
-        1,
-        'contents',
-        1,
-        'id',
-      ]);
+      cellId = firstTable(state.org.present).getIn(['contents', 1, 'contents', 1, 'id']);
       store = createStore(undoable(reducer), state.org.present);
     });
 
@@ -1126,16 +1017,14 @@ describe('org reducer', () => {
       const newState = reducer(stateCellSelected, types.moveTableRowUp());
       const check_kept = check_kept_factory(state.org.present, newState);
 
-      expect(
-        firstTable(newState.getIn(['headers', 0, 'description'])).getIn(['contents', 0])
-      ).toEqual(firstTable(oldState.getIn(['headers', 0, 'description'])).getIn(['contents', 1]));
-      expect(
-        firstTable(newState.getIn(['headers', 0, 'description'])).getIn(['contents', 1])
-      ).toEqual(firstTable(oldState.getIn(['headers', 0, 'description'])).getIn(['contents', 0]));
-      check_kept((st) =>
-        firstTable(st.getIn(['headers', 0, 'description'])).getIn(['contents', 2])
+      expect(firstTable(newState).getIn(['contents', 0])).toEqual(
+        firstTable(oldState).getIn(['contents', 1])
       );
-      check_kept((st) => firstTable(st.getIn(['headers', 0, 'description'])).get('contents').size);
+      expect(firstTable(newState).getIn(['contents', 1])).toEqual(
+        firstTable(oldState).getIn(['contents', 0])
+      );
+      check_kept((st) => firstTable(st).getIn(['contents', 2]));
+      check_kept((st) => firstTable(st).get('contents').size);
     });
 
     it('is undoable', () => {
@@ -1152,13 +1041,7 @@ describe('org reducer', () => {
     beforeEach(() => {
       state = readInitialState();
       state.org.present = parseOrg(testOrgFile);
-      cellId = firstTable(state.org.present.getIn(['headers', 0, 'description'])).getIn([
-        'contents',
-        1,
-        'contents',
-        1,
-        'id',
-      ]);
+      cellId = firstTable(state.org.present).getIn(['contents', 1, 'contents', 1, 'id']);
       store = createStore(undoable(reducer), state.org.present);
     });
 
@@ -1169,16 +1052,14 @@ describe('org reducer', () => {
       const newState = reducer(stateCellSelected, types.moveTableRowDown());
       const check_kept = check_kept_factory(state.org.present, newState);
 
-      expect(
-        firstTable(newState.getIn(['headers', 0, 'description'])).getIn(['contents', 2])
-      ).toEqual(firstTable(oldState.getIn(['headers', 0, 'description'])).getIn(['contents', 1]));
-      expect(
-        firstTable(newState.getIn(['headers', 0, 'description'])).getIn(['contents', 1])
-      ).toEqual(firstTable(oldState.getIn(['headers', 0, 'description'])).getIn(['contents', 2]));
-      check_kept((st) =>
-        firstTable(st.getIn(['headers', 0, 'description'])).getIn(['contents', 0])
+      expect(firstTable(newState).getIn(['contents', 2])).toEqual(
+        firstTable(oldState).getIn(['contents', 1])
       );
-      check_kept((st) => firstTable(st.getIn(['headers', 0, 'description'])).get('contents').size);
+      expect(firstTable(newState).getIn(['contents', 1])).toEqual(
+        firstTable(oldState).getIn(['contents', 2])
+      );
+      check_kept((st) => firstTable(st).getIn(['contents', 0]));
+      check_kept((st) => firstTable(st).get('contents').size);
     });
 
     it('is undoable', () => {
@@ -1195,13 +1076,7 @@ describe('org reducer', () => {
     beforeEach(() => {
       state = readInitialState();
       state.org.present = parseOrg(testOrgFile);
-      cellId = firstTable(state.org.present.getIn(['headers', 0, 'description'])).getIn([
-        'contents',
-        1,
-        'contents',
-        1,
-        'id',
-      ]);
+      cellId = firstTable(state.org.present).getIn(['contents', 1, 'contents', 1, 'id']);
       store = createStore(undoable(reducer), state.org.present);
     });
 
@@ -1213,39 +1088,15 @@ describe('org reducer', () => {
       const check_kept = check_kept_factory(state.org.present, newState);
 
       [0, 1, 2].forEach((i) => {
-        expect(
-          firstTable(newState.getIn(['headers', 0, 'description'])).getIn([
-            'contents',
-            i,
-            'contents',
-          ]).size
-        ).toEqual(
-          firstTable(oldState.getIn(['headers', 0, 'description'])).getIn([
-            'contents',
-            i,
-            'contents',
-          ]).size - 1
+        expect(firstTable(newState).getIn(['contents', i, 'contents']).size).toEqual(
+          firstTable(oldState).getIn(['contents', i, 'contents']).size - 1
         );
-        expect(
-          firstTable(newState.getIn(['headers', 0, 'description'])).getIn([
-            'contents',
-            i,
-            'contents',
-            1,
-          ])
-        ).toEqual(
-          firstTable(oldState.getIn(['headers', 0, 'description'])).getIn([
-            'contents',
-            i,
-            'contents',
-            2,
-          ])
+        expect(firstTable(newState).getIn(['contents', i, 'contents', 1])).toEqual(
+          firstTable(oldState).getIn(['contents', i, 'contents', 2])
         );
-        check_kept((st) =>
-          firstTable(st.getIn(['headers', 0, 'description'])).getIn(['contents', i, 'contents', 0])
-        );
+        check_kept((st) => firstTable(st).getIn(['contents', i, 'contents', 0]));
       });
-      check_kept((st) => firstTable(st.getIn(['headers', 0, 'description'])).get('contents').size);
+      check_kept((st) => firstTable(st).get('contents').size);
     });
     it('is undoable', () => {
       check_is_undoable_on_table(store, cellId, types.removeTableColumn());
@@ -1261,13 +1112,7 @@ describe('org reducer', () => {
     beforeEach(() => {
       state = readInitialState();
       state.org.present = parseOrg(testOrgFile);
-      cellId = firstTable(state.org.present.getIn(['headers', 0, 'description'])).getIn([
-        'contents',
-        1,
-        'contents',
-        1,
-        'id',
-      ]);
+      cellId = firstTable(state.org.present).getIn(['contents', 1, 'contents', 1, 'id']);
       store = createStore(undoable(reducer), state.org.present);
     });
 
@@ -1278,19 +1123,15 @@ describe('org reducer', () => {
       const newState = reducer(stateCellSelected, types.removeTableRow());
       const check_kept = check_kept_factory(state.org.present, newState);
 
-      expect(
-        firstTable(newState.getIn(['headers', 0, 'description'])).getIn(['contents']).size
-      ).toEqual(
-        firstTable(oldState.getIn(['headers', 0, 'description'])).getIn(['contents']).size - 1
+      expect(firstTable(newState).getIn(['contents']).size).toEqual(
+        firstTable(oldState).getIn(['contents']).size - 1
       );
 
-      expect(
-        firstTable(newState.getIn(['headers', 0, 'description'])).getIn(['contents', 1])
-      ).toEqual(firstTable(oldState.getIn(['headers', 0, 'description'])).getIn(['contents', 2]));
-
-      check_kept((st) =>
-        firstTable(st.getIn(['headers', 0, 'description'])).getIn(['contents', 0])
+      expect(firstTable(newState).getIn(['contents', 1])).toEqual(
+        firstTable(oldState).getIn(['contents', 2])
       );
+
+      check_kept((st) => firstTable(st).getIn(['contents', 0]));
     });
 
     it('is undoable', () => {
@@ -1307,13 +1148,7 @@ describe('org reducer', () => {
     beforeEach(() => {
       state = readInitialState();
       state.org.present = parseOrg(testOrgFile);
-      cellId = firstTable(state.org.present.getIn(['headers', 0, 'description'])).getIn([
-        'contents',
-        1,
-        'contents',
-        1,
-        'id',
-      ]);
+      cellId = firstTable(state.org.present).getIn(['contents', 1, 'contents', 1, 'id']);
       store = createStore(undoable(reducer), state.org.present);
     });
 
@@ -1325,42 +1160,16 @@ describe('org reducer', () => {
       const check_kept = check_kept_factory(state.org.present, newState);
 
       [0, 1, 2].forEach((i) => {
-        expect(
-          firstTable(newState.getIn(['headers', 0, 'description'])).getIn([
-            'contents',
-            i,
-            'contents',
-          ]).size
-        ).toEqual(
-          firstTable(oldState.getIn(['headers', 0, 'description'])).getIn([
-            'contents',
-            i,
-            'contents',
-          ]).size + 1
+        expect(firstTable(newState).getIn(['contents', i, 'contents']).size).toEqual(
+          firstTable(oldState).getIn(['contents', i, 'contents']).size + 1
         );
-        expect(
-          firstTable(newState.getIn(['headers', 0, 'description'])).getIn([
-            'contents',
-            i,
-            'contents',
-            3,
-          ])
-        ).toEqual(
-          firstTable(oldState.getIn(['headers', 0, 'description'])).getIn([
-            'contents',
-            i,
-            'contents',
-            2,
-          ])
+        expect(firstTable(newState).getIn(['contents', i, 'contents', 3])).toEqual(
+          firstTable(oldState).getIn(['contents', i, 'contents', 2])
         );
-        check_kept((st) =>
-          firstTable(st.getIn(['headers', 0, 'description'])).getIn(['contents', i, 'contents', 0])
-        );
-        check_kept((st) =>
-          firstTable(st.getIn(['headers', 0, 'description'])).getIn(['contents', i, 'contents', 1])
-        );
+        check_kept((st) => firstTable(st).getIn(['contents', i, 'contents', 0]));
+        check_kept((st) => firstTable(st).getIn(['contents', i, 'contents', 1]));
       });
-      check_kept((st) => firstTable(st.getIn(['headers', 0, 'description'])).get('contents').size);
+      check_kept((st) => firstTable(st).get('contents').size);
     });
 
     it('is undoable', () => {
@@ -1377,13 +1186,7 @@ describe('org reducer', () => {
     beforeEach(() => {
       state = readInitialState();
       state.org.present = parseOrg(testOrgFile);
-      cellId = firstTable(state.org.present.getIn(['headers', 0, 'description'])).getIn([
-        'contents',
-        1,
-        'contents',
-        1,
-        'id',
-      ]);
+      cellId = firstTable(state.org.present).getIn(['contents', 1, 'contents', 1, 'id']);
       store = createStore(undoable(reducer), state.org.present);
     });
 
@@ -1395,19 +1198,13 @@ describe('org reducer', () => {
       const check_kept = check_kept_factory(state.org.present, newState);
 
       [0, 1].forEach((i) => {});
-      check_kept((st) =>
-        firstTable(st.getIn(['headers', 0, 'description'])).getIn(['contents', 0])
+      check_kept((st) => firstTable(st).getIn(['contents', 0]));
+      check_kept((st) => firstTable(st).getIn(['contents', 1]));
+      expect(firstTable(newState).getIn(['contents', 3])).toEqual(
+        firstTable(oldState).getIn(['contents', 2])
       );
-      check_kept((st) =>
-        firstTable(st.getIn(['headers', 0, 'description'])).getIn(['contents', 1])
-      );
-      expect(
-        firstTable(newState.getIn(['headers', 0, 'description'])).getIn(['contents', 3])
-      ).toEqual(firstTable(oldState.getIn(['headers', 0, 'description'])).getIn(['contents', 2]));
-      expect(
-        firstTable(newState.getIn(['headers', 0, 'description'])).getIn(['contents']).size
-      ).toEqual(
-        firstTable(oldState.getIn(['headers', 0, 'description'])).getIn(['contents']).size + 1
+      expect(firstTable(newState).getIn(['contents']).size).toEqual(
+        firstTable(oldState).getIn(['contents']).size + 1
       );
     });
 

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -196,4 +196,88 @@ describe('org reducer', () => {
       expect(store.getState().org.present).toEqual(oldState);
     });
   });
+
+  describe('MOVE_HEADER_LEFT', () => {
+    let nestedHeaderId;
+    let ml_state;
+    const ml_testOrgFile = readFixture('nested_header');
+
+    beforeEach(() => {
+      ml_state = readInitialState();
+      ml_state.org.present = parseOrg(ml_testOrgFile);
+      // The target is to move "A nested header" to the top level.
+
+      // "A nested header" the 2nd item but we count from 0 not 1.
+      nestedHeaderId = ml_state.org.present.get('headers').get(1).get('id');
+    });
+
+    it('should handle MOVE_HEADER_LEFT', () => {
+      // Mapping the headers to their nesting level. This is how the
+      // initially parsed file should look like.
+      expect(extractTitlesAndNestings(ml_state.org.present.get('headers'))).toEqual([
+        ['Top level header', 1],
+        ['A nested header', 2],
+      ]);
+
+      const action = types.moveHeaderLeft(nestedHeaderId);
+      const newState = reducer(ml_state.org.present, action);
+
+      // "A nested header" is not at the top level.
+      expect(extractTitlesAndNestings(newState.get('headers'))).toEqual([
+        ['Top level header', 1],
+        ['A nested header', 1],
+      ]);
+    });
+
+    it('is undoable', () => {
+      const store = createStore(undoable(reducer), ml_state.org.present);
+      const oldState = store.getState().present;
+      store.dispatch(types.moveHeaderLeft(nestedHeaderId));
+      expect(store.getState().present).not.toEqual(oldState);
+      store.dispatch({ type: ActionTypes.UNDO });
+      expect(store.getState().present).toEqual(oldState);
+    });
+  });
+
+  describe('MOVE_HEADER_RIGHT', () => {
+    let nestedHeaderId;
+    let ml_state;
+    const ml_testOrgFile = readFixture('nested_header');
+
+    beforeEach(() => {
+      ml_state = readInitialState();
+      ml_state.org.present = parseOrg(ml_testOrgFile);
+      // The target is to move "A nested header" to the next nesting level.
+
+      // "A nested header" the 2nd item but we count from 0 not 1.
+      nestedHeaderId = ml_state.org.present.get('headers').get(1).get('id');
+    });
+
+    it('should handle MOVE_HEADER_RIGHT', () => {
+      // Mapping the headers to their nesting level. This is how the
+      // initially parsed file should look like.
+      expect(extractTitlesAndNestings(ml_state.org.present.get('headers'))).toEqual([
+        ['Top level header', 1],
+        ['A nested header', 2],
+      ]);
+
+      const action = types.moveHeaderRight(nestedHeaderId);
+      const newState = reducer(ml_state.org.present, action);
+
+      // "A nested header" is not at the top level.
+      expect(extractTitlesAndNestings(newState.get('headers'))).toEqual([
+        ['Top level header', 1],
+        ['A nested header', 3],
+      ]);
+    });
+
+    it('is undoable', () => {
+      const store = createStore(undoable(reducer), ml_state.org.present);
+      const oldState = store.getState().present;
+      store.dispatch(types.moveHeaderRight(nestedHeaderId));
+      expect(store.getState().present).not.toEqual(oldState);
+      store.dispatch({ type: ActionTypes.UNDO });
+      expect(store.getState().present).toEqual(oldState);
+    });
+  });
 });

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -268,187 +268,10 @@ describe('org reducer', () => {
     });
   });
 
-  describe('MOVE_HEADER_LEFT', () => {
-    let nestedHeaderId;
-    let state;
-    const testOrgFile = readFixture('nested_header');
-
-    beforeEach(() => {
-      state = readInitialState();
-      state.org.present = parseOrg(testOrgFile);
-      // The target is to move "A nested header" to the top level.
-
-      // "A nested header" the 2nd item but we count from 0 not 1.
-      nestedHeaderId = state.org.present.get('headers').get(1).get('id');
-    });
-
-    it('should handle MOVE_HEADER_LEFT', () => {
-      // Mapping the headers to their nesting level. This is how the
-      // initially parsed file should look like.
-      expect(extractTitlesAndNestings(state.org.present.get('headers'))).toEqual([
-        ['Top level header', 1],
-        ['A nested header', 2],
-        ['A deep nested header', 3],
-        ['A second nested header', 2],
-      ]);
-
-      const action = types.moveHeaderLeft(nestedHeaderId);
-      const newState = reducer(state.org.present, action);
-
-      // "A nested header" is not at the top level.
-      expect(extractTitlesAndNestings(newState.get('headers'))).toEqual([
-        ['Top level header', 1],
-        ['A nested header', 1],
-        ['A deep nested header', 3],
-        ['A second nested header', 2],
-      ]);
-    });
-
-    it('is undoable', () => {
-      check_is_undoable(state, types.moveHeaderLeft(nestedHeaderId));
-    });
-  });
-
-  describe('MOVE_HEADER_RIGHT', () => {
-    let nestedHeaderId;
-    let state;
-    const testOrgFile = readFixture('nested_header');
-
-    beforeEach(() => {
-      state = readInitialState();
-      state.org.present = parseOrg(testOrgFile);
-      // The target is to move "A nested header" to the next nesting level.
-
-      // "A nested header" the 2nd item but we count from 0 not 1.
-      nestedHeaderId = state.org.present.get('headers').get(1).get('id');
-    });
-
-    it('should handle MOVE_HEADER_RIGHT', () => {
-      // Mapping the headers to their nesting level. This is how the
-      // initially parsed file should look like.
-      expect(extractTitlesAndNestings(state.org.present.get('headers'))).toEqual([
-        ['Top level header', 1],
-        ['A nested header', 2],
-        ['A deep nested header', 3],
-        ['A second nested header', 2],
-      ]);
-
-      const action = types.moveHeaderRight(nestedHeaderId);
-      const newState = reducer(state.org.present, action);
-
-      // "A nested header" is not at the top level.
-      expect(extractTitlesAndNestings(newState.get('headers'))).toEqual([
-        ['Top level header', 1],
-        ['A nested header', 3],
-        ['A deep nested header', 3],
-        ['A second nested header', 2],
-      ]);
-    });
-
-    it('is undoable', () => {
-      check_is_undoable(state, types.moveHeaderRight(nestedHeaderId));
-    });
-  });
-
-  describe('MOVE_HEADER_DOWN', () => {
-    let nestedHeaderId;
-    let nestedHeader2Id;
-    let state;
-    const testOrgFile = readFixture('nested_header');
-
-    beforeEach(() => {
-      state = readInitialState();
-      state.org.present = parseOrg(testOrgFile);
-      // The target is to move "A nested header" down.
-
-      // "A nested header" the 2nd item but we count from 0 not 1.
-      nestedHeaderId = state.org.present.get('headers').get(1).get('id');
-      // "A second nested header" the 4th item but we count from 0 not 1.
-      nestedHeader2Id = state.org.present.get('headers').get(3).get('id');
-    });
-
-    it('should handle MOVE_HEADER_DOWN', () => {
-      // Mapping the headers to their nesting level. This is how the
-      // initially parsed file should look like.
-      expect(extractTitlesAndNestings(state.org.present.get('headers'))).toEqual([
-        ['Top level header', 1],
-        ['A nested header', 2],
-        ['A deep nested header', 3],
-        ['A second nested header', 2],
-      ]);
-
-      const action = types.moveHeaderDown(nestedHeaderId);
-      const newState = reducer(state.org.present, action);
-
-      // "A nested header" is not at the top level.
-      expect(extractTitlesAndNestings(newState.get('headers'))).toEqual([
-        ['Top level header', 1],
-        ['A second nested header', 2],
-        ['A nested header', 2],
-        ['A deep nested header', 3],
-      ]);
-    });
-
-    it('should just dirty if already on the bottom', () => {
-      check_just_dirtying(state.org.present, types.moveHeaderDown(nestedHeader2Id));
-    });
-
-    it('is undoable', () => {
-      check_is_undoable(state, types.moveHeaderDown(nestedHeaderId));
-    });
-  });
-
-  describe('MOVE_HEADER_UP', () => {
-    let nestedHeader2Id;
-    let nestedHeaderId;
-    let state;
-    const testOrgFile = readFixture('nested_header');
-
-    beforeEach(() => {
-      state = readInitialState();
-      state.org.present = parseOrg(testOrgFile);
-      // The target is to move "A second nested header" up.
-
-      // "A nested header" the 2nd item but we count from 0 not 1.
-      nestedHeaderId = state.org.present.get('headers').get(1).get('id');
-      // "A second nested header" the 4th item but we count from 0 not 1.
-      nestedHeader2Id = state.org.present.get('headers').get(3).get('id');
-    });
-
-    it('should handle MOVE_HEADER_UP', () => {
-      // Mapping the headers to their nesting level. This is how the
-      // initially parsed file should look like.
-      expect(extractTitlesAndNestings(state.org.present.get('headers'))).toEqual([
-        ['Top level header', 1],
-        ['A nested header', 2],
-        ['A deep nested header', 3],
-        ['A second nested header', 2],
-      ]);
-
-      const action = types.moveHeaderUp(nestedHeader2Id);
-      const newState = reducer(state.org.present, action);
-
-      // "A nested header" is not at the top level.
-      expect(extractTitlesAndNestings(newState.get('headers'))).toEqual([
-        ['Top level header', 1],
-        ['A second nested header', 2],
-        ['A nested header', 2],
-        ['A deep nested header', 3],
-      ]);
-    });
-
-    it('should just dirty if already at the top', () => {
-      check_just_dirtying(state.org.present, types.moveHeaderUp(nestedHeaderId));
-    });
-
-    it('is undoable', () => {
-      check_is_undoable(state, types.moveHeaderUp(nestedHeader2Id));
-    });
-  });
-
-  describe('MOVE_SUBTREE_LEFT', () => {
-    let nestedHeaderId;
+  describe('tree moving', () => {
     let topLevelHeaderId;
+    let nestedHeaderId;
+    let nestedHeader2Id;
     let state;
     const testOrgFile = readFixture('nested_header');
 
@@ -456,82 +279,192 @@ describe('org reducer', () => {
       state = readInitialState();
       state.org.present = parseOrg(testOrgFile);
       // The target is to move "A nested header" to the top level.
-
-      // "A nested header" the 2nd item but we count from 0 not 1.
-      nestedHeaderId = state.org.present.get('headers').get(1).get('id');
 
       topLevelHeaderId = state.org.present.get('headers').get(0).get('id');
-    });
-
-    it('should handle MOVE_SUBTREE_LEFT', () => {
-      // Mapping the headers to their nesting level. This is how the
-      // initially parsed file should look like.
-      expect(extractTitlesAndNestings(state.org.present.get('headers'))).toEqual([
-        ['Top level header', 1],
-        ['A nested header', 2],
-        ['A deep nested header', 3],
-        ['A second nested header', 2],
-      ]);
-
-      const action = types.moveSubtreeLeft(nestedHeaderId);
-      const newState = reducer(state.org.present, action);
-
-      // "A nested header" is not at the top level.
-      expect(extractTitlesAndNestings(newState.get('headers'))).toEqual([
-        ['Top level header', 1],
-        ['A nested header', 1],
-        ['A deep nested header', 2],
-        ['A second nested header', 2],
-      ]);
-    });
-
-    it('should just dirty when trying to move left a toplevel subtree', () => {
-      check_just_dirtying(state.org.present, types.moveSubtreeLeft(topLevelHeaderId));
-    });
-
-    it('is undoable', () => {
-      check_is_undoable(state, types.moveSubtreeLeft(nestedHeaderId));
-    });
-  });
-
-  describe('MOVE_SUBTREE_RIGHT', () => {
-    let nestedHeaderId;
-    let state;
-    const testOrgFile = readFixture('nested_header');
-
-    beforeEach(() => {
-      state = readInitialState();
-      state.org.present = parseOrg(testOrgFile);
-      // The target is to move "A nested header" to the deeper nested level.
-
       // "A nested header" the 2nd item but we count from 0 not 1.
       nestedHeaderId = state.org.present.get('headers').get(1).get('id');
+      // "A second nested header" the 4th item but we count from 0 not 1.
+      nestedHeader2Id = state.org.present.get('headers').get(3).get('id');
     });
 
-    it('should handle MOVE_SUBTREE_RIGHT', () => {
-      // Mapping the headers to their nesting level. This is how the
-      // initially parsed file should look like.
-      expect(extractTitlesAndNestings(state.org.present.get('headers'))).toEqual([
-        ['Top level header', 1],
-        ['A nested header', 2],
-        ['A deep nested header', 3],
-        ['A second nested header', 2],
-      ]);
+    describe('MOVE_HEADER_LEFT', () => {
+      it('should handle MOVE_HEADER_LEFT', () => {
+        // Mapping the headers to their nesting level. This is how the
+        // initially parsed file should look like.
+        expect(extractTitlesAndNestings(state.org.present.get('headers'))).toEqual([
+          ['Top level header', 1],
+          ['A nested header', 2],
+          ['A deep nested header', 3],
+          ['A second nested header', 2],
+        ]);
 
-      const action = types.moveSubtreeRight(nestedHeaderId);
-      const newState = reducer(state.org.present, action);
+        const action = types.moveHeaderLeft(nestedHeaderId);
+        const newState = reducer(state.org.present, action);
 
-      // "A nested header" is not at the top level.
-      expect(extractTitlesAndNestings(newState.get('headers'))).toEqual([
-        ['Top level header', 1],
-        ['A nested header', 3],
-        ['A deep nested header', 4],
-        ['A second nested header', 2],
-      ]);
+        // "A nested header" is not at the top level.
+        expect(extractTitlesAndNestings(newState.get('headers'))).toEqual([
+          ['Top level header', 1],
+          ['A nested header', 1],
+          ['A deep nested header', 3],
+          ['A second nested header', 2],
+        ]);
+      });
+
+      it('is undoable', () => {
+        check_is_undoable(state, types.moveHeaderLeft(nestedHeaderId));
+      });
     });
 
-    it('is undoable', () => {
-      check_is_undoable(state, types.moveSubtreeRight(nestedHeaderId));
+    describe('MOVE_HEADER_RIGHT', () => {
+      it('should handle MOVE_HEADER_RIGHT', () => {
+        // Mapping the headers to their nesting level. This is how the
+        // initially parsed file should look like.
+        expect(extractTitlesAndNestings(state.org.present.get('headers'))).toEqual([
+          ['Top level header', 1],
+          ['A nested header', 2],
+          ['A deep nested header', 3],
+          ['A second nested header', 2],
+        ]);
+
+        const action = types.moveHeaderRight(nestedHeaderId);
+        const newState = reducer(state.org.present, action);
+
+        // "A nested header" is not at the top level.
+        expect(extractTitlesAndNestings(newState.get('headers'))).toEqual([
+          ['Top level header', 1],
+          ['A nested header', 3],
+          ['A deep nested header', 3],
+          ['A second nested header', 2],
+        ]);
+      });
+
+      it('is undoable', () => {
+        check_is_undoable(state, types.moveHeaderRight(nestedHeaderId));
+      });
+    });
+
+    describe('MOVE_HEADER_DOWN', () => {
+      it('should handle MOVE_HEADER_DOWN', () => {
+        // Mapping the headers to their nesting level. This is how the
+        // initially parsed file should look like.
+        expect(extractTitlesAndNestings(state.org.present.get('headers'))).toEqual([
+          ['Top level header', 1],
+          ['A nested header', 2],
+          ['A deep nested header', 3],
+          ['A second nested header', 2],
+        ]);
+
+        const action = types.moveHeaderDown(nestedHeaderId);
+        const newState = reducer(state.org.present, action);
+
+        // "A nested header" is not at the top level.
+        expect(extractTitlesAndNestings(newState.get('headers'))).toEqual([
+          ['Top level header', 1],
+          ['A second nested header', 2],
+          ['A nested header', 2],
+          ['A deep nested header', 3],
+        ]);
+      });
+
+      it('should just dirty if already on the bottom', () => {
+        check_just_dirtying(state.org.present, types.moveHeaderDown(nestedHeader2Id));
+      });
+
+      it('is undoable', () => {
+        check_is_undoable(state, types.moveHeaderDown(nestedHeaderId));
+      });
+    });
+
+    describe('MOVE_HEADER_UP', () => {
+      it('should handle MOVE_HEADER_UP', () => {
+        // Mapping the headers to their nesting level. This is how the
+        // initially parsed file should look like.
+        expect(extractTitlesAndNestings(state.org.present.get('headers'))).toEqual([
+          ['Top level header', 1],
+          ['A nested header', 2],
+          ['A deep nested header', 3],
+          ['A second nested header', 2],
+        ]);
+
+        const action = types.moveHeaderUp(nestedHeader2Id);
+        const newState = reducer(state.org.present, action);
+
+        // "A nested header" is not at the top level.
+        expect(extractTitlesAndNestings(newState.get('headers'))).toEqual([
+          ['Top level header', 1],
+          ['A second nested header', 2],
+          ['A nested header', 2],
+          ['A deep nested header', 3],
+        ]);
+      });
+
+      it('should just dirty if already at the top', () => {
+        check_just_dirtying(state.org.present, types.moveHeaderUp(nestedHeaderId));
+      });
+
+      it('is undoable', () => {
+        check_is_undoable(state, types.moveHeaderUp(nestedHeader2Id));
+      });
+    });
+
+    describe('MOVE_SUBTREE_LEFT', () => {
+      it('should handle MOVE_SUBTREE_LEFT', () => {
+        // Mapping the headers to their nesting level. This is how the
+        // initially parsed file should look like.
+        expect(extractTitlesAndNestings(state.org.present.get('headers'))).toEqual([
+          ['Top level header', 1],
+          ['A nested header', 2],
+          ['A deep nested header', 3],
+          ['A second nested header', 2],
+        ]);
+
+        const action = types.moveSubtreeLeft(nestedHeaderId);
+        const newState = reducer(state.org.present, action);
+
+        // "A nested header" is not at the top level.
+        expect(extractTitlesAndNestings(newState.get('headers'))).toEqual([
+          ['Top level header', 1],
+          ['A nested header', 1],
+          ['A deep nested header', 2],
+          ['A second nested header', 2],
+        ]);
+      });
+
+      it('should just dirty when trying to move left a toplevel subtree', () => {
+        check_just_dirtying(state.org.present, types.moveSubtreeLeft(topLevelHeaderId));
+      });
+
+      it('is undoable', () => {
+        check_is_undoable(state, types.moveSubtreeLeft(nestedHeaderId));
+      });
+    });
+
+    describe('MOVE_SUBTREE_RIGHT', () => {
+      it('should handle MOVE_SUBTREE_RIGHT', () => {
+        // Mapping the headers to their nesting level. This is how the
+        // initially parsed file should look like.
+        expect(extractTitlesAndNestings(state.org.present.get('headers'))).toEqual([
+          ['Top level header', 1],
+          ['A nested header', 2],
+          ['A deep nested header', 3],
+          ['A second nested header', 2],
+        ]);
+
+        const action = types.moveSubtreeRight(nestedHeaderId);
+        const newState = reducer(state.org.present, action);
+
+        // "A nested header" is not at the top level.
+        expect(extractTitlesAndNestings(newState.get('headers'))).toEqual([
+          ['Top level header', 1],
+          ['A nested header', 3],
+          ['A deep nested header', 4],
+          ['A second nested header', 2],
+        ]);
+      });
+
+      it('is undoable', () => {
+        check_is_undoable(state, types.moveSubtreeRight(nestedHeaderId));
+      });
     });
   });
 

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -747,4 +747,37 @@ describe('org reducer', () => {
       check_kept((st) => headerWithId(st.get('headers'), headerId).get('logBookEntries'));
     });
   });
+
+  describe('REORDER_TAGS', () => {
+    let headerId;
+    let state;
+    const testOrgFile = readFixture('more_tags');
+    const fromIndex = 0;
+    const toIndex = 2;
+
+    beforeEach(() => {
+      state = readInitialState();
+      state.org.present = parseOrg(testOrgFile);
+      headerId = state.org.present.get('headers').get(0).get('id');
+    });
+
+    it('should handle REORDER_TAGS', () => {
+      const stateSelected = reducer(state.org.present, { type: 'SELECT_HEADER', headerId });
+      const newState = reducer(stateSelected, types.reorderTags(fromIndex, toIndex));
+
+      expect(stateSelected.get('selectedHeaderId')).toEqual(headerId);
+      expect(newState.get('selectedHeaderId')).toEqual(headerId);
+      expect(
+        headerWithId(newState.get('headers'), headerId).getIn(['titleLine', 'tags']).toJS()
+      ).toEqual(['t2', 't3', 't1', 'spec_tag']);
+
+      const check_kept = check_kept_factory(state.org.present, newState);
+      check_kept((st) => st.get('headers').size);
+      check_kept((st) => headerWithId(st.get('headers'), headerId).getIn(['titleLine', 'title']));
+      check_kept((st) =>
+        headerWithId(st.get('headers'), headerId).getIn(['titleLine', 'rawTitle'])
+      );
+      check_kept((st) => headerWithId(st.get('headers'), headerId).get('description'));
+    });
+  });
 });

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -1652,6 +1652,14 @@ describe('org reducer', () => {
       ]);
     });
 
+    it('should reset header focus', () => {
+      const action = types.removeHeader(nestedHeaderId);
+      const focusedState = reducer(state.org.present, types.focusHeader(nestedHeaderId));
+      expect(focusedState.get('focusedHeaderId')).toEqual(nestedHeaderId);
+      const newState = reducer(focusedState, types.removeHeader(nestedHeaderId));
+      expect(newState.get('focusedHeaderId')).toEqual(null);
+    });
+
     it('is undoable', () => {
       check_is_undoable(state, types.removeHeader(nestedHeaderId));
     });

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -1135,11 +1135,22 @@ describe('org reducer', () => {
           .toJS()
           .map((x) => x.checkboxState)
       ).toEqual(['checked', 'checked', 'partial', null]);
+
       expect(
         headerWithId(newState.get('headers'), bottomHeaderId)
           .getIn(['titleLine', 'title', 1, 'fraction'])
           .toJS()
       ).toEqual([2, 3]);
+
+      expect(headerWithId(newState.get('headers'), bottomHeaderId).getIn([
+        'description',
+        0,
+        'items', // compoundBoxE
+        1,
+        'titleLine',
+        1,
+        'percentage'
+      ])).toEqual(100);
     });
 
     it('should keep the partial state when some children are not checked', () => {

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -1431,7 +1431,7 @@ describe('org reducer', () => {
     });
 
     it('is undoable', () => {
-      check_is_undoable(state, types.moveHeaderLeft(nestedHeaderId));
+      check_is_undoable(state, types.removeHeader(nestedHeaderId));
     });
   });
 
@@ -1555,6 +1555,42 @@ describe('org reducer', () => {
         const newState = reducer(stateSelected, types.selectNextVisibleHeader());
         expect(newState.get('selectedHeaderId')).toEqual(topHeaderId);
       });
+    });
+  });
+
+  describe('UPDATE_HEADER_DESCRIPTION', () => {
+    let nestedHeaderId;
+    let state;
+    const testOrgFile = readFixture('nested_header');
+    const newDescription =
+      'One man once said TODO,\n - [ ] and <2020-01-18 Sat> \n - others :followed: ';
+
+    beforeEach(() => {
+      state = readInitialState();
+      state.org.present = parseOrg(testOrgFile);
+      // The target is to move "A nested header" to the top level.
+
+      // "A nested header" the 2nd item but we count from 0 not 1.
+      nestedHeaderId = state.org.present.get('headers').get(1).get('id');
+    });
+
+    it('should handle UPDATE_HEADER_DESCRIPTION', () => {
+      const action = types.updateHeaderDescription(nestedHeaderId, newDescription);
+      const newState = reducer(state.org.present, action);
+      const check_kept = check_kept_factory(state.org.present, newState);
+      check_kept((st) =>
+        headerWithId(st.get('headers'), nestedHeaderId).getIn(['titleLine', 'rawTitle'])
+      );
+      expect(headerWithId(newState.get('headers'), nestedHeaderId).get('rawDescription')).toEqual(
+        newDescription
+      );
+      expect(headerWithId(newState.get('headers'), nestedHeaderId).get('description')).not.toEqual(
+        headerWithId(state.org.present.get('headers'), nestedHeaderId).get('description')
+      );
+    });
+
+    it('is undoable', () => {
+      check_is_undoable(state, types.updateHeaderDescription(nestedHeaderId, newDescription));
     });
   });
 });

--- a/test_helpers/fixtures/checkboxes.org
+++ b/test_helpers/fixtures/checkboxes.org
@@ -2,10 +2,16 @@
 - [ ] One
 - [ ] Two
 - [X] Three
-* Another header [2/3]
+* Another header [1/3]
 - [X] One
 - [-] Two
   - [ ] Nested one
     - [ ] Nested nested
   - [X] Nested two
-- [X] Three
+- [-] Three
+  - [ ] Three-nested one
+  - [-] Three-nested two
+    - [ ] Three-nested-nested one
+    - [X] Three-nested-nested two
+  - [ ] three-nested three
+- Not a checkbox

--- a/test_helpers/fixtures/checkboxes.org
+++ b/test_helpers/fixtures/checkboxes.org
@@ -1,17 +1,17 @@
 * Header with checkboxes
-- [ ] One
-- [ ] Two
-- [X] Three
+- [ ] Box A
+- [ ] Box B
+- [X] Box C
 * Another header [1/3]
-- [X] One
-- [-] Two
-  - [ ] Nested one
-    - [ ] Nested nested
-  - [X] Nested two
-- [-] Three
-  - [ ] Three-nested one
-  - [-] Three-nested two
-    - [ ] Three-nested-nested one
-    - [X] Three-nested-nested two
-  - [ ] three-nested three
+- [X] Box D
+- [-] Box E
+  - [ ] Box G
+    - [ ] Box H
+  - [X] Box I
+- [-] Box J
+  - [ ] Box K
+  - [-] Box L
+    - [ ] Box M
+    - [X] Box N
+  - [ ] Box O
 - Not a checkbox

--- a/test_helpers/fixtures/checkboxes.org
+++ b/test_helpers/fixtures/checkboxes.org
@@ -1,0 +1,8 @@
+* Header with checkboxes
+- [ ] One
+- [ ] Two
+- [X] Three 
+* Another header 
+- [ ] One
+- [ ] Two
+- [X] Three 

--- a/test_helpers/fixtures/checkboxes.org
+++ b/test_helpers/fixtures/checkboxes.org
@@ -4,7 +4,7 @@
 - [X] Box C
 * Another header [1/3]
 - [X] Box D
-- [-] Box E
+- [-] Box E [50%]
   - [ ] Box G
     - [ ] Box H
   - [X] Box I

--- a/test_helpers/fixtures/checkboxes.org
+++ b/test_helpers/fixtures/checkboxes.org
@@ -1,8 +1,11 @@
 * Header with checkboxes
 - [ ] One
 - [ ] Two
-- [X] Three 
-* Another header 
-- [ ] One
-- [ ] Two
-- [X] Three 
+- [X] Three
+* Another header [2/3]
+- [X] One
+- [-] Two
+  - [ ] Nested one
+    - [ ] Nested nested
+  - [X] Nested two
+- [X] Three

--- a/test_helpers/fixtures/more_tags.org
+++ b/test_helpers/fixtures/more_tags.org
@@ -1,0 +1,1 @@
+* Tagged header                                  :t1:t2:t3:spec_tag:

--- a/test_helpers/fixtures/nested_header.org
+++ b/test_helpers/fixtures/nested_header.org
@@ -1,2 +1,3 @@
 * Top level header
 ** A nested header
+*** A deep nested header

--- a/test_helpers/fixtures/nested_header.org
+++ b/test_helpers/fixtures/nested_header.org
@@ -1,3 +1,4 @@
 * Top level header
 ** A nested header
 *** A deep nested header
+** A second nested header

--- a/test_helpers/fixtures/nested_header.org
+++ b/test_helpers/fixtures/nested_header.org
@@ -1,0 +1,2 @@
+* Top level header
+** A nested header

--- a/test_helpers/fixtures/table.org
+++ b/test_helpers/fixtures/table.org
@@ -1,0 +1,12 @@
+* A table
+#+BEGIN: clocktable :maxlevel 25 :scope subtree :formula "$3=$2*150;t"
+#+CAPTION: Clock summary at [2019-09-22 Sun 11:21]
+| Headline            |   Time |        |
+|---------------------+--------+--------|
+| *Total time*        | *4:10* | 625.00 |
+|---------------------+--------+--------|
+| Tables              |   4:10 | 625.00 |
+| Something todo      |   2:05 | 312.50 |
+| Something else todo |   2:05 | 312.50 |
+#+TBLFM: $3=$2*150;t
+#+END:

--- a/test_helpers/fixtures/various_todos.org
+++ b/test_helpers/fixtures/various_todos.org
@@ -1,0 +1,5 @@
+* DONE This is done
+* TODO Header with repeater
+* This is not a todo
+* TODO Repeating task
+  SCHEDULED: <2019-11-27 Wed +1d>


### PR DESCRIPTION
I would like to propose a test suite for the org format transformers implemented in `src/reducer/org.js`.
This suite covers up to 99.36% of all the statements, which boosts confidence in refactoring and implementing new features.
This changeset touches almost exclusively the test code, except for the following changes in the non-test code:

- package.json: add the coverage target (running `yarn coverage` yields detailed test coverage statistics)
- src/actions/org.js: add a comment clarifying the expected values in the `updateTimestampWithId` arguments
- src/lib/timestamps.js: add a `timestampForDate` function to enable tests involving timestamps
- src/reducers/org.js:
  - fix the potential moveHeaderDown null-reference access
  - Eliminate dead code, provided `parentListItem.has('checkboxState') == parentListItem.get('isCheckbox')`. This is the most disrupting change, I will be grateful if you confirm that this assumption is correct.

The testing revealed one more bug that I would need your advice to fix:

On this line: https://github.com/200ok-ch/organice/blob/master/src/reducers/org.js#L90
the code intent is to close all the nested headers when closing a parent header.

However, the `index` variable on that line ranges over the headers themselves, not their indices (i.e. objects, not integers). That's why the code does not work.

As a result, the nested headers are never closed, but nevertheless they are hidden because their parent header is closed. So when I reopen the parent header the openness of the subheaders is preserved.

Personally, I think this is convenient, and I would preserve the current behavior and removed the erroneous code.
The alternative is to fix the erroneous code and make sure the subheaders are closed.

Shall I (a) remove the erroneous code, or (b) fix it?
