### PR TITLE
Make Docker containers configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,21 +8,19 @@ RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/http\:\/\/mirror.clarkson.edu/g' 
 
 RUN apk add --no-cache bash yarn
 
-COPY . /opt/organice
-WORKDIR /opt/organice
-
-RUN yarn install \
-    && yarn global add serve \
-    && yarn build \
-    && yarn cache clean \
-    && rm -rf node_modules
-
 # No root privileges are required. Create and switch to non-root user.
 # https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
 RUN addgroup -S organice \
     && adduser -S organice -G organice
+
+COPY --chown=organice . /opt/organice
+WORKDIR /opt/organice
+
+RUN yarn install \
+    && yarn global add serve
+
 USER organice
 
 ENV NODE_ENV=production
 EXPOSE 5000
-ENTRYPOINT ["serve", "-s", "build"]
+ENTRYPOINT ["/bin/bash", "-c", "yarn build && serve -s build"]

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -6,3 +6,5 @@ services:
       context: .
     ports:
       - "5000:5000"
+    volumes:
+      - ./.env.sample:/opt/organice/.env

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,3 +4,5 @@ services:
     image: 'twohundredok/organice:latest'
     ports:
       - '5000:5000'
+    volumes:
+      - ./.env:/opt/organice/.env


### PR DESCRIPTION
This change makes it possible to configure the application when run using the official Docker image by setting the relevant environment variables or mounting a `.env` file.

It does this by delaying building assets until the container is started.

Without this change, it is not possible to use the official image with a Dropbox or Google Drive backend.

However, this change has two negative side-effects:
1) The image size jumps from 139MB to 819MB, because of the need to include the node dependencies in order to build at runtime.
2) The startup time is slightly slower.