### PR TITLE
[WIP] display clock times in search

### DIFF
--- a/src/components/OrgFile/components/AgendaModal/components/AgendaDay/stylesheet.css
+++ b/src/components/OrgFile/components/AgendaModal/components/AgendaDay/stylesheet.css
@@ -43,6 +43,7 @@
 }
 
 .agenda-day__header__header-container {
+  width: 100%;
   margin-top: 18px;
 }
 

--- a/src/components/OrgFile/components/Header/index.js
+++ b/src/components/OrgFile/components/Header/index.js
@@ -19,7 +19,7 @@ import HeaderActionDrawer from './components/HeaderActionDrawer';
 
 import { headerWithId } from '../../../../lib/org_utils';
 import { interpolateColors, rgbaObject, rgbaString } from '../../../../lib/color';
-import { getCurrentTimestamp } from '../../../../lib/timestamps';
+import { getCurrentTimestamp, millisDuration } from '../../../../lib/timestamps';
 
 class Header extends PureComponent {
   SWIPE_ACTION_ACTIVATION_DISTANCE = 80;
@@ -332,6 +332,7 @@ ${header.get('rawDescription')}`;
       focusedHeader,
       isFocused,
       shouldDisableActions,
+      showClockDisplay,
     } = this.props;
 
     const indentLevel = !!focusedHeader
@@ -493,6 +494,11 @@ ${header.get('rawDescription')}`;
                 isSelected={isSelected}
                 shouldDisableExplicitWidth={swipedDistance === 0}
                 shouldDisableActions={shouldDisableActions}
+                addition={
+                  showClockDisplay && header.get('totalTimeLoggedRecursive') !== 0
+                    ? millisDuration(header.get('totalTimeLoggedRecursive'))
+                    : null
+                }
               />
 
               <Collapse
@@ -540,6 +546,7 @@ const mapStateToProps = (state, ownProps) => {
     focusedHeader,
     isFocused: !!focusedHeader && focusedHeader.get('id') === ownProps.header.get('id'),
     inEditMode: !!state.org.present.get('editMode'),
+    showClockDisplay: state.org.present.get('showClockDisplay'),
   };
 };
 

--- a/src/components/OrgFile/components/Header/index.js
+++ b/src/components/OrgFile/components/Header/index.js
@@ -497,7 +497,7 @@ ${header.get('rawDescription')}`;
                 addition={
                   showClockDisplay && header.get('totalTimeLoggedRecursive') !== 0
                     ? millisDuration(header.get('totalTimeLoggedRecursive'))
-                    : null
+                    : ''
                 }
               />
 

--- a/src/components/OrgFile/components/SearchModal/components/HeaderListView/index.js
+++ b/src/components/OrgFile/components/SearchModal/components/HeaderListView/index.js
@@ -40,8 +40,8 @@ function HeaderListView(props) {
                   shouldDisableExplicitWidth
                   onClick={handleHeaderClick(header.get('id'))}
                   addition={
-                    showClockedTimes && header.get('totalTimeLogged') !== 0
-                      ? millisDuration(header.get('totalTimeLogged'))
+                    showClockedTimes && header.get('totalFilteredTimeLogged') !== 0
+                      ? millisDuration(header.get('totalFilteredTimeLogged'))
                       : null
                   }
                 />

--- a/src/components/OrgFile/components/SearchModal/components/HeaderListView/index.js
+++ b/src/components/OrgFile/components/SearchModal/components/HeaderListView/index.js
@@ -5,6 +5,8 @@ import { connect } from 'react-redux';
 import * as orgActions from '../../../../../../actions/org';
 import './stylesheet.css';
 
+import { millisDuration } from '../../../../../../lib/timestamps';
+
 import TitleLine from '../../../TitleLine';
 
 function HeaderListView(props) {
@@ -20,7 +22,7 @@ function HeaderListView(props) {
     props.org.setSearchFilterInformation('', 0, context);
   }, [context, props.org]);
 
-  const { headers } = props;
+  const { headers, showClockedTimes } = props;
 
   return (
     <div className="agenda-day__container">
@@ -37,6 +39,11 @@ function HeaderListView(props) {
                   shouldDisableActions
                   shouldDisableExplicitWidth
                   onClick={handleHeaderClick(header.get('id'))}
+                  addition={
+                    showClockedTimes && header.get('totalTimeLogged') !== 0
+                      ? millisDuration(header.get('totalTimeLogged'))
+                      : null
+                  }
                 />
               </div>
             </div>
@@ -51,6 +58,7 @@ const mapStateToProps = (state) => ({
   // When no filtering has happened, yet (initial state), use all headers.
   headers:
     state.org.present.getIn(['search', 'filteredHeaders']) || state.org.present.get('headers'),
+  showClockedTimes: state.org.present.getIn(['search', 'showClockedTimes']),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/components/OrgFile/components/SearchModal/index.js
+++ b/src/components/OrgFile/components/SearchModal/index.js
@@ -10,6 +10,7 @@ import HeaderListView from './components/HeaderListView';
 import Drawer from '../../../UI/Drawer';
 
 import { isMobileBrowser, isIos } from '../../../../lib/browser_utils';
+import { millisDuration } from '../../../../lib/timestamps';
 
 import * as orgActions from '../../../../actions/org';
 
@@ -18,7 +19,15 @@ import * as orgActions from '../../../../actions/org';
 // changing all.
 function SearchModal(props) {
   const [dateDisplayType, setdateDisplayType] = useState('absolute');
-  const { onClose, searchFilter, searchFilterValid, searchFilterSuggestions, context } = props;
+  const {
+    onClose,
+    searchFilter,
+    searchFilterValid,
+    searchFilterSuggestions,
+    context,
+    showClockedTimes,
+    clockedTime,
+  } = props;
 
   function handleHeaderClick(headerId) {
     props.onClose(headerId);
@@ -45,7 +54,10 @@ function SearchModal(props) {
 
   return (
     <Drawer onClose={onClose} maxSize={true}>
-      <h2 className="agenda__title">{capitalize(context)}</h2>
+      <div className="task-list__modal-title">
+        <h2 className="agenda__title">{capitalize(context)}</h2>
+        {showClockedTimes ? millisDuration(clockedTime) : null}
+      </div>
 
       <datalist id="task-list__datalist-filter">
         {searchFilterSuggestions.map((string, idx) => (
@@ -96,6 +108,8 @@ const mapStateToProps = (state) => ({
   searchFilter: state.org.present.getIn(['search', 'searchFilter']) || '',
   searchFilterValid: state.org.present.getIn(['search', 'searchFilterValid']),
   searchFilterSuggestions: state.org.present.getIn(['search', 'searchFilterSuggestions']) || [],
+  showClockedTimes: state.org.present.getIn(['search', 'showClockedTimes']),
+  clockedTime: state.org.present.getIn(['search', 'clockedTime']),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/components/OrgFile/components/SearchModal/stylesheet.css
+++ b/src/components/OrgFile/components/SearchModal/stylesheet.css
@@ -20,3 +20,9 @@
 .task-list__filter-input-invalid {
   border: 2px solid var(--red);
 }
+
+.task-list__modal-title {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/components/OrgFile/components/TitleLine/index.js
+++ b/src/components/OrgFile/components/TitleLine/index.js
@@ -10,7 +10,7 @@ import classNames from 'classnames';
 import * as orgActions from '../../../../actions/org';
 import * as baseActions from '../../../../actions/base';
 
-import { getCurrentTimestampAsText, millisDuration } from '../../../../lib/timestamps';
+import { getCurrentTimestampAsText } from '../../../../lib/timestamps';
 import { createIsTodoKeywordInDoneState } from '../../../../lib/org_utils';
 
 import { generateTitleLine } from '../../../../lib/export_org';
@@ -183,25 +183,19 @@ class TitleLine extends PureComponent {
       shouldDisableActions,
       shouldDisableExplicitWidth,
       todoKeywordSets,
-      showClockDisplay,
+      addition,
     } = this.props;
     const { containerWidth } = this.state;
 
     const isTodoKeywordInDoneState = createIsTodoKeywordInDoneState(todoKeywordSets);
     const todoKeyword = header.getIn(['titleLine', 'todoKeyword']);
 
-    const titleLineStyle = {
-      width: '100%',
-      display: 'flex',
-      justifyContent: 'space-between',
-    };
-
     const titleStyle = {
       color,
       wordBreak: 'break-word',
     };
 
-    const clockDisplayStyle = {
+    const additionStyle = {
       color,
       minWidth: '5em',
       textAlign: 'right',
@@ -259,7 +253,7 @@ class TitleLine extends PureComponent {
           </div>
         ) : (
           <div style={{ width: '100%' }}>
-            <div style={titleLineStyle}>
+            <div className="title-line-text">
               <span style={titleStyle} ref={this.handleTitleSpanRef}>
                 <AttributedString
                   parts={header.getIn(['titleLine', 'title'])}
@@ -270,10 +264,8 @@ class TitleLine extends PureComponent {
                 />
                 {!header.get('opened') && hasContent ? '...' : ''}
               </span>
-              {showClockDisplay && header.get('totalTimeLoggedRecursive') !== 0 ? (
-                <span style={clockDisplayStyle}>
-                  {millisDuration(header.get('totalTimeLoggedRecursive'))}
-                </span>
+              {addition !== null && addition !== undefined && addition !== '' ? (
+                <span style={additionStyle}>{addition}</span>
               ) : null}
             </div>
             {header.getIn(['titleLine', 'tags']).size > 0 && (
@@ -307,7 +299,6 @@ const mapStateToProps = (state, ownProps) => {
     closeSubheadersRecursively: state.base.get('closeSubheadersRecursively'),
     isSelected: state.org.present.get('selectedHeaderId') === ownProps.header.get('id'),
     todoKeywordSets: state.org.present.get('todoKeywordSets'),
-    showClockDisplay: state.org.present.get('showClockDisplay'),
   };
 };
 

--- a/src/components/OrgFile/components/TitleLine/index.js
+++ b/src/components/OrgFile/components/TitleLine/index.js
@@ -264,7 +264,7 @@ class TitleLine extends PureComponent {
                 />
                 {!header.get('opened') && hasContent ? '...' : ''}
               </span>
-              {addition !== null && addition !== undefined && addition !== '' ? (
+              {addition !== null && addition !== undefined ? (
                 <span style={additionStyle}>{addition}</span>
               ) : null}
             </div>

--- a/src/components/OrgFile/components/TitleLine/stylesheet.css
+++ b/src/components/OrgFile/components/TitleLine/stylesheet.css
@@ -51,3 +51,9 @@
 .insert-timestamp-icon {
   margin-right: 5px;
 }
+
+.title-line-text {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/lib/clocking.js
+++ b/src/lib/clocking.js
@@ -1,7 +1,7 @@
 import { subheadersOfHeaderWithIndex } from './org_utils';
 import { dateForTimestamp } from './timestamps';
 
-export const totalTimeLogged = (header) => {
+const totalTimeLogged = (header) => {
   const logBookEntries = header.get('logBookEntries', []);
 
   const times = logBookEntries.map((entry) =>
@@ -9,6 +9,21 @@ export const totalTimeLogged = (header) => {
       ? dateForTimestamp(entry.get('end')) - dateForTimestamp(entry.get('start'))
       : 0
   );
+
+  const addedTimes = times.reduce((acc, val) => acc + val, 0);
+  return addedTimes;
+};
+
+export const totalFilteredTimeLogged = (filters, header) => {
+  const clocks = header
+    .get('logBookEntries', [])
+    .map((l) => [l.get('start'), l.get('end')])
+    .filter(
+      ([start, end]) => start !== undefined && start !== null && end !== undefined && end !== null
+    )
+    .filter((ts) => ts.some((t) => filters.every((f) => f(t))));
+
+  const times = clocks.map(([start, end]) => dateForTimestamp(end) - dateForTimestamp(start));
 
   const addedTimes = times.reduce((acc, val) => acc + val, 0);
   return addedTimes;

--- a/src/lib/clocking.js
+++ b/src/lib/clocking.js
@@ -1,7 +1,7 @@
 import { subheadersOfHeaderWithIndex } from './org_utils';
 import { dateForTimestamp } from './timestamps';
 
-const totalTimeLogged = (header) => {
+export const totalTimeLogged = (header) => {
   const logBookEntries = header.get('logBookEntries', []);
 
   const times = logBookEntries.map((entry) =>

--- a/src/lib/headline_filter.js
+++ b/src/lib/headline_filter.js
@@ -137,7 +137,7 @@ const isRelative = (moment) => {
   return moment.type === 'offset' || moment.type === 'unit';
 };
 
-const timeFilter = (filterDescription) => {
+export const timeFilter = (filterDescription) => {
   const timeFilterDescription = filterDescription.field.timerange;
   let lower;
   let upper;

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -5,7 +5,7 @@ import _ from 'lodash';
 
 import headline_filter_parser from '../lib/headline_filter_parser';
 import { isMatch, computeCompletionsForDatalist } from '../lib/headline_filter';
-import { updateHeadersTotalTimeLogged } from '../lib/clocking';
+import { updateHeadersTotalTimeLogged, totalTimeLogged } from '../lib/clocking';
 
 import {
   extractAllOrgTags,
@@ -1074,6 +1074,23 @@ export const setSearchFilterInformation = (state, action) => {
       filteredHeaders = filteredHeaders.filter((h) => {
         return !filterIds.includes(h.get('id'));
       });
+    }
+
+    // show clocked times & sum if there is a clock search term
+    const showClockedTimes =
+      searchFilterExpr.filter((f) => f.type === 'field').filter((f) => f.field.type === 'clock')
+        .length !== 0;
+
+    console.debug(searchFilterExpr.filter((f) => f.type === 'field').filter((f) => f.field.type === 'clock'))
+    state.setIn(['search', 'showClockedTimes'], showClockedTimes);
+    if (showClockedTimes) {
+      if (!state.get('showClockDisplay')) {
+        filteredHeaders = headers.map((header) =>
+        header.set('totalTimeLogged', totalTimeLogged(header))
+      );
+      }
+      const clockedTime = filteredHeaders.reduce((acc, val) => acc + val.get('totalTimeLogged'), 0);
+      state.setIn(['search', 'clockedTime'], clockedTime);
     }
 
     state.setIn(['search', 'filteredHeaders'], filteredHeaders);

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -1081,13 +1081,12 @@ export const setSearchFilterInformation = (state, action) => {
       searchFilterExpr.filter((f) => f.type === 'field').filter((f) => f.field.type === 'clock')
         .length !== 0;
 
-    console.debug(searchFilterExpr.filter((f) => f.type === 'field').filter((f) => f.field.type === 'clock'))
     state.setIn(['search', 'showClockedTimes'], showClockedTimes);
     if (showClockedTimes) {
       if (!state.get('showClockDisplay')) {
         filteredHeaders = headers.map((header) =>
-        header.set('totalTimeLogged', totalTimeLogged(header))
-      );
+          header.set('totalTimeLogged', totalTimeLogged(header))
+        );
       }
       const clockedTime = filteredHeaders.reduce((acc, val) => acc + val.get('totalTimeLogged'), 0);
       state.setIn(['search', 'clockedTime'], clockedTime);


### PR DESCRIPTION
I refactored my previous changes to TitleLine to allow a string to be passed in as an 'addition'-prop. That string is then displayed right aligned.
This allows to show the recursive clocked times in the regular header list (when the corresponding setting is activated) and the per-item sums in search (when a 'clock:' search term is present).
Additionally there is a sum of clocked times over all search results displayed in the top right of the search modal.

The discussion whether this is the right way to display clock times in search started over at #504 and is not yet resolved. This is my proposal.