### PR TITLE
only search subheaders if a header is focused

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -4,6 +4,13 @@ All user visible changes to organice will be documented in this file.
 
 When there are updates to the changelog, you will be notified and see a 'gift' icon appear on the top right corner.
 
+* [2020-10-19 Mon]
+** Added
+   - When a header is focused, and the user uses the 'search' or 'task
+     list' feature, then the searched header list is automatically
+     narrowed to only subheaders of the originally focused header.
+     - Thank you [[https://github.com/tarnung][tarnung]] for your [[https://github.com/200ok-ch/organice/pull/517][PR]] 🙏
+
 * [2020-10-10 Sat]
 ** Added
    - Display time summaries for clock entries in each subtree

--- a/sample.org
+++ b/sample.org
@@ -283,6 +283,8 @@ Tap a header in the view to jump to it.
 
 Using the filter input, you can search for headlines. Specifically, you can search for headline text, TODO keywords, tags, and [[https://orgmode.org/guide/Properties.html][orgmode properties]]. It also supports alternatives, and you can exclude headlines by negating a filter.
 
+When a header is focused, and the user uses the 'search' or 'task list' feature, then the searched header list is automatically narrowed to only subheaders of the originally focused header.
+
 ** Differences Search and Task List
 
 - In the task list, you can tap on the date to switch to a more readable relative date format.

--- a/src/components/OrgFile/OrgFile.integration.test.js
+++ b/src/components/OrgFile/OrgFile.integration.test.js
@@ -338,6 +338,21 @@ describe('Render all views', () => {
           expect(drawerElem).toHaveTextContent('A header with tags');
           expect(drawerElem).not.toHaveTextContent('Another top level header');
         });
+
+        test('searches in sub-headers when focused', () => {
+          // Click 'focus' on the first header
+          fireEvent.click(queryByText('Top level header'));
+          fireEvent.click(container.querySelectorAll("[data-testid='header-action-focus']")[0]);
+
+          fireEvent.click(getByTitle('Show search'));
+          const drawerElem = getByTestId('drawer');
+
+          // Only sub-headers are visible
+          expect(drawerElem).not.toHaveTextContent('A header with tags');
+          expect(drawerElem).not.toHaveTextContent('Another top level header');
+          expect(drawerElem).toHaveTextContent('A nested header');
+          expect(drawerElem).toHaveTextContent('A todo item with schedule and deadline');
+        });
       });
 
       describe('Refile', () => {

--- a/src/components/OrgFile/components/Header/components/HeaderActionDrawer/index.js
+++ b/src/components/OrgFile/components/Header/components/HeaderActionDrawer/index.js
@@ -74,6 +74,7 @@ export default class HeaderActionDrawer extends PureComponent {
             : this.iconWithFFClickCatcher({
                 className: 'fas fa-compress fa-lg',
                 onClick: onFocus,
+                testId: 'header-action-focus',
                 title: 'Narrow to subtree (Focus on this header)',
               })}
 

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -1056,7 +1056,7 @@ export const setSearchFilterInformation = (state, action) => {
 
     // Only search subheaders if a header is focused
     const focusedHeaderId = state.get('focusedHeaderId');
-    if (focusedHeaderId === undefined || focusedHeaderId === null) {
+    if (focusedHeaderId === undefined || focusedHeaderId === null || context === 'refile') {
       filteredHeaders = headers.filter(isMatch(searchFilterExpr));
     } else {
       const subheaders = subheadersOfHeaderWithId(headers, focusedHeaderId);

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -1052,7 +1052,16 @@ export const setSearchFilterInformation = (state, action) => {
   state.setIn(['search', 'searchFilterValid'], searchFilterValid);
   // Only run filter if a filter is given and parsing was successful
   if (searchFilterValid) {
-    let filteredHeaders = headers.filter(isMatch(searchFilterExpr));
+    let filteredHeaders;
+
+    // Only search subheaders if a header is focused
+    const focusedHeaderId = state.get('focusedHeaderId');
+    if (focusedHeaderId === undefined || focusedHeaderId === null) {
+      filteredHeaders = headers.filter(isMatch(searchFilterExpr));
+    } else {
+      const subheaders = subheadersOfHeaderWithId(headers, focusedHeaderId);
+      filteredHeaders = subheaders.filter(isMatch(searchFilterExpr));
+    }
 
     // Filter selectedHeader and its subheaders from `headers`,
     // because you don't want to refile a header to itself or to one

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -1056,7 +1056,7 @@ export const setSearchFilterInformation = (state, action) => {
 
     // Only search subheaders if a header is focused
     const focusedHeaderId = state.get('focusedHeaderId');
-    if (focusedHeaderId === undefined || focusedHeaderId === null || context === 'refile') {
+    if (!focusedHeaderId || context === 'refile') {
       filteredHeaders = headers.filter(isMatch(searchFilterExpr));
     } else {
       const subheaders = subheadersOfHeaderWithId(headers, focusedHeaderId);


### PR DESCRIPTION
Issue #246

When a header is focused, should there be an indication in the search modal that search is limited?
I think it's ok as a standard behaviour without notification but not everyone might agree.