### PR TITLE
Replace some <a> tags with <ExternalLink>

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,9 +50,9 @@
     "eslint-nibble": "^5.1.0",
     "eslint-plugin-jest": "^23.20.0",
     "eslint-plugin-react": "^7.20.6",
-    "eslint-plugin-react-redux": "^3.1.0",
-    "prettier": "^2.0.5",
+    "eslint-plugin-react-redux": "^3.3.0",
     "prettier-eslint": "^11.0.0",
+    "prettier": "^2.0.5",
     "prettier-eslint-cli": "^5.0.0",
     "raw.macro": "0.4.2",
     "react-test-renderer": "^16.13.1"

--- a/package.json
+++ b/package.json
@@ -50,9 +50,9 @@
     "eslint-nibble": "^5.1.0",
     "eslint-plugin-jest": "^23.20.0",
     "eslint-plugin-react": "^7.20.6",
-    "eslint-plugin-react-redux": "^3.3.0",
-    "prettier-eslint": "^11.0.0",
+    "eslint-plugin-react-redux": "^3.1.0",
     "prettier": "^2.0.5",
+    "prettier-eslint": "^11.0.0",
     "prettier-eslint-cli": "^5.0.0",
     "raw.macro": "0.4.2",
     "react-test-renderer": "^16.13.1"

--- a/public/index.html
+++ b/public/index.html
@@ -21,11 +21,11 @@
       crossorigin="anonymous"
     />
     <title>organice</title>
-    <link rel="manifest" href="/manifest.json">
+    <link rel="manifest" href="/manifest.json" />
   </head>
   <body>
     <noscript>
-      <div style="font-size: 22px; font-family: sans;">
+      <div style="font-size: 22px; font-family: sans">
         It looks like you don't have JavaScript enabled, but organice is a big, fancy React app that
         requires JavaScript to run!
 
@@ -34,7 +34,7 @@
 
         If you're interested in inspecting the source code yourself (or even deploying your own
         version of the project), you can find the project's repo here:
-        <a href="https://github.com/200ok-ch/organice" target="_blank" rel="noopener noreferrer">https://github.com/200ok-ch/organice</a>
+        <ExternalLink href="https://github.com/200ok-ch/organice" />
       </div>
     </noscript>
     <script

--- a/src/components/CaptureTemplatesEditor/components/CaptureTemplate/index.js
+++ b/src/components/CaptureTemplatesEditor/components/CaptureTemplate/index.js
@@ -119,10 +119,9 @@ export default ({
       <div className="capture-template__help-text">
         Instead of a letter, you can specify the name of any free Font Awesome icon (like lemon or
         calendar-plus) to use as the capture icon. You can search the available icons{' '}
-        <ExternalLink
-          href="https://fontawesome.com/icons?d=gallery&s=solid&m=free"
-          content="here"
-        />
+        <ExternalLink href="https://fontawesome.com/icons?d=gallery&s=solid&m=free">
+          here
+        </ExternalLink>
         .
       </div>
     </div>
@@ -279,10 +278,9 @@ export default ({
           </li>
           <li>
             <code>%{'<custom variable>'}</code> - A custom variable from a URL param capture. See{' '}
-            <ExternalLink
-              href="https://organice.200ok.ch/documentation.html#capture_templates"
-              content="the README file"
-            />{' '}
+            <ExternalLink href="https://organice.200ok.ch/documentation.html#capture_templates">
+              the README file
+            </ExternalLink>{' '}
             for more details.
           </li>
         </ul>

--- a/src/components/CaptureTemplatesEditor/components/CaptureTemplate/index.js
+++ b/src/components/CaptureTemplatesEditor/components/CaptureTemplate/index.js
@@ -7,6 +7,7 @@ import './stylesheet.css';
 
 import ActionButton from '../../../OrgFile/components/ActionDrawer/components/ActionButton';
 import Switch from '../../../UI/Switch/';
+import ExternalLink from '../../../UI/ExternalLink';
 
 import classNames from 'classnames';
 
@@ -118,13 +119,10 @@ export default ({
       <div className="capture-template__help-text">
         Instead of a letter, you can specify the name of any free Font Awesome icon (like lemon or
         calendar-plus) to use as the capture icon. You can search the available icons{' '}
-        <a
+        <ExternalLink
           href="https://fontawesome.com/icons?d=gallery&s=solid&m=free"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          here
-        </a>
+          content="here"
+        />
         .
       </div>
     </div>
@@ -281,13 +279,10 @@ export default ({
           </li>
           <li>
             <code>%{'<custom variable>'}</code> - A custom variable from a URL param capture. See{' '}
-            <a
+            <ExternalLink
               href="https://organice.200ok.ch/documentation.html#capture_templates"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              the README file
-            </a>{' '}
+              content="the README file"
+            />{' '}
             for more details.
           </li>
         </ul>

--- a/src/components/HeaderBar/index.js
+++ b/src/components/HeaderBar/index.js
@@ -267,8 +267,9 @@ class HeaderBar extends PureComponent {
 
           {!isAuthenticated && (
             <span>
-              <ExternalLink href="https://github.com/200ok-ch/organice" content="" />
-              <i className="fab fa-github header-bar__actions__item" />
+              <ExternalLink href="https://github.com/200ok-ch/organice">
+                <i className="fab fa-github header-bar__actions__item" />
+              </ExternalLink>
             </span>
           )}
 

--- a/src/components/HeaderBar/index.js
+++ b/src/components/HeaderBar/index.js
@@ -12,6 +12,8 @@ import * as baseActions from '../../actions/base';
 import * as orgActions from '../../actions/org';
 import { ActionCreators as undoActions } from 'redux-undo';
 
+import ExternalLink from '../UI/ExternalLink';
+
 import { List } from 'immutable';
 import _ from 'lodash';
 import classNames from 'classnames';
@@ -264,13 +266,10 @@ class HeaderBar extends PureComponent {
           )}
 
           {!isAuthenticated && (
-            <a
-              href="https://github.com/200ok-ch/organice"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
+            <span>
+              <ExternalLink href="https://github.com/200ok-ch/organice" content="" />
               <i className="fab fa-github header-bar__actions__item" />
-            </a>
+            </span>
           )}
 
           {isAuthenticated && !activeModalPage && !!path && (

--- a/src/components/HeaderBar/index.js
+++ b/src/components/HeaderBar/index.js
@@ -266,11 +266,9 @@ class HeaderBar extends PureComponent {
           )}
 
           {!isAuthenticated && (
-            <span>
-              <ExternalLink href="https://github.com/200ok-ch/organice">
-                <i className="fab fa-github header-bar__actions__item" />
-              </ExternalLink>
-            </span>
+            <ExternalLink href="https://github.com/200ok-ch/organice">
+              <i className="fab fa-github header-bar__actions__item" />
+            </ExternalLink>
           )}
 
           {isAuthenticated && !activeModalPage && !!path && (

--- a/src/components/Landing/__snapshots__/Landing.test.js.snap
+++ b/src/components/Landing/__snapshots__/Landing.test.js.snap
@@ -54,7 +54,7 @@ exports[`<Landing /> renders 1`] = `
         </div>
       </a>
       <a
-        href="/documentation.html"
+        href="https://organice.200ok.ch/documentation.html"
         rel="noopener noreferrer"
         target="_blank"
       >

--- a/src/components/Landing/index.js
+++ b/src/components/Landing/index.js
@@ -32,7 +32,7 @@ export default () => {
         <Link to="/sample">
           <div className="btn landing-button doc-button">View sample</div>
         </Link>
-        <ExternalLink href="/documentation.html">
+        <ExternalLink href="https://organice.200ok.ch/documentation.html">
           <div className="btn landing-button doc-button">Documentation</div>
         </ExternalLink>
       </div>

--- a/src/components/Landing/index.js
+++ b/src/components/Landing/index.js
@@ -32,8 +32,9 @@ export default () => {
         <Link to="/sample">
           <div className="btn landing-button doc-button">View sample</div>
         </Link>
-        <div className="btn landing-button doc-button"></div>
-        <ExternalLink href="/documentation.html" content="Documentation" />
+        <ExternalLink href="/documentation.html">
+          <div className="btn landing-button doc-button">Documentation</div>
+        </ExternalLink>
       </div>
       <footer>
         <Link to="/privacy-policy">Privacy Policy</Link>

--- a/src/components/Landing/index.js
+++ b/src/components/Landing/index.js
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 
 import './stylesheet.css';
 import logo from '../../images/organice.svg';
+import ExternalLink from '../UI/ExternalLink';
 
 export default () => {
   return (
@@ -31,9 +32,8 @@ export default () => {
         <Link to="/sample">
           <div className="btn landing-button doc-button">View sample</div>
         </Link>
-        <a href="/documentation.html" target="_blank" rel="noopener noreferrer">
-          <div className="btn landing-button doc-button">Documentation</div>
-        </a>
+        <div className="btn landing-button doc-button"></div>
+        <ExternalLink href="/documentation.html" content="Documentation" />
       </div>
       <footer>
         <Link to="/privacy-policy">Privacy Policy</Link>

--- a/src/components/OrgFile/components/AttributedString/index.js
+++ b/src/components/OrgFile/components/AttributedString/index.js
@@ -7,6 +7,7 @@ import './stylesheet.css';
 import TablePart from './components/TablePart';
 import ListPart from './components/ListPart';
 import TimestampPart from './components/TimestampPart';
+import ExternalLink from '../../../UI/ExternalLink';
 
 import { orgFileExtensions } from '../../../../lib/org_utils';
 
@@ -51,11 +52,7 @@ export default ({ parts, subPartDataAndHandlers }) => {
       target = 'file://' + target;
     }
 
-    return (
-      <a key={id} href={target} target="_blank" rel="noopener noreferrer">
-        {title}
-      </a>
-    );
+    return <ExternalLink key={id} href={target} content={title} />;
   };
 
   const normalisePath = (target) => {
@@ -142,25 +139,19 @@ export default ({ parts, subPartDataAndHandlers }) => {
             );
           case 'url':
             return (
-              <a
+              <ExternalLink
                 href={part.get('content')}
                 key={part.get('id')}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {part.get('content')}
-              </a>
+                content={part.get('content')}
+              />
             );
           case 'www-url':
             return (
-              <a
+              <ExternalLink
                 href={`https://${part.get('content')}`}
                 key={part.get('id')}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {part.get('content')}
-              </a>
+                content={part.get('content')}
+              />
             );
           case 'e-mail':
             return (

--- a/src/components/OrgFile/components/AttributedString/index.js
+++ b/src/components/OrgFile/components/AttributedString/index.js
@@ -52,7 +52,11 @@ export default ({ parts, subPartDataAndHandlers }) => {
       target = 'file://' + target;
     }
 
-    return <ExternalLink key={id} href={target} content={title} />;
+    return (
+      <ExternalLink key={id} href={target}>
+        {title}
+      </ExternalLink>
+    );
   };
 
   const normalisePath = (target) => {
@@ -139,19 +143,15 @@ export default ({ parts, subPartDataAndHandlers }) => {
             );
           case 'url':
             return (
-              <ExternalLink
-                href={part.get('content')}
-                key={part.get('id')}
-                content={part.get('content')}
-              />
+              <ExternalLink href={part.get('content')} key={part.get('id')}>
+                {part.get('content')}
+              </ExternalLink>
             );
           case 'www-url':
             return (
-              <ExternalLink
-                href={`https://${part.get('content')}`}
-                key={part.get('id')}
-                content={part.get('content')}
-              />
+              <ExternalLink href={`https://${part.get('content')}`} key={part.get('id')}>
+                {part.get('content')}
+              </ExternalLink>
             );
           case 'e-mail':
             return (

--- a/src/components/OrgFile/index.js
+++ b/src/components/OrgFile/index.js
@@ -393,10 +393,9 @@ class OrgFile extends PureComponent {
           <br />
           This was probably the result of an error in attempting to parse your org file. It'd be
           super helpful if you could{' '}
-          <ExternalLink
-            href="https://github.com/200ok-ch/organice/issues/new"
-            content="create an issue"
-          />{' '}
+          <ExternalLink href="https://github.com/200ok-ch/organice/issues/new">
+            create an issue
+          </ExternalLink>{' '}
           (and include the org file if possible!)
         </div>
       );
@@ -463,10 +462,9 @@ class OrgFile extends PureComponent {
               ) : (
                 <Fragment>
                   If you think this is a bug, please{' '}
-                  <ExternalLink
-                    href="https://github.com/200ok-ch/organice/issues/new"
-                    content="create an issue"
-                  />{' '}
+                  <ExternalLink href="https://github.com/200ok-ch/organice/issues/new">
+                    create an issue
+                  </ExternalLink>{' '}
                   and include the org file if possible!
                 </Fragment>
               )}

--- a/src/components/OrgFile/index.js
+++ b/src/components/OrgFile/index.js
@@ -18,6 +18,7 @@ import PropertyListEditorModal from './components/PropertyListEditorModal';
 import AgendaModal from './components/AgendaModal';
 import TaskListModal from './components/TaskListModal';
 import SearchModal from './components/SearchModal';
+import ExternalLink from '../UI/ExternalLink';
 
 import * as baseActions from '../../actions/base';
 import * as syncBackendActions from '../../actions/sync_backend';
@@ -392,13 +393,10 @@ class OrgFile extends PureComponent {
           <br />
           This was probably the result of an error in attempting to parse your org file. It'd be
           super helpful if you could{' '}
-          <a
+          <ExternalLink
             href="https://github.com/200ok-ch/organice/issues/new"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            create an issue
-          </a>{' '}
+            content="create an issue"
+          />{' '}
           (and include the org file if possible!)
         </div>
       );
@@ -465,13 +463,10 @@ class OrgFile extends PureComponent {
               ) : (
                 <Fragment>
                   If you think this is a bug, please{' '}
-                  <a
+                  <ExternalLink
                     href="https://github.com/200ok-ch/organice/issues/new"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    create an issue
-                  </a>{' '}
+                    content="create an issue"
+                  />{' '}
                   and include the org file if possible!
                 </Fragment>
               )}

--- a/src/components/PrivacyPolicy/index.js
+++ b/src/components/PrivacyPolicy/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import './stylesheet.css';
+import ExternalLink from '../UI/ExternalLink';
 const PrivacyPolicy = () => {
   return (
     <div className="privacy-policy-container">
@@ -7,10 +8,8 @@ const PrivacyPolicy = () => {
       <p>Last updated: May 9th, 2020</p>
 
       <p>
-        <a href="https://200ok.ch/" target="_blank" rel="noopener noreferrer">
-          200ok llc
-        </a>{' '}
-        operates the https://organice.200ok.ch website and mobile apps.
+        <ExternalLink href="https://200ok.ch/" content="200ok llc" /> operates the{' '}
+        <ExternalLink href="https://organice.200ok.ch" /> website and mobile apps.
       </p>
 
       <p>

--- a/src/components/PrivacyPolicy/index.js
+++ b/src/components/PrivacyPolicy/index.js
@@ -8,7 +8,7 @@ const PrivacyPolicy = () => {
       <p>Last updated: May 9th, 2020</p>
 
       <p>
-        <ExternalLink href="https://200ok.ch/" content="200ok llc" /> operates the{' '}
+        <ExternalLink href="https://200ok.ch/">200ok llc</ExternalLink> operates the{' '}
         <ExternalLink href="https://organice.200ok.ch" /> website and mobile apps.
       </p>
 

--- a/src/components/Settings/index.js
+++ b/src/components/Settings/index.js
@@ -11,6 +11,7 @@ import './stylesheet.css';
 
 import TabButtons from '../UI/TabButtons';
 import Switch from '../UI/Switch';
+import ExternalLink from '../UI/ExternalLink';
 
 const Settings = ({
   fontSize,
@@ -136,13 +137,10 @@ const Settings = ({
           <div className="setting-label__description">
             Log TODO state changes (currently only for repeating items) into the LOGBOOK drawer
             instead of into the body of the heading (default). See the Orgmode documentation on{' '}
-            <a
+            <ExternalLink
               href="https://www.gnu.org/software/emacs/manual/html_node/org/Tracking-TODO-state-changes.html"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              org-log-into-drawer
-            </a>{' '}
+              content="org-log-into-drawer"
+            />{' '}
             for more information.
           </div>
         </div>
@@ -172,13 +170,12 @@ const Settings = ({
             By default, the metadata body (including deadlines and drawers) of an exported org
             heading is indented according to its level. If instead you prefer to keep your body text
             flush-left, i.e.{' '}
-            <a
-              href="https://orgmode.org/manual/Hard-indentation.html"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <code>(setq org-adapt-indentation nil)</code>
-            </a>
+            <code>
+              <ExternalLink
+                href="https://orgmode.org/manual/Hard-indentation.html"
+                content="(setq org-adapt-indentation nil)"
+              />
+            </code>
             , then activate this setting. The raw content text is left unchanged.
           </div>
         </div>
@@ -244,19 +241,16 @@ const Settings = ({
         </Link>
 
         <button className="btn settings-btn">
-          <a
+          <ExternalLink
             href="https://organice.200ok.ch/documentation.html"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation <i className="fas fa-external-link-alt fa-sm" />
-          </a>
+            content="Documentation"
+          />{' '}
+          <i className="fas fa-external-link-alt fa-sm" />
         </button>
 
         <button className="btn settings-btn">
-          <a href="https://github.com/200ok-ch/organice" target="_blank" rel="noopener noreferrer">
-            Github repo <i className="fas fa-external-link-alt fa-sm" />
-          </a>
+          <ExternalLink href="https://github.com/200ok-ch/organice" content="Github repo" />{' '}
+          <i className="fas fa-external-link-alt fa-sm" />
         </button>
 
         <hr className="settings-button-separator" />

--- a/src/components/Settings/index.js
+++ b/src/components/Settings/index.js
@@ -137,10 +137,9 @@ const Settings = ({
           <div className="setting-label__description">
             Log TODO state changes (currently only for repeating items) into the LOGBOOK drawer
             instead of into the body of the heading (default). See the Orgmode documentation on{' '}
-            <ExternalLink
-              href="https://www.gnu.org/software/emacs/manual/html_node/org/Tracking-TODO-state-changes.html"
-              content="org-log-into-drawer"
-            />{' '}
+            <ExternalLink href="https://www.gnu.org/software/emacs/manual/html_node/org/Tracking-TODO-state-changes.html">
+              <code>org-log-into-drawer</code>
+            </ExternalLink>{' '}
             for more information.
           </div>
         </div>
@@ -170,12 +169,9 @@ const Settings = ({
             By default, the metadata body (including deadlines and drawers) of an exported org
             heading is indented according to its level. If instead you prefer to keep your body text
             flush-left, i.e.{' '}
-            <code>
-              <ExternalLink
-                href="https://orgmode.org/manual/Hard-indentation.html"
-                content="(setq org-adapt-indentation nil)"
-              />
-            </code>
+            <ExternalLink href="https://orgmode.org/manual/Hard-indentation.html">
+              <code>(setq org-adapt-indentation nil)</code>
+            </ExternalLink>
             , then activate this setting. The raw content text is left unchanged.
           </div>
         </div>
@@ -241,16 +237,17 @@ const Settings = ({
         </Link>
 
         <button className="btn settings-btn">
-          <ExternalLink
-            href="https://organice.200ok.ch/documentation.html"
-            content="Documentation"
-          />{' '}
-          <i className="fas fa-external-link-alt fa-sm" />
+          <ExternalLink href="https://organice.200ok.ch/documentation.html">
+            Documentation
+            <i className="fas fa-external-link-alt fa-sm" />
+          </ExternalLink>{' '}
         </button>
 
         <button className="btn settings-btn">
-          <ExternalLink href="https://github.com/200ok-ch/organice" content="Github repo" />{' '}
-          <i className="fas fa-external-link-alt fa-sm" />
+          <ExternalLink href="https://github.com/200ok-ch/organice">
+            Github repo
+            <i className="fas fa-external-link-alt fa-sm" />
+          </ExternalLink>{' '}
         </button>
 
         <hr className="settings-button-separator" />

--- a/src/components/UI/ExternalLink/index.js
+++ b/src/components/UI/ExternalLink/index.js
@@ -1,8 +1,8 @@
 import React from 'react';
-export default ({ href, content, key }) => {
+export default ({ href, key, children }) => {
   return (
     <a href={href} target="_blank" rel="noopener noreferrer" key={key}>
-      {content ? content : href}
+      {children ? children : href}
     </a>
   );
 };

--- a/src/components/UI/ExternalLink/index.js
+++ b/src/components/UI/ExternalLink/index.js
@@ -1,0 +1,8 @@
+import React from 'react';
+export default ({ href, content, key }) => {
+  return (
+    <a href={href} target="_blank" rel="noopener noreferrer" key={key}>
+      {content ? content : href}
+    </a>
+  );
+};

--- a/src/components/UI/ExternalLink/index.js
+++ b/src/components/UI/ExternalLink/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
-export default ({ href, key, children }) => {
+export default ({ href, children }) => {
   return (
-    <a href={href} target="_blank" rel="noopener noreferrer" key={key}>
+    <a href={href} target="_blank" rel="noopener noreferrer">
       {children ? children : href}
     </a>
   );


### PR DESCRIPTION
The first examples looked like this interface is good: `<ExternalLink href="url" content="text" />`

But later, I stumpled upon links with HTML tags inside, so it's probably better to allow children as described here: https://reactjs.org/docs/composition-vs-inheritance.html

Any reason to keep the `content` property and only use its value instead of childen if no children? Maybe it's a little bit shorter? But I think it's cleaner to have only one "interface".