### PR TITLE
Fix subheader fold propagation

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -4,6 +4,13 @@ All user visible changes to organice will be documented in this file.
 
 When there are updates to the changelog, you will be notified and see a 'gift' icon appear on the top right corner.
 
+* [2020-08-29 Sat]
+** Fixed
+   - If a user folds a header, all its subheaders should collapse as well, so that when the user reopens it, they stay closed.
+     - The previous behavior is buggy in a way that it keeps the subheaders open as they were, restoring their openness when the header is unfolded.
+     - The previous behavior is useful, though. So this change introduces a user setting to toggle the behaviour.
+   - Thank you [[https://github.com/necto][necto]] for your [[https://github.com/200ok-ch/organice/pull/440][PR]] 🙏
+
 * [2020-08-25 Tue]
 ** Fixed
    - Updating table cell values and removing table rows or colums was

--- a/src/actions/base.js
+++ b/src/actions/base.js
@@ -102,6 +102,11 @@ export const setShouldLogIntoDrawer = (shouldLogIntoDrawer) => ({
   shouldLogIntoDrawer,
 });
 
+export const setCloseSubheadersRecursively = (closeSubheadersRecursively) => ({
+  type: 'SET_CLOSE_SUBHEADERS_RECURSIVELY',
+  closeSubheadersRecursively,
+});
+
 export const setShouldNotIndentOnExport = (shouldNotIndentOnExport) => ({
   type: 'SET_SHOULD_NOT_INDENT_ON_EXPORT',
   shouldNotIndentOnExport,

--- a/src/actions/org.js
+++ b/src/actions/org.js
@@ -179,9 +179,10 @@ export const openHeader = (headerId) => ({
   headerId,
 });
 
-export const toggleHeaderOpened = (headerId) => ({
+export const toggleHeaderOpened = (headerId, closeSubheadersRecursively) => ({
   type: 'TOGGLE_HEADER_OPENED',
   headerId,
+  closeSubheadersRecursively,
 });
 
 export const selectHeader = (headerId) => (dispatch) => {

--- a/src/components/OrgFile/components/Header/index.js
+++ b/src/components/OrgFile/components/Header/index.js
@@ -184,10 +184,10 @@ class Header extends PureComponent {
   handleHeaderClick(event) {
     const classList = event.target.classList;
     if (classList.contains('header') || classList.contains('header__bullet')) {
-      const { header, hasContent, isSelected } = this.props;
+      const { header, hasContent, isSelected, closeSubheadersRecursively } = this.props;
 
       if (hasContent && (!header.get('opened') || isSelected)) {
-        this.props.org.toggleHeaderOpened(header.get('id'));
+        this.props.org.toggleHeaderOpened(header.get('id'), closeSubheadersRecursively);
       }
 
       this.props.org.selectHeader(header.get('id'));
@@ -525,6 +525,7 @@ const mapStateToProps = (state, ownProps) => {
   return {
     bulletStyle: state.base.get('bulletStyle'),
     shouldLogIntoDrawer: state.base.get('shouldLogIntoDrawer'),
+    closeSubheadersRecursively: state.base.get('closeSubheadersRecursively'),
     focusedHeader,
     isFocused: !!focusedHeader && focusedHeader.get('id') === ownProps.header.get('id'),
     inEditMode: !!state.org.present.get('editMode'),

--- a/src/components/OrgFile/components/TitleLine/index.js
+++ b/src/components/OrgFile/components/TitleLine/index.js
@@ -85,13 +85,13 @@ class TitleLine extends PureComponent {
   }
 
   handleTitleClick() {
-    const { header, hasContent, isSelected, onClick } = this.props;
+    const { header, hasContent, isSelected, onClick, closeSubheadersRecursively } = this.props;
 
     if (!!onClick) {
       onClick();
     } else {
       if (hasContent && (!header.get('opened') || isSelected)) {
-        this.props.org.toggleHeaderOpened(header.get('id'));
+        this.props.org.toggleHeaderOpened(header.get('id'), closeSubheadersRecursively);
       }
 
       this.props.org.selectHeader(header.get('id'));
@@ -284,6 +284,7 @@ const mapStateToProps = (state, ownProps) => {
       state.org.present.get('selectedHeaderId') === ownProps.header.get('id'),
     setShouldLogIntoDrawer: state.base.get('shouldLogIntoDrawer'),
     shouldTapTodoToAdvance: state.base.get('shouldTapTodoToAdvance'),
+    closeSubheadersRecursively: state.base.get('closeSubheadersRecursively'),
     isSelected: state.org.present.get('selectedHeaderId') === ownProps.header.get('id'),
     todoKeywordSets: state.org.present.get('todoKeywordSets'),
   };

--- a/src/components/OrgFile/index.js
+++ b/src/components/OrgFile/index.js
@@ -140,10 +140,10 @@ class OrgFile extends PureComponent {
   }
 
   handleToggleHeaderOpenedHotKey() {
-    const { selectedHeaderId } = this.props;
+    const { selectedHeaderId, closeSubheadersRecursively } = this.props;
 
     if (selectedHeaderId) {
-      this.props.org.toggleHeaderOpened(selectedHeaderId);
+      this.props.org.toggleHeaderOpened(selectedHeaderId, closeSubheadersRecursively);
     }
   }
 
@@ -516,6 +516,7 @@ const mapStateToProps = (state) => {
     activePopupData: !!activePopup ? activePopup.get('data') : null,
     captureTemplates: state.capture.get('captureTemplates').concat(sampleCaptureTemplates),
     pendingCapture: state.org.present.get('pendingCapture'),
+    closeSubheadersRecursively: state.base.get('closeSubheadersRecursively'),
     orgFileErrorMessage: state.org.present.get('orgFileErrorMessage'),
   };
 };

--- a/src/components/Settings/index.js
+++ b/src/components/Settings/index.js
@@ -21,6 +21,7 @@ const Settings = ({
   shouldSyncOnBecomingVisibile,
   shouldShowTitleInOrgFile,
   shouldLogIntoDrawer,
+  closeSubheadersRecursively,
   shouldNotIndentOnExport,
   agendaDefaultDeadlineDelayValue,
   agendaDefaultDeadlineDelayUnit,
@@ -57,6 +58,9 @@ const Settings = ({
     base.setShouldShowTitleInOrgFile(!shouldShowTitleInOrgFile);
 
   const handleShouldLogIntoDrawer = () => base.setShouldLogIntoDrawer(!shouldLogIntoDrawer);
+
+  const handleCloseSubheadersRecursively = () =>
+    base.setCloseSubheadersRecursively(!closeSubheadersRecursively);
 
   const handleShouldNotIndentOnExport = () =>
     base.setShouldNotIndentOnExport(!shouldNotIndentOnExport);
@@ -139,6 +143,21 @@ const Settings = ({
           </div>
         </div>
         <Switch isEnabled={shouldLogIntoDrawer} onToggle={handleShouldLogIntoDrawer} />
+      </div>
+
+      <div className="setting-container">
+        <div className="setting-label">
+          When folding a header, fold all ist subheaders too
+          <div className="setting-label__description">
+            When folding a header, fold recursively all its subheaders, so that when the header is
+            reopened all subheaders are folded, regardless of their state prior to folding. If this
+            turned off, the fold-state of the subheaders is preserved when the header is unfolded.
+          </div>
+        </div>
+        <Switch
+          isEnabled={closeSubheadersRecursively}
+          onToggle={handleCloseSubheadersRecursively}
+        />
       </div>
 
       <div className="setting-container">
@@ -253,6 +272,7 @@ const mapStateToProps = (state) => {
     shouldSyncOnBecomingVisibile: state.base.get('shouldSyncOnBecomingVisibile'),
     shouldShowTitleInOrgFile: state.base.get('shouldShowTitleInOrgFile'),
     shouldLogIntoDrawer: state.base.get('shouldLogIntoDrawer'),
+    closeSubheadersRecursively: state.base.get('closeSubheadersRecursively'),
     shouldNotIndentOnExport: state.base.get('shouldNotIndentOnExport'),
     hasUnseenChangelog: state.base.get('hasUnseenChangelog'),
   };

--- a/src/components/Settings/index.js
+++ b/src/components/Settings/index.js
@@ -147,11 +147,12 @@ const Settings = ({
 
       <div className="setting-container">
         <div className="setting-label">
-          When folding a header, fold all ist subheaders too
+          When folding a header, fold all subheaders too
           <div className="setting-label__description">
             When folding a header, fold recursively all its subheaders, so that when the header is
-            reopened all subheaders are folded, regardless of their state prior to folding. If this
-            turned off, the fold-state of the subheaders is preserved when the header is unfolded.
+            reopened all subheaders are folded, regardless of their state prior to folding. This is
+            the default in Emacs Org mode. If this turned off, the fold-state of the subheaders is
+            preserved when the header is unfolded.
           </div>
         </div>
         <Switch

--- a/src/lib/org_utils.js
+++ b/src/lib/org_utils.js
@@ -50,7 +50,7 @@ export const headerWithId = (headers, headerId) => {
   return headers.get(indexOfHeaderWithId(headers, headerId));
 };
 
-export const subheadersOfHeaderWithId = (headers, headerId) => {
+const subheaderIndexRangeForHeaderId = (headers, headerId) => {
   const { header, headerIndex } = indexAndHeaderWithId(headers, headerId);
 
   const afterHeaders = headers.slice(headerIndex + 1);
@@ -59,10 +59,20 @@ export const subheadersOfHeaderWithId = (headers, headerId) => {
   });
 
   if (nextSiblingHeaderIndex === -1) {
-    return afterHeaders;
+    return [headerIndex + 1, headers.size];
   } else {
-    return afterHeaders.slice(0, nextSiblingHeaderIndex);
+    return [headerIndex + 1, headerIndex + 1 + nextSiblingHeaderIndex];
   }
+};
+
+export const subheaderIndicesOfHeaderWithId = (headers, headerId) => {
+  let [begin, end] = subheaderIndexRangeForHeaderId(headers, headerId);
+  return _.range(begin, end);
+};
+
+export const subheadersOfHeaderWithId = (headers, headerId) => {
+  let [begin, end] = subheaderIndexRangeForHeaderId(headers, headerId);
+  return headers.slice(begin, end);
 };
 
 export const numSubheadersOfHeaderWithId = (headers, headerId) =>

--- a/src/reducers/base.js
+++ b/src/reducers/base.js
@@ -33,6 +33,9 @@ const setShouldShowTitleInOrgFile = (state, action) =>
 const setShouldLogIntoDrawer = (state, action) =>
   state.set('shouldLogIntoDrawer', action.shouldLogIntoDrawer);
 
+const setCloseSubheadersRecursively = (state, action) =>
+  state.set('closeSubheadersRecursively', action.closeSubheadersRecursively);
+
 /**
  * When enabled, keep all heading body text flush-left. When disabled (the
  * default) indent the body text of headings according to the nesting level of
@@ -137,6 +140,8 @@ export default (state = Map(), action) => {
       return setShouldShowTitleInOrgFile(state, action);
     case 'SET_SHOULD_LOG_INTO_DRAWER':
       return setShouldLogIntoDrawer(state, action);
+    case 'SET_CLOSE_SUBHEADERS_RECURSIVELY':
+      return setCloseSubheadersRecursively(state, action);
     case 'SET_SHOULD_NOT_INDENT_ON_EXPORT':
       return setShouldNotIndentOnExport(state, action);
     case 'SET_HAS_UNSEEN_CHANGELOG':

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -86,7 +86,7 @@ const toggleHeaderOpened = (state, action) => {
     return state;
   }
 
-  if (isOpened) {
+  if (isOpened && action.closeSubheadersRecursively) {
     const subheaderIndices = subheaderIndicesOfHeaderWithId(headers, action.headerId);
     subheaderIndices.forEach((index) => {
       state = state.setIn(['headers', index, 'opened'], false);

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -27,6 +27,7 @@ import {
   indexAndHeaderWithId,
   parentIdOfHeaderWithId,
   subheadersOfHeaderWithId,
+  subheaderIndicesOfHeaderWithId,
   numSubheadersOfHeaderWithId,
   indexOfPreviousSibling,
   openDirectParent,
@@ -86,9 +87,9 @@ const toggleHeaderOpened = (state, action) => {
   }
 
   if (isOpened) {
-    const subheaders = subheadersOfHeaderWithId(headers, action.headerId);
-    subheaders.forEach((index) => {
-      state = state.setIn(['headers', headerIndex + index + 1, 'opened'], false);
+    const subheaderIndices = subheaderIndicesOfHeaderWithId(headers, action.headerId);
+    subheaderIndices.forEach((index) => {
+      state = state.setIn(['headers', index, 'opened'], false);
     });
   }
 

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -697,6 +697,20 @@ describe('org reducer', () => {
         expect(headerWithId(newState.get('headers'), nestedHeaderId).get('opened')).toEqual(false);
       });
 
+      it('should close the header and subheaders on the second toggle', () => {
+        const topLevelOpen = reducer(state.org.present, types.toggleHeaderOpened(topLevelHeaderId));
+        const nestedOpen = reducer(topLevelOpen, types.toggleHeaderOpened(nestedHeaderId));
+        const deepNestedOpen = reducer(nestedOpen, types.toggleHeaderOpened(deepNestedHeaderId));
+        const allClosed = reducer(deepNestedOpen, types.toggleHeaderOpened(topLevelHeaderId));
+        expect(headerWithId(allClosed.get('headers'), topLevelHeaderId).get('opened')).toEqual(
+          false
+        );
+        expect(headerWithId(allClosed.get('headers'), nestedHeaderId).get('opened')).toEqual(false);
+        expect(headerWithId(allClosed.get('headers'), deepNestedHeaderId).get('opened')).toEqual(
+          false
+        );
+      });
+
       it('should ignore if focused and open', () => {
         expect(state.org.present.get('headers').every((hdr) => !hdr.get('opened'))).toEqual(true);
         const openState = reducer(state.org.present, types.toggleHeaderOpened(topLevelHeaderId));

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -692,30 +692,63 @@ describe('org reducer', () => {
 
     describe('TOGGLE_HEADER_OPENED', () => {
       it('should open only the header on the first toggle', () => {
-        const newState = reducer(state.org.present, types.toggleHeaderOpened(topLevelHeaderId));
+        const newState = reducer(
+          state.org.present,
+          types.toggleHeaderOpened(topLevelHeaderId, true)
+        );
         expect(headerWithId(newState.get('headers'), topLevelHeaderId).get('opened')).toEqual(true);
         expect(headerWithId(newState.get('headers'), nestedHeaderId).get('opened')).toEqual(false);
       });
 
       it('should close the header and subheaders on the second toggle', () => {
-        const topLevelOpen = reducer(state.org.present, types.toggleHeaderOpened(topLevelHeaderId));
-        const nestedOpen = reducer(topLevelOpen, types.toggleHeaderOpened(nestedHeaderId));
-        const deepNestedOpen = reducer(nestedOpen, types.toggleHeaderOpened(deepNestedHeaderId));
-        const allClosed = reducer(deepNestedOpen, types.toggleHeaderOpened(topLevelHeaderId));
-        expect(headerWithId(allClosed.get('headers'), topLevelHeaderId).get('opened')).toEqual(
+        const topLevelOpen = reducer(
+          state.org.present,
+          types.toggleHeaderOpened(topLevelHeaderId, true)
+        );
+        const nestedOpen = reducer(topLevelOpen, types.toggleHeaderOpened(nestedHeaderId, true));
+        const deepNestedOpen = reducer(
+          nestedOpen,
+          types.toggleHeaderOpened(deepNestedHeaderId, true)
+        );
+        const allClosed = reducer(deepNestedOpen, types.toggleHeaderOpened(topLevelHeaderId, true));
+        const reopened = reducer(allClosed, types.toggleHeaderOpened(topLevelHeaderId, true));
+        expect(headerWithId(reopened.get('headers'), topLevelHeaderId).get('opened')).toEqual(true);
+        expect(headerWithId(reopened.get('headers'), nestedHeaderId).get('opened')).toEqual(false);
+        expect(headerWithId(reopened.get('headers'), deepNestedHeaderId).get('opened')).toEqual(
           false
         );
-        expect(headerWithId(allClosed.get('headers'), nestedHeaderId).get('opened')).toEqual(false);
-        expect(headerWithId(allClosed.get('headers'), deepNestedHeaderId).get('opened')).toEqual(
-          false
+      });
+
+      it('should close only the header when said so', () => {
+        const topLevelOpen = reducer(
+          state.org.present,
+          types.toggleHeaderOpened(topLevelHeaderId, true)
+        );
+        const nestedOpen = reducer(topLevelOpen, types.toggleHeaderOpened(nestedHeaderId, true));
+        const deepNestedOpen = reducer(
+          nestedOpen,
+          types.toggleHeaderOpened(deepNestedHeaderId, true)
+        );
+        const allClosed = reducer(
+          deepNestedOpen,
+          types.toggleHeaderOpened(topLevelHeaderId, false)
+        );
+        const reopened = reducer(allClosed, types.toggleHeaderOpened(topLevelHeaderId, false));
+        expect(headerWithId(reopened.get('headers'), topLevelHeaderId).get('opened')).toEqual(true);
+        expect(headerWithId(reopened.get('headers'), nestedHeaderId).get('opened')).toEqual(true);
+        expect(headerWithId(reopened.get('headers'), deepNestedHeaderId).get('opened')).toEqual(
+          true
         );
       });
 
       it('should ignore if focused and open', () => {
         expect(state.org.present.get('headers').every((hdr) => !hdr.get('opened'))).toEqual(true);
-        const openState = reducer(state.org.present, types.toggleHeaderOpened(topLevelHeaderId));
+        const openState = reducer(
+          state.org.present,
+          types.toggleHeaderOpened(topLevelHeaderId, true)
+        );
         const focusedState = reducer(openState, types.focusHeader(topLevelHeaderId));
-        const newState = reducer(focusedState, types.toggleHeaderOpened(topLevelHeaderId));
+        const newState = reducer(focusedState, types.toggleHeaderOpened(topLevelHeaderId, true));
         expect(newState).toEqual(focusedState);
       });
     });

--- a/src/util/settings_persister.js
+++ b/src/util/settings_persister.js
@@ -119,6 +119,12 @@ export const persistableFields = [
   },
   {
     category: 'base',
+    name: 'closeSubheadersRecursively',
+    type: 'boolean',
+    shouldStoreInConfig: true,
+  },
+  {
+    category: 'base',
     name: 'shouldNotIndentOnExport',
     type: 'boolean',
     shouldStoreInConfig: true,


### PR DESCRIPTION
Addressing the bug found in #431:

If a user folds a header, all its subheaders should collapse as well, so that when the user reopens it, they stay closed.

The previous behavior is buggy in a way that it keeps the subheaders open as they were, restoring their openness when the header is unfolded.

The previous behavior is useful at least for two users of organice (@munen and myself), so this change set also introduces a user setting.