### PR TITLE
Handle a checkbox in an invalid state: throw in dev; ignore in prod

### DIFF
--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -1,3 +1,5 @@
+/* global process */
+
 import { Map, List, fromJS } from 'immutable';
 import _ from 'lodash';
 
@@ -817,7 +819,11 @@ const updateParentListCheckboxes = (state, itemPath) => {
         case 'partial':
           return false;
         default:
-          return false;
+          if (process.env.NODE_ENV !== 'production') {
+            throw Error("Unexpected checkboxState: '" + state + "'");
+          } else {
+            return false;
+          }
       }
     })
     .toJS();


### PR DESCRIPTION
As discussed in: https://github.com/200ok-ch/organice/pull/431#issuecomment-680136909

A catch-all default case might potentially conceal a bug if a new checkboxState is introduced, or a checkboxState is set into an invalid state by mistake. This change forces the code to crash, i.e. fail-stop.
The production build is not affected. 

Unfortunately, I wasn't able to check if this change does not reintroduce the lint warning. When I run `yarn lint` even with a deleted the `default` case, here is the output:
```
yarn run v1.22.4
$ yarn eslint && yarn prettier-eslint --list-different
$ ./node_modules/.bin/eslint --cache .

/home/necto/proj/organice/src/reducers/org.unit.test.js
   143:5  warning  Test has no assertions  jest/expect-expect
   262:5  warning  Test has no assertions  jest/expect-expect
   320:7  warning  Test has no assertions  jest/expect-expect
   348:7  warning  Test has no assertions  jest/expect-expect
   376:7  warning  Test has no assertions  jest/expect-expect
   380:7  warning  Test has no assertions  jest/expect-expect
   408:7  warning  Test has no assertions  jest/expect-expect
   412:7  warning  Test has no assertions  jest/expect-expect
   440:7  warning  Test has no assertions  jest/expect-expect
   444:7  warning  Test has no assertions  jest/expect-expect
   472:7  warning  Test has no assertions  jest/expect-expect
   505:7  warning  Test has no assertions  jest/expect-expect
   542:7  warning  Test has no assertions  jest/expect-expect
   690:7  warning  Test has no assertions  jest/expect-expect
   823:5  warning  Test has no assertions  jest/expect-expect
   827:5  warning  Test has no assertions  jest/expect-expect
  1059:5  warning  Test has no assertions  jest/expect-expect
  1105:5  warning  Test has no assertions  jest/expect-expect
  1149:5  warning  Test has no assertions  jest/expect-expect
  1181:5  warning  Test has no assertions  jest/expect-expect
  1298:5  warning  Test has no assertions  jest/expect-expect
  1479:7  warning  Test has no assertions  jest/expect-expect
  1483:7  warning  Test has no assertions  jest/expect-expect
  1509:7  warning  Test has no assertions  jest/expect-expect
  1513:7  warning  Test has no assertions  jest/expect-expect
  1536:7  warning  Test has no assertions  jest/expect-expect
  1540:7  warning  Test has no assertions  jest/expect-expect
  1563:7  warning  Test has no assertions  jest/expect-expect
  1567:7  warning  Test has no assertions  jest/expect-expect
  1592:7  warning  Test has no assertions  jest/expect-expect
  1596:7  warning  Test has no assertions  jest/expect-expect
  1620:7  warning  Test has no assertions  jest/expect-expect
  1624:7  warning  Test has no assertions  jest/expect-expect
  1650:7  warning  Test has no assertions  jest/expect-expect
  1654:7  warning  Test has no assertions  jest/expect-expect
  1677:7  warning  Test has no assertions  jest/expect-expect
  1681:7  warning  Test has no assertions  jest/expect-expect

✖ 37 problems (0 errors, 37 warnings)

$ ./node_modules/.bin/prettier-eslint "`pwd`/**/*.js" --list-different
/home/necto/proj/organice/src/lib/headline_filter_parser.js
/home/necto/proj/organice/src/reducers/org.js
/home/necto/proj/organice/src/reducers/org.unit.test.js
success formatting 3 files with prettier-eslint
91 files were unchanged
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
i.e., only the warnings about the no-assertions (which are misleaded by my intermediary assertion function, I'll take a look at his later).
