### PR TITLE
improve header stickiness

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -4,6 +4,13 @@ All user visible changes to organice will be documented in this file.
 
 When there are updates to the changelog, you will be notified and see a 'gift' icon appear on the top right corner.
 
+* [2020-10-10 Sat]
+** Changed
+
+   - Improve header stickiness
+     - The header bar was not always sticky for longer documents and the therefore some functionality was hard to reach (the user had to scroll to the top to reach it).
+     - Thank you [[https://github.com/tarnung][tarnung]] for your [[https://github.com/200ok-ch/organice/pull/499][PR]] 🙏
+
 * [2020-09-20 Sun]
 ** Added
 

--- a/src/base.css
+++ b/src/base.css
@@ -30,6 +30,7 @@ body,
   color: var(--base00);
   background: var(--base3);
   height: 100%;
+  overflow-y: hidden;
 }
 
 h2 {

--- a/src/components/OrgFile/components/HeaderList/stylesheet.css
+++ b/src/components/OrgFile/components/HeaderList/stylesheet.css
@@ -3,6 +3,7 @@
 .header-list-container {
   font-family: Courier;
   margin-top: 10px;
+  padding-bottom: 100px;
 
   z-index: 1;
 }
@@ -11,5 +12,6 @@
   box-shadow: inset 0px 0px 5px 0px rgba(148, 148, 148, 0.75);
   margin: 0;
   margin-top: 10px;
+  padding-bottom: 100px;
   border-radius: 5px;
 }


### PR DESCRIPTION
On Desktop the headerbar isn't sticky, since the scrollcontainer is the html-body. The whole #root-div itself scrolls inside of it, headerbar included. If the org-file is long enough I get an inner scrollbar for the #root-div and an outer scrollbar for the html-body.
On mobile I get an inconsistent experience. When I scroll to the top and back down, sometimes the headerbar stays, sometimes it scrolls away. Both scrollbars are present there too, but I don't know what determines which one is used.

This change fixes the issue on desktop browsers. I have not tried it on mobile yet but it works on browser-simulated mobile dimensions.