### PR TITLE
fix: UX regression for iOS on Search and TODO List

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -4,6 +4,11 @@ All user visible changes to organice will be documented in this file.
 
 When there are updates to the changelog, you will be notified and see a 'gift' icon appear on the top right corner.
 
+* [2020-09-05 Sat]
+
+** Fixed
+  - Search and Todo List modals could be moved off screen on iOS since [2020-08-30 Sun]. The fix is to disable =autoFocus= on is. The rationale for that documented here: https://github.com/200ok-ch/organice/pull/462
+
 * [2020-08-30 Sun]
 
 ** Added

--- a/sample.org
+++ b/sample.org
@@ -166,7 +166,7 @@ Checkboxes:
 
 Currently, plain lists are mostly display only (except that you can check/uncheck checkboxes). If native support for manipulating plain lists is important to you, please let me know by upvoting [[https://github.com/200ok-ch/organice/issues/26][the issue]] on Github
 * Timestamps
-organice has native support for displaying and editing timestamps.
+organice has native support for displaying and editing [[https://orgmode.org/manual/Timestamps.html#Timestamps][timestamps]].
 
 Try tapping on the timestamps below to get a feel for the editor:
 

--- a/src/components/OrgFile/components/CaptureModal/index.js
+++ b/src/components/OrgFile/components/CaptureModal/index.js
@@ -126,7 +126,7 @@ export default ({ template, onCapture, headers, onClose }) => {
             rows="4"
             value={textareaValue}
             onChange={handleTextareaChange}
-            autoFocus={true}
+            autoFocus
             ref={textarea}
           />
           <div className="capture-modal-button-container">

--- a/src/components/OrgFile/components/SearchModal/index.js
+++ b/src/components/OrgFile/components/SearchModal/index.js
@@ -9,7 +9,7 @@ import classNames from 'classnames';
 import HeaderListView from './components/HeaderListView';
 import Drawer from '../../../UI/Drawer';
 
-import { isMobileBrowser } from '../../../../lib/browser_utils';
+import { isMobileBrowser, isIos } from '../../../../lib/browser_utils';
 
 import * as orgActions from '../../../../actions/org';
 
@@ -57,7 +57,18 @@ function SearchModal(props) {
         <input
           type="text"
           value={searchFilter}
-          autoFocus
+          // On iOS, setting autoFocus here will move the contents of
+          // the drawer off the screen, because the keyboard pops up
+          // late when the height is already set to '92%'. Some other
+          // complications: There's no API to check if the keyboard is
+          // open or not. When setting the height of the container to
+          // something like 48% for iOS, this works on iPhone (tested
+          // on Xs and 6S), but when the keyboard is closed, the
+          // container is still small when the user wants to read the
+          // longer list without the keyboard in the way. There might
+          // be a better way: If the drawer wouldn't move, iOS likely
+          // would set the heights correctly automatically.
+          autoFocus={!isIos()}
           className={classNames('textfield', 'task-list__filter-input', {
             'task-list__filter-input--invalid': !!searchFilter && !searchFilterValid,
           })}

--- a/src/components/OrgFile/components/TaskListModal/index.js
+++ b/src/components/OrgFile/components/TaskListModal/index.js
@@ -8,7 +8,7 @@ import classNames from 'classnames';
 import TaskListView from './components/TaskListView';
 import Drawer from '../../../UI/Drawer';
 
-import { isMobileBrowser } from '../../../../lib/browser_utils';
+import { isMobileBrowser, isIos } from '../../../../lib/browser_utils';
 
 import * as orgActions from '../../../../actions/org';
 
@@ -58,7 +58,8 @@ function TaskListModal(props) {
         <input
           type="text"
           value={searchFilter}
-          autoFocus
+          // Rationale: See SearchModal: index.js
+          autoFocus={!isIos()}
           className={classNames('textfield', 'task-list__filter-input', {
             'task-list__filter-input--invalid': !!searchFilter && !searchFilterValid,
           })}

--- a/src/lib/browser_utils.js
+++ b/src/lib/browser_utils.js
@@ -29,6 +29,14 @@ export const isMobileBrowser = (() => {
   });
 })();
 
+export const isIos = () => {
+  return browser.satisfies({
+    mobile: {
+      safari: '>=6',
+    },
+  });
+};
+
 /** Is iPhone Model X (tested with Xs) */
 export const isIphoneX = window.matchMedia
   ? window.matchMedia('(max-device-width: 812px) and (-webkit-device-pixel-ratio : 3)').matches


### PR DESCRIPTION
Closes #454.

Unfortunately, the 'fix' is to disable auto-focus for iOS. Rationale:

On iOS, setting autoFocus in the `Modal` will move the contents of the
drawer off the screen, because the keyboard pops up late when the
height is already set to '92%' in the `Drawer`. With Redux, we could
certainly propagate a height back, but that seems hacky and there's
other complications:

- There's no API to check if the keyboard is open or not. 
- When setting the height of the container to something like 48% for iOS, this works on iPhone (tested on Xs and 6S), but when the keyboard is closed, the container is still small when the user wants to read the longer list without the keyboard in the way.

There might be a better way: If the drawer wouldn't move, iOS likely
would set the heights correctly automatically.

I didn't spend more time on this (it's already hours), because the
_right_ solution would likely be to work on redoing the design in a
well known fashion like Material Design.