### PR TITLE
fix: Get rid of `start_url` in manifest.json

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -18,7 +18,6 @@
       "type": "image/x-icon"
     }
   ],
-  "start_url": "./index.html",
   "display": "standalone",
   "theme_color": "#000000",
   "background_color": "#ffffff"


### PR DESCRIPTION
This prevents users to bookmark specific files or URLs.

Downside: It looks like the borg set it as required field, though: https://web.dev/add-manifest/ Testing from an Android or Google Chrome user is required here.

On iOS, using organice as PWA works without this attribute.