### PR TITLE
refactor: 'focusing' becomes 'narrowing'

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -13,6 +13,10 @@ When there are updates to the changelog, you will be notified and see a 'gift' i
 ** Added
    - When a header is focused, and the user uses the 'search' or 'task list' feature, then the searched header list is automatically narrowed to only subheaders of the originally focused header.
      - Thank you [[https://github.com/tarnung][tarnung]] for your [[https://github.com/200ok-ch/organice/pull/517][PR]] 🙏
+** Changed
+   - The 'focus header' feature is renamed.
+     - /Narrowing/ means focusing on this header, making the rest temporarily inaccessible.
+     - Canceling the narrowing, which makes all headers once again accessible, is called /widening/.
 
 * [2020-10-10 Sat]
 ** Added

--- a/sample.org
+++ b/sample.org
@@ -18,7 +18,7 @@ If you want the "header action drawer" to disappear or to deselect the current h
 2. Pen in square: Edit header description
 3. Tags: [[https://orgmode.org/manual/Tags.html][Modify tags]]
 4. Properties: [[https://orgmode.org/manual/Properties-and-columns.html][Modify properties]]
-5. Expand: [[https://orgmode.org/manual/Structure-editing.html][Narrow to subtree]] (Focus on this header)
+5. Expand: [[https://orgmode.org/manual/Structure-editing.html][Narrow to subtree]] (/Narrowing/ means focusing on this header, making the rest temporarily inaccessible.)
 6. Plus: Create new header below
 7. Mail: Share this header via email
 8. Calendar 1: [[https://orgmode.org/manual/Deadlines-and-scheduling.html][Set deadline datetime]]
@@ -54,12 +54,14 @@ Try it out on these headers:
 **** Starla                                             :cute:old:medium:dog:
 **** Rex                                                :cute:old:medium:dog:
 **** Maz                                          :cute:middleaged:large:dog:
-** Focusing
-The next button in the header action drawer "focuses" on a header, hiding all others and promoting it to the top level. Press the button again to "unfocus".
+** Narrowing
+The next button in the header action drawer "narrows" to a header, hiding all others and promoting it to the top level. Press the button again to "widen".
 
-This is purely visual - your org file isn't affected under the hood.
+Narrowing can make it easier to concentrate on a single heading or topic by eliminating clutter. It can also be used to limit the range of operation of a search command.
 
-I find this useful for focusing on my "Groceries" list when I go to the grocery store. Give it a shot on this grocery list:
+This is purely visual - your Org file isn't affected under the hood.
+
+Example: You can narrow on the "Groceries" list when you go to the grocery store. Give it a shot on this grocery list:
 *** Groceries
 - [ ] Mangoes
 - [ ] Dark chocolate
@@ -283,7 +285,7 @@ Tap a header in the view to jump to it.
 
 Using the filter input, you can search for headlines. Specifically, you can search for headline text, TODO keywords, tags, and [[https://orgmode.org/guide/Properties.html][orgmode properties]]. It also supports alternatives, and you can exclude headlines by negating a filter.
 
-When a header is focused, and the user uses the 'search' or 'task list' feature, then the searched header list is automatically narrowed to only subheaders of the originally focused header.
+When a header is narrowed, and the user uses the 'search' or 'task list' feature, then the searched header list is automatically narrowed to only subheaders of the originally narrowed header.
 
 ** Differences Search and Task List
 

--- a/src/actions/org.js
+++ b/src/actions/org.js
@@ -32,7 +32,7 @@ export const stopDisplayingFile = () => {
   return (dispatch) => {
     dispatch({ type: 'STOP_DISPLAYING_FILE' });
     dispatch(ActionCreators.clearHistory());
-    dispatch(unfocusHeader());
+    dispatch(widenHeader());
     dispatch(closePopup());
     dispatch(setLastSyncAt(null));
   };
@@ -201,7 +201,7 @@ export const selectHeaderAndOpenParents = (headerId) => (dispatch) => {
 /**
  * Action to advance the state, e.g. TODO -> DONE, of the header specified in headerId.
  *
- * @param {*} headerId headerId to advance, or null if you want the currently focused header.
+ * @param {*} headerId headerId to advance, or null if you want the currently narrowed header.
  * @param {*} logIntoDrawer false to log state change into body, true to log into :LOGBOOK: drawer.
  */
 export const advanceTodoState = (headerId, logIntoDrawer) => ({
@@ -321,13 +321,13 @@ export const addNote = (inputText, currentDate) => ({
   dirtying: true,
 });
 
-export const focusHeader = (headerId) => ({
-  type: 'FOCUS_HEADER',
+export const narrowHeader = (headerId) => ({
+  type: 'NARROW_HEADER',
   headerId,
 });
 
-export const unfocusHeader = () => ({
-  type: 'UNFOCUS_HEADER',
+export const widenHeader = () => ({
+  type: 'WIDEN_HEADER',
 });
 
 export const applyOpennessState = () => ({

--- a/src/components/OrgFile/OrgFile.integration.test.js
+++ b/src/components/OrgFile/OrgFile.integration.test.js
@@ -339,10 +339,10 @@ describe('Render all views', () => {
           expect(drawerElem).not.toHaveTextContent('Another top level header');
         });
 
-        test('searches in sub-headers when focused', () => {
-          // Click 'focus' on the first header
+        test('searches in sub-headers when narrowed', () => {
+          // Click 'narrow' on the first header
           fireEvent.click(queryByText('Top level header'));
-          fireEvent.click(container.querySelectorAll("[data-testid='header-action-focus']")[0]);
+          fireEvent.click(container.querySelectorAll("[data-testid='header-action-narrow']")[0]);
 
           fireEvent.click(getByTitle('Show search'));
           const drawerElem = getByTestId('drawer');

--- a/src/components/OrgFile/components/ActionDrawer/index.js
+++ b/src/components/OrgFile/components/ActionDrawer/index.js
@@ -400,7 +400,7 @@ const mapStateToProps = (state) => {
     inEditMode: !!state.org.present.get('editMode'),
     selectedHeaderId: state.org.present.get('selectedHeaderId'),
     isDirty: state.org.present.get('isDirty'),
-    isFocusedHeaderActive: !!state.org.present.get('focusedHeaderId'),
+    isNarrowedHeaderActive: !!state.org.present.get('narrowedHeaderId'),
     selectedTableCellId: state.org.present.get('selectedTableCellId'),
     captureTemplates: state.capture.get('captureTemplates', List()),
     path: state.org.present.get('path'),

--- a/src/components/OrgFile/components/Header/components/HeaderActionDrawer/index.js
+++ b/src/components/OrgFile/components/Header/components/HeaderActionDrawer/index.js
@@ -24,9 +24,9 @@ export default class HeaderActionDrawer extends PureComponent {
       onEnterDescriptionEditMode,
       onTagsClick,
       onPropertiesClick,
-      isFocused,
-      onFocus,
-      onUnfocus,
+      isNarrowed,
+      onNarrow,
+      onWiden,
       onAddNewHeader,
       onDeadlineClick,
       onClockInOutClick,
@@ -65,17 +65,18 @@ export default class HeaderActionDrawer extends PureComponent {
             title: 'Modify properties',
           })}
 
-          {isFocused
+          {isNarrowed
             ? this.iconWithFFClickCatcher({
                 className: 'fas fa-expand fa-lg',
-                onClick: onUnfocus,
-                title: 'Widen (Unfocus from this header)',
+                onClick: onWiden,
+                title: 'Widen (Cancelling the narrowing.)',
               })
             : this.iconWithFFClickCatcher({
                 className: 'fas fa-compress fa-lg',
-                onClick: onFocus,
-                testId: 'header-action-focus',
-                title: 'Narrow to subtree (Focus on this header)',
+                onClick: onNarrow,
+                testId: 'header-action-narrow',
+                title:
+                  'Narrow to subtree (focusing in on some portion of the buffer, making the rest temporarily inaccessible.)',
               })}
 
           {this.iconWithFFClickCatcher({

--- a/src/components/OrgFile/components/Header/index.js
+++ b/src/components/OrgFile/components/Header/index.js
@@ -43,8 +43,8 @@ class Header extends PureComponent {
       'handleEnterDescriptionEditMode',
       'handleShowTagsModal',
       'handleShowPropertyListEditorModal',
-      'handleFocus',
-      'handleUnfocus',
+      'handleNarrow',
+      'handleWiden',
       'handleAddNewHeader',
       'handleRest',
       'handleDeadlineClick',
@@ -212,12 +212,12 @@ class Header extends PureComponent {
     this.props.base.activatePopup('property-list-editor');
   }
 
-  handleFocus() {
-    this.props.org.focusHeader(this.props.header.get('id'));
+  handleNarrow() {
+    this.props.org.narrowHeader(this.props.header.get('id'));
   }
 
-  handleUnfocus() {
-    this.props.org.unfocusHeader();
+  handleWiden() {
+    this.props.org.widenHeader();
   }
 
   handleAddNewHeader() {
@@ -329,13 +329,13 @@ ${header.get('rawDescription')}`;
       hasContent,
       isSelected,
       bulletStyle,
-      focusedHeader,
-      isFocused,
+      narrowedHeader,
+      isNarrowed,
       shouldDisableActions,
     } = this.props;
 
-    const indentLevel = !!focusedHeader
-      ? header.get('nestingLevel') - focusedHeader.get('nestingLevel') + 1
+    const indentLevel = !!narrowedHeader
+      ? header.get('nestingLevel') - narrowedHeader.get('nestingLevel') + 1
       : header.get('nestingLevel');
 
     const {
@@ -503,11 +503,11 @@ ${header.get('rawDescription')}`;
                 <HeaderActionDrawer
                   onEnterTitleEditMode={this.handleEnterTitleEditMode}
                   onEnterDescriptionEditMode={this.handleEnterDescriptionEditMode}
-                  isFocused={isFocused}
+                  isNarrowed={isNarrowed}
                   onTagsClick={this.handleShowTagsModal}
                   onPropertiesClick={this.handleShowPropertyListEditorModal}
-                  onFocus={this.handleFocus}
-                  onUnfocus={this.handleUnfocus}
+                  onNarrow={this.handleNarrow}
+                  onWiden={this.handleWiden}
                   onAddNewHeader={this.handleAddNewHeader}
                   onDeadlineClick={this.handleDeadlineClick}
                   onClockInOutClick={this.handleClockInOutClick}
@@ -529,16 +529,16 @@ ${header.get('rawDescription')}`;
 }
 
 const mapStateToProps = (state, ownProps) => {
-  const focusedHeader = !!state.org.present.get('focusedHeaderId')
-    ? headerWithId(state.org.present.get('headers'), state.org.present.get('focusedHeaderId'))
+  const narrowedHeader = !!state.org.present.get('narrowedHeaderId')
+    ? headerWithId(state.org.present.get('headers'), state.org.present.get('narrowedHeaderId'))
     : null;
 
   return {
     bulletStyle: state.base.get('bulletStyle'),
     shouldLogIntoDrawer: state.base.get('shouldLogIntoDrawer'),
     closeSubheadersRecursively: state.base.get('closeSubheadersRecursively'),
-    focusedHeader,
-    isFocused: !!focusedHeader && focusedHeader.get('id') === ownProps.header.get('id'),
+    narrowedHeader,
+    isNarrowed: !!narrowedHeader && narrowedHeader.get('id') === ownProps.header.get('id'),
     inEditMode: !!state.org.present.get('editMode'),
   };
 };

--- a/src/components/OrgFile/components/HeaderList/index.js
+++ b/src/components/OrgFile/components/HeaderList/index.js
@@ -38,7 +38,7 @@ class HeaderList extends PureComponent {
   }
 
   render() {
-    const { headers, selectedHeaderId, focusedHeaderId, shouldDisableActions } = this.props;
+    const { headers, selectedHeaderId, narrowedHeaderId, shouldDisableActions } = this.props;
 
     const headerRenderData = headers
       .map((header) => {
@@ -80,16 +80,16 @@ class HeaderList extends PureComponent {
       }
     });
 
-    if (!!focusedHeaderId) {
-      const focusedHeaderIndex = headerRenderData.findIndex(
-        (headerRenderDatum) => headerRenderDatum.header.get('id') === focusedHeaderId
+    if (!!narrowedHeaderId) {
+      const narrowedHeaderIndex = headerRenderData.findIndex(
+        (headerRenderDatum) => headerRenderDatum.header.get('id') === narrowedHeaderId
       );
 
-      const previousHeaders = headerRenderData.slice(0, focusedHeaderIndex);
+      const previousHeaders = headerRenderData.slice(0, narrowedHeaderIndex);
       previousHeaders.forEach((headerRenderDatum) => (headerRenderDatum.displayed = false));
 
-      const numSubheaders = numSubheadersOfHeaderWithId(headers, focusedHeaderId);
-      const followingHeaders = headerRenderData.slice(focusedHeaderIndex + numSubheaders + 1);
+      const numSubheaders = numSubheadersOfHeaderWithId(headers, narrowedHeaderId);
+      const followingHeaders = headerRenderData.slice(narrowedHeaderIndex + numSubheaders + 1);
       followingHeaders.forEach((headerRenderDatum) => (headerRenderDatum.displayed = false));
     }
 
@@ -109,7 +109,7 @@ class HeaderList extends PureComponent {
     );
 
     const className = classNames('header-list-container', {
-      'header-list-container--focused': !!focusedHeaderId,
+      'header-list-container--narrowed': !!narrowedHeaderId,
     });
     return (
       <div className={className}>
@@ -138,7 +138,7 @@ const mapStateToProps = (state) => {
   return {
     headers: state.org.present.get('headers'),
     selectedHeaderId: state.org.present.get('selectedHeaderId'),
-    focusedHeaderId: state.org.present.get('focusedHeaderId'),
+    narrowedHeaderId: state.org.present.get('narrowedHeaderId'),
   };
 };
 

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -86,7 +86,7 @@ const toggleHeaderOpened = (state, action) => {
   const { header, headerIndex } = indexAndHeaderWithId(headers, action.headerId);
   const isOpened = header.get('opened');
 
-  if (isOpened && state.get('focusedHeaderId') === action.headerId) {
+  if (isOpened && state.get('narrowedHeaderId') === action.headerId) {
     return state;
   }
 
@@ -268,8 +268,8 @@ const addHeader = (state, action) => {
     state.get('todoKeywordSets')
   );
 
-  if (action.headerId === state.get('focusedHeaderId')) {
-    state = state.set('focusedHeaderId', null);
+  if (action.headerId === state.get('narrowedHeaderId')) {
+    state = state.set('narrowedHeaderId', null);
   }
 
   return state.update('headers', (headers) =>
@@ -335,8 +335,8 @@ const removeHeader = (state, action) => {
     headers = headers.delete(headerIndex);
   });
 
-  if (action.headerId === state.get('focusedHeaderId')) {
-    state = state.set('focusedHeaderId', null);
+  if (action.headerId === state.get('narrowedHeaderId')) {
+    state = state.set('narrowedHeaderId', null);
   }
 
   state = state.set('headers', headers);
@@ -554,11 +554,11 @@ const addNote = (state, action) => {
   return addNoteGeneric(state, { noteText });
 };
 
-const focusHeader = (state, action) => {
-  return state.set('focusedHeaderId', action.headerId);
+const narrowHeader = (state, action) => {
+  return state.set('narrowedHeaderId', action.headerId);
 };
 
-const unfocusHeader = (state) => state.set('focusedHeaderId', null);
+const widenHeader = (state) => state.set('narrowedHeaderId', null);
 
 const applyOpennessState = (state) => {
   const opennessState = state.get('opennessState');
@@ -1054,12 +1054,12 @@ export const setSearchFilterInformation = (state, action) => {
   if (searchFilterValid) {
     let filteredHeaders;
 
-    // Only search subheaders if a header is focused
-    const focusedHeaderId = state.get('focusedHeaderId');
-    if (!focusedHeaderId || context === 'refile') {
+    // Only search subheaders if a header is narrowed
+    const narrowedHeaderId = state.get('narrowedHeaderId');
+    if (!narrowedHeaderId || context === 'refile') {
       filteredHeaders = headers.filter(isMatch(searchFilterExpr));
     } else {
-      const subheaders = subheadersOfHeaderWithId(headers, focusedHeaderId);
+      const subheaders = subheadersOfHeaderWithId(headers, narrowedHeaderId);
       filteredHeaders = subheaders.filter(isMatch(searchFilterExpr));
     }
 
@@ -1173,10 +1173,10 @@ const reducer = (state, action) => {
       return applyOpennessState(state, action);
     case 'SET_DIRTY':
       return setDirty(state, action);
-    case 'FOCUS_HEADER':
-      return focusHeader(state, action);
-    case 'UNFOCUS_HEADER':
-      return unfocusHeader(state, action);
+    case 'NARROW_HEADER':
+      return narrowHeader(state, action);
+    case 'WIDEN_HEADER':
+      return widenHeader(state, action);
     case 'SET_SELECTED_TABLE_CELL_ID':
       return setSelectedTableCellId(state, action);
     case 'ADD_NEW_TABLE_ROW':

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -496,11 +496,11 @@ describe('org reducer', () => {
         ]);
       });
 
-      it('should reset header focus', () => {
-        const focusedState = reducer(state.org.present, types.focusHeader(nestedHeaderId));
-        expect(focusedState.get('focusedHeaderId')).toEqual(nestedHeaderId);
-        const newState = reducer(focusedState, types.removeHeader(nestedHeaderId));
-        expect(newState.get('focusedHeaderId')).toEqual(null);
+      it('should reset header narrowing', () => {
+        const narrowedState = reducer(state.org.present, types.narrowHeader(nestedHeaderId));
+        expect(narrowedState.get('narrowedHeaderId')).toEqual(nestedHeaderId);
+        const newState = reducer(narrowedState, types.removeHeader(nestedHeaderId));
+        expect(newState.get('narrowedHeaderId')).toEqual(null);
       });
 
       it('is undoable', () => {
@@ -509,7 +509,7 @@ describe('org reducer', () => {
     });
 
     describe('ADD_HEADER', () => {
-      it('should handle ADD_HEADER and unfocus', () => {
+      it('should handle ADD_HEADER and widen', () => {
         const oldState = state.org.present;
         expect(extractTitlesAndNestings(oldState.get('headers'))).toEqual([
           ['Top level header', 1],
@@ -518,10 +518,10 @@ describe('org reducer', () => {
           ['A second nested header', 2],
         ]);
 
-        const stateSelected = reducer(oldState, types.focusHeader(nestedHeaderId));
-        expect(stateSelected.get('focusedHeaderId')).toEqual(nestedHeaderId);
+        const stateSelected = reducer(oldState, types.narrowHeader(nestedHeaderId));
+        expect(stateSelected.get('narrowedHeaderId')).toEqual(nestedHeaderId);
         const newState = reducer(stateSelected, types.addHeader(nestedHeaderId));
-        expect(newState.get('focusedHeaderId')).toBeNull();
+        expect(newState.get('narrowedHeaderId')).toBeNull();
 
         // "A nested header" is not at the top level.
         expect(extractTitlesAndNestings(newState.get('headers'))).toEqual([
@@ -533,11 +533,11 @@ describe('org reducer', () => {
         ]);
       });
 
-      it('should reset header focus', () => {
-        const focusedState = reducer(state.org.present, types.focusHeader(nestedHeaderId));
-        expect(focusedState.get('focusedHeaderId')).toEqual(nestedHeaderId);
-        const newState = reducer(focusedState, types.removeHeader(nestedHeaderId));
-        expect(newState.get('focusedHeaderId')).toEqual(null);
+      it('should reset header narrowing', () => {
+        const narrowedState = reducer(state.org.present, types.narrowHeader(nestedHeaderId));
+        expect(narrowedState.get('narrowedHeaderId')).toEqual(nestedHeaderId);
+        const newState = reducer(narrowedState, types.removeHeader(nestedHeaderId));
+        expect(newState.get('narrowedHeaderId')).toEqual(null);
       });
 
       it('is undoable', () => {
@@ -744,15 +744,15 @@ describe('org reducer', () => {
         );
       });
 
-      it('should ignore if focused and open', () => {
+      it('should ignore if narrowed and open', () => {
         expect(state.org.present.get('headers').every((hdr) => !hdr.get('opened'))).toEqual(true);
         const openState = reducer(
           state.org.present,
           types.toggleHeaderOpened(topLevelHeaderId, true)
         );
-        const focusedState = reducer(openState, types.focusHeader(topLevelHeaderId));
-        const newState = reducer(focusedState, types.toggleHeaderOpened(topLevelHeaderId, true));
-        expect(newState).toEqual(focusedState);
+        const narrowedState = reducer(openState, types.narrowHeader(topLevelHeaderId));
+        const newState = reducer(narrowedState, types.toggleHeaderOpened(topLevelHeaderId, true));
+        expect(newState).toEqual(narrowedState);
       });
     });
   });
@@ -1748,7 +1748,7 @@ describe('org reducer', () => {
     });
   });
 
-  describe('FOCUS_HEADER', () => {
+  describe('NARROW_HEADER', () => {
     let state;
     const headerId = generateId();
 
@@ -1756,9 +1756,9 @@ describe('org reducer', () => {
       state = readInitialState();
     });
 
-    it('should handle FOCUS_HEADER', () => {
-      const newState = reducer(state.org.present, types.focusHeader(headerId));
-      expect(newState.get('focusedHeaderId')).toEqual(headerId);
+    it('should handle NARROW_HEADER', () => {
+      const newState = reducer(state.org.present, types.narrowHeader(headerId));
+      expect(newState.get('narrowedHeaderId')).toEqual(headerId);
     });
   });
 


### PR DESCRIPTION
This is according to the naming in Emacs: https://www.gnu.org/software/emacs/manual/html_node/emacs/Narrowing.html