### PR TITLE
Auto-focus filter input fields

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -9,6 +9,8 @@ When there are updates to the changelog, you will be notified and see a 'gift' i
 ** Added
    - Add note to header (=M-x org-add-note=)
      - This adds a button for taking notes to tasks (org-add-note). They will be prepended to the header contents after :PROPERTIES: and before the :LOGBOOK:
+   - Auto-focus filter input fields (search and task-list)
+
 * [2020-08-29 Sat]
 ** Fixed
    - If a user folds a header, all its subheaders should collapse as well, so that when the user reopens it, they stay closed.

--- a/src/components/OrgFile/components/SearchModal/index.js
+++ b/src/components/OrgFile/components/SearchModal/index.js
@@ -57,7 +57,7 @@ function SearchModal(props) {
         <input
           type="text"
           value={searchFilter}
-          autoFous
+          autoFocus
           className={classNames('textfield', 'task-list__filter-input', {
             'task-list__filter-input--invalid': !!searchFilter && !searchFilterValid,
           })}

--- a/src/components/OrgFile/components/SearchModal/index.js
+++ b/src/components/OrgFile/components/SearchModal/index.js
@@ -57,6 +57,7 @@ function SearchModal(props) {
         <input
           type="text"
           value={searchFilter}
+          autoFous
           className={classNames('textfield', 'task-list__filter-input', {
             'task-list__filter-input--invalid': !!searchFilter && !searchFilterValid,
           })}

--- a/src/components/OrgFile/components/TaskListModal/index.js
+++ b/src/components/OrgFile/components/TaskListModal/index.js
@@ -58,6 +58,7 @@ function TaskListModal(props) {
         <input
           type="text"
           value={searchFilter}
+          autoFocus
           className={classNames('textfield', 'task-list__filter-input', {
             'task-list__filter-input--invalid': !!searchFilter && !searchFilterValid,
           })}


### PR DESCRIPTION
Closes #404 

I thought, I already had an [`autofocus` attribute](https://developer.mozilla.org/de/docs/Web/HTML/Element/Input) on the input fields once, but they have no effect. In React the attribute must be `autoFocus`: https://blog.danieljohnson.io/react-ref-autofocus/