### PR TITLE
Feat/recursive clock times in search

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -14,6 +14,9 @@ When there are updates to the changelog, you will be notified and see a 'gift' i
 ** Added
    - Add 'time range' queries to search for planning items (SCHEDULED and DEADLINE), plain active timestamps or clocked work time.
      - Thank you [[https://github.com/tarnung][tarnung]] for your [[https://github.com/200ok-ch/organice/pull/505][PR]] 🙏
+   - Add 'recursive clock times in search'.
+     - The =clock:= search term now includes headers that have time logged on their children.
+     - Thank you [[https://github.com/tarnung][tarnung]] for your [[https://github.com/200ok-ch/organice/pull/524][PR]] 🙏
 * [2020-10-19 Mon]
 ** Added
    - When a header is focused, and the user uses the 'search' or 'task list' feature, then the searched header list is automatically narrowed to only subheaders of the originally focused header.

--- a/sample.org
+++ b/sample.org
@@ -362,7 +362,7 @@ Next to units, =START= and =END= can also be expressed in dates like. Dates can 
 
 Some examples on how to use time ranges:
 
-- =clock:..= searches for all items with time clocked.
+- =clock:..= searches for all items with time clocked. This includes headers that have time logged on their children.
 - =sched:w= searches for all scheduled items in the current week (same for other units).
 - =dead:..w= searches for all deadlines between now and the end of the week.
 - =date:today= searches for all planning items (scheduled and deadline items) as well as items with active timestamps.

--- a/src/components/OrgFile/__snapshots__/OrgFile.integration.test.js.snap
+++ b/src/components/OrgFile/__snapshots__/OrgFile.integration.test.js.snap
@@ -158,7 +158,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
                     <span>
                       A header with a custom todo sequence in DONE state
                     </span>
-
+                    
                   </span>
                 </div>
               </div>
@@ -716,7 +716,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
                   <span>
                     A header with a custom todo sequence in DONE state
                   </span>
-
+                  
                 </span>
                 <span
                   style="min-width: 5em; text-align: right; margin-right: 5px;"

--- a/src/components/OrgFile/__snapshots__/OrgFile.integration.test.js.snap
+++ b/src/components/OrgFile/__snapshots__/OrgFile.integration.test.js.snap
@@ -56,7 +56,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
                 style="width: 100%;"
               >
                 <div
-                  style="width: 100%; display: flex; justify-content: space-between;"
+                  class="title-line-text"
                 >
                   <span
                     style="color: black; word-break: break-word;"
@@ -103,7 +103,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
                 style="width: 100%;"
               >
                 <div
-                  style="width: 100%; display: flex; justify-content: space-between;"
+                  class="title-line-text"
                 >
                   <span
                     style="color: black; word-break: break-word;"
@@ -150,7 +150,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
                 style="width: 100%;"
               >
                 <div
-                  style="width: 100%; display: flex; justify-content: space-between;"
+                  class="title-line-text"
                 >
                   <span
                     style="color: black; word-break: break-word;"
@@ -158,7 +158,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
                     <span>
                       A header with a custom todo sequence in DONE state
                     </span>
-                    
+
                   </span>
                 </div>
               </div>
@@ -184,7 +184,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
                 style="width: 100%;"
               >
                 <div
-                  style="width: 100%; display: flex; justify-content: space-between;"
+                  class="title-line-text"
                 >
                   <span
                     style="color: black; word-break: break-word;"
@@ -231,7 +231,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
                 style="width: 100%;"
               >
                 <div
-                  style="width: 100%; display: flex; justify-content: space-between;"
+                  class="title-line-text"
                 >
                   <span
                     style="color: black; word-break: break-word;"
@@ -361,7 +361,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
               style="width: 100%;"
             >
               <div
-                style="width: 100%; display: flex; justify-content: space-between;"
+                class="title-line-text"
               >
                 <span
                   style="word-break: break-word;"
@@ -371,6 +371,9 @@ exports[`Render all views Org Functionality Renders everything starting from an 
                   </span>
                   ...
                 </span>
+                <span
+                  style="min-width: 5em; text-align: right; margin-right: 5px;"
+                />
               </div>
             </div>
           </div>
@@ -412,7 +415,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
               style="width: 100%;"
             >
               <div
-                style="width: 100%; display: flex; justify-content: space-between;"
+                class="title-line-text"
               >
                 <span
                   style="word-break: break-word;"
@@ -422,6 +425,9 @@ exports[`Render all views Org Functionality Renders everything starting from an 
                   </span>
                   ...
                 </span>
+                <span
+                  style="min-width: 5em; text-align: right; margin-right: 5px;"
+                />
               </div>
             </div>
           </div>
@@ -463,7 +469,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
               style="width: 100%;"
             >
               <div
-                style="width: 100%; display: flex; justify-content: space-between;"
+                class="title-line-text"
               >
                 <span
                   style="word-break: break-word;"
@@ -473,6 +479,9 @@ exports[`Render all views Org Functionality Renders everything starting from an 
                   </span>
                   
                 </span>
+                <span
+                  style="min-width: 5em; text-align: right; margin-right: 5px;"
+                />
               </div>
               <div>
                 <div
@@ -526,7 +535,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
               style="width: 100%;"
             >
               <div
-                style="width: 100%; display: flex; justify-content: space-between;"
+                class="title-line-text"
               >
                 <span
                   style="word-break: break-word;"
@@ -543,6 +552,9 @@ exports[`Render all views Org Functionality Renders everything starting from an 
                   </span>
                   
                 </span>
+                <span
+                  style="min-width: 5em; text-align: right; margin-right: 5px;"
+                />
               </div>
             </div>
           </div>
@@ -584,7 +596,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
               style="width: 100%;"
             >
               <div
-                style="width: 100%; display: flex; justify-content: space-between;"
+                class="title-line-text"
               >
                 <span
                   style="word-break: break-word;"
@@ -594,6 +606,9 @@ exports[`Render all views Org Functionality Renders everything starting from an 
                   </span>
                   ...
                 </span>
+                <span
+                  style="min-width: 5em; text-align: right; margin-right: 5px;"
+                />
               </div>
             </div>
           </div>
@@ -635,7 +650,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
               style="width: 100%;"
             >
               <div
-                style="width: 100%; display: flex; justify-content: space-between;"
+                class="title-line-text"
               >
                 <span
                   style="word-break: break-word;"
@@ -645,6 +660,9 @@ exports[`Render all views Org Functionality Renders everything starting from an 
                   </span>
                   ...
                 </span>
+                <span
+                  style="min-width: 5em; text-align: right; margin-right: 5px;"
+                />
               </div>
             </div>
           </div>
@@ -690,7 +708,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
               style="width: 100%;"
             >
               <div
-                style="width: 100%; display: flex; justify-content: space-between;"
+                class="title-line-text"
               >
                 <span
                   style="word-break: break-word;"
@@ -698,8 +716,11 @@ exports[`Render all views Org Functionality Renders everything starting from an 
                   <span>
                     A header with a custom todo sequence in DONE state
                   </span>
-                  
+
                 </span>
+                <span
+                  style="min-width: 5em; text-align: right; margin-right: 5px;"
+                />
               </div>
             </div>
           </div>

--- a/src/components/OrgFile/__snapshots__/OrgFile.integration.test.js.snap
+++ b/src/components/OrgFile/__snapshots__/OrgFile.integration.test.js.snap
@@ -371,9 +371,6 @@ exports[`Render all views Org Functionality Renders everything starting from an 
                   </span>
                   ...
                 </span>
-                <span
-                  style="min-width: 5em; text-align: right; margin-right: 5px;"
-                />
               </div>
             </div>
           </div>
@@ -425,9 +422,6 @@ exports[`Render all views Org Functionality Renders everything starting from an 
                   </span>
                   ...
                 </span>
-                <span
-                  style="min-width: 5em; text-align: right; margin-right: 5px;"
-                />
               </div>
             </div>
           </div>
@@ -479,9 +473,6 @@ exports[`Render all views Org Functionality Renders everything starting from an 
                   </span>
                   
                 </span>
-                <span
-                  style="min-width: 5em; text-align: right; margin-right: 5px;"
-                />
               </div>
               <div>
                 <div
@@ -552,9 +543,6 @@ exports[`Render all views Org Functionality Renders everything starting from an 
                   </span>
                   
                 </span>
-                <span
-                  style="min-width: 5em; text-align: right; margin-right: 5px;"
-                />
               </div>
             </div>
           </div>
@@ -606,9 +594,6 @@ exports[`Render all views Org Functionality Renders everything starting from an 
                   </span>
                   ...
                 </span>
-                <span
-                  style="min-width: 5em; text-align: right; margin-right: 5px;"
-                />
               </div>
             </div>
           </div>
@@ -660,9 +645,6 @@ exports[`Render all views Org Functionality Renders everything starting from an 
                   </span>
                   ...
                 </span>
-                <span
-                  style="min-width: 5em; text-align: right; margin-right: 5px;"
-                />
               </div>
             </div>
           </div>
@@ -718,9 +700,6 @@ exports[`Render all views Org Functionality Renders everything starting from an 
                   </span>
                   
                 </span>
-                <span
-                  style="min-width: 5em; text-align: right; margin-right: 5px;"
-                />
               </div>
             </div>
           </div>

--- a/src/components/OrgFile/components/AgendaModal/components/AgendaDay/stylesheet.css
+++ b/src/components/OrgFile/components/AgendaModal/components/AgendaDay/stylesheet.css
@@ -43,6 +43,7 @@
 }
 
 .agenda-day__header__header-container {
+  width: 100%;
   margin-top: 18px;
 }
 

--- a/src/components/OrgFile/components/Header/index.js
+++ b/src/components/OrgFile/components/Header/index.js
@@ -19,7 +19,7 @@ import HeaderActionDrawer from './components/HeaderActionDrawer';
 
 import { headerWithId } from '../../../../lib/org_utils';
 import { interpolateColors, rgbaObject, rgbaString } from '../../../../lib/color';
-import { getCurrentTimestamp } from '../../../../lib/timestamps';
+import { getCurrentTimestamp, millisDuration } from '../../../../lib/timestamps';
 
 class Header extends PureComponent {
   SWIPE_ACTION_ACTIVATION_DISTANCE = 80;
@@ -332,6 +332,7 @@ ${header.get('rawDescription')}`;
       focusedHeader,
       isFocused,
       shouldDisableActions,
+      showClockDisplay,
     } = this.props;
 
     const indentLevel = !!focusedHeader
@@ -493,6 +494,11 @@ ${header.get('rawDescription')}`;
                 isSelected={isSelected}
                 shouldDisableExplicitWidth={swipedDistance === 0}
                 shouldDisableActions={shouldDisableActions}
+                addition={
+                  showClockDisplay && header.get('totalTimeLoggedRecursive') !== 0
+                    ? millisDuration(header.get('totalTimeLoggedRecursive'))
+                    : null
+                }
               />
 
               <Collapse
@@ -540,6 +546,7 @@ const mapStateToProps = (state, ownProps) => {
     focusedHeader,
     isFocused: !!focusedHeader && focusedHeader.get('id') === ownProps.header.get('id'),
     inEditMode: !!state.org.present.get('editMode'),
+    showClockDisplay: state.org.present.get('showClockDisplay'),
   };
 };
 

--- a/src/components/OrgFile/components/Header/index.js
+++ b/src/components/OrgFile/components/Header/index.js
@@ -497,7 +497,7 @@ ${header.get('rawDescription')}`;
                 addition={
                   showClockDisplay && header.get('totalTimeLoggedRecursive') !== 0
                     ? millisDuration(header.get('totalTimeLoggedRecursive'))
-                    : null
+                    : ''
                 }
               />
 

--- a/src/components/OrgFile/components/SearchModal/components/HeaderListView/index.js
+++ b/src/components/OrgFile/components/SearchModal/components/HeaderListView/index.js
@@ -40,8 +40,8 @@ function HeaderListView(props) {
                   shouldDisableExplicitWidth
                   onClick={handleHeaderClick(header.get('id'))}
                   addition={
-                    showClockedTimes && header.get('totalTimeLogged') !== 0
-                      ? millisDuration(header.get('totalTimeLogged'))
+                    showClockedTimes && header.get('totalFilteredTimeLogged') !== 0
+                      ? millisDuration(header.get('totalFilteredTimeLogged'))
                       : null
                   }
                 />

--- a/src/components/OrgFile/components/SearchModal/components/HeaderListView/index.js
+++ b/src/components/OrgFile/components/SearchModal/components/HeaderListView/index.js
@@ -40,8 +40,8 @@ function HeaderListView(props) {
                   shouldDisableExplicitWidth
                   onClick={handleHeaderClick(header.get('id'))}
                   addition={
-                    showClockedTimes && header.get('totalFilteredTimeLogged') !== 0
-                      ? millisDuration(header.get('totalFilteredTimeLogged'))
+                    showClockedTimes && header.get('totalFilteredTimeLoggedRecursive') !== 0
+                      ? millisDuration(header.get('totalFilteredTimeLoggedRecursive'))
                       : null
                   }
                 />

--- a/src/components/OrgFile/components/SearchModal/components/HeaderListView/index.js
+++ b/src/components/OrgFile/components/SearchModal/components/HeaderListView/index.js
@@ -5,6 +5,8 @@ import { connect } from 'react-redux';
 import * as orgActions from '../../../../../../actions/org';
 import './stylesheet.css';
 
+import { millisDuration } from '../../../../../../lib/timestamps';
+
 import TitleLine from '../../../TitleLine';
 
 function HeaderListView(props) {
@@ -20,7 +22,7 @@ function HeaderListView(props) {
     props.org.setSearchFilterInformation('', 0, context);
   }, [context, props.org]);
 
-  const { headers } = props;
+  const { headers, showClockedTimes } = props;
 
   return (
     <div className="agenda-day__container">
@@ -37,6 +39,11 @@ function HeaderListView(props) {
                   shouldDisableActions
                   shouldDisableExplicitWidth
                   onClick={handleHeaderClick(header.get('id'))}
+                  addition={
+                    showClockedTimes && header.get('totalTimeLogged') !== 0
+                      ? millisDuration(header.get('totalTimeLogged'))
+                      : null
+                  }
                 />
               </div>
             </div>
@@ -51,6 +58,7 @@ const mapStateToProps = (state) => ({
   // When no filtering has happened, yet (initial state), use all headers.
   headers:
     state.org.present.getIn(['search', 'filteredHeaders']) || state.org.present.get('headers'),
+  showClockedTimes: state.org.present.getIn(['search', 'showClockedTimes']),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/components/OrgFile/components/SearchModal/index.js
+++ b/src/components/OrgFile/components/SearchModal/index.js
@@ -56,7 +56,11 @@ function SearchModal(props) {
     <Drawer onClose={onClose} maxSize={true}>
       <div className="task-list__modal-title">
         <h2 className="agenda__title">{capitalize(context)}</h2>
-        {showClockedTimes ? millisDuration(clockedTime) : null}
+        {showClockedTimes ? (
+          <span title="Sum of time logged on all search results directly (not including time logged on their children)">
+            {millisDuration(clockedTime)}
+          </span>
+        ) : null}
       </div>
 
       <datalist id="task-list__datalist-filter">

--- a/src/components/OrgFile/components/SearchModal/index.js
+++ b/src/components/OrgFile/components/SearchModal/index.js
@@ -10,6 +10,7 @@ import HeaderListView from './components/HeaderListView';
 import Drawer from '../../../UI/Drawer';
 
 import { isMobileBrowser, isIos } from '../../../../lib/browser_utils';
+import { millisDuration } from '../../../../lib/timestamps';
 
 import * as orgActions from '../../../../actions/org';
 
@@ -18,7 +19,15 @@ import * as orgActions from '../../../../actions/org';
 // changing all.
 function SearchModal(props) {
   const [dateDisplayType, setdateDisplayType] = useState('absolute');
-  const { onClose, searchFilter, searchFilterValid, searchFilterSuggestions, context } = props;
+  const {
+    onClose,
+    searchFilter,
+    searchFilterValid,
+    searchFilterSuggestions,
+    context,
+    showClockedTimes,
+    clockedTime,
+  } = props;
 
   function handleHeaderClick(headerId) {
     props.onClose(headerId);
@@ -45,7 +54,10 @@ function SearchModal(props) {
 
   return (
     <Drawer onClose={onClose} maxSize={true}>
-      <h2 className="agenda__title">{capitalize(context)}</h2>
+      <div className="task-list__modal-title">
+        <h2 className="agenda__title">{capitalize(context)}</h2>
+        {showClockedTimes ? millisDuration(clockedTime) : null}
+      </div>
 
       <datalist id="task-list__datalist-filter">
         {searchFilterSuggestions.map((string, idx) => (
@@ -96,6 +108,8 @@ const mapStateToProps = (state) => ({
   searchFilter: state.org.present.getIn(['search', 'searchFilter']) || '',
   searchFilterValid: state.org.present.getIn(['search', 'searchFilterValid']),
   searchFilterSuggestions: state.org.present.getIn(['search', 'searchFilterSuggestions']) || [],
+  showClockedTimes: state.org.present.getIn(['search', 'showClockedTimes']),
+  clockedTime: state.org.present.getIn(['search', 'clockedTime']),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/components/OrgFile/components/SearchModal/stylesheet.css
+++ b/src/components/OrgFile/components/SearchModal/stylesheet.css
@@ -20,3 +20,9 @@
 .task-list__filter-input-invalid {
   border: 2px solid var(--red);
 }
+
+.task-list__modal-title {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/components/OrgFile/components/TitleLine/index.js
+++ b/src/components/OrgFile/components/TitleLine/index.js
@@ -10,7 +10,7 @@ import classNames from 'classnames';
 import * as orgActions from '../../../../actions/org';
 import * as baseActions from '../../../../actions/base';
 
-import { getCurrentTimestampAsText, millisDuration } from '../../../../lib/timestamps';
+import { getCurrentTimestampAsText } from '../../../../lib/timestamps';
 import { createIsTodoKeywordInDoneState } from '../../../../lib/org_utils';
 
 import { generateTitleLine } from '../../../../lib/export_org';
@@ -183,25 +183,19 @@ class TitleLine extends PureComponent {
       shouldDisableActions,
       shouldDisableExplicitWidth,
       todoKeywordSets,
-      showClockDisplay,
+      addition,
     } = this.props;
     const { containerWidth } = this.state;
 
     const isTodoKeywordInDoneState = createIsTodoKeywordInDoneState(todoKeywordSets);
     const todoKeyword = header.getIn(['titleLine', 'todoKeyword']);
 
-    const titleLineStyle = {
-      width: '100%',
-      display: 'flex',
-      justifyContent: 'space-between',
-    };
-
     const titleStyle = {
       color,
       wordBreak: 'break-word',
     };
 
-    const clockDisplayStyle = {
+    const additionStyle = {
       color,
       minWidth: '5em',
       textAlign: 'right',
@@ -259,7 +253,7 @@ class TitleLine extends PureComponent {
           </div>
         ) : (
           <div style={{ width: '100%' }}>
-            <div style={titleLineStyle}>
+            <div className="title-line-text">
               <span style={titleStyle} ref={this.handleTitleSpanRef}>
                 <AttributedString
                   parts={header.getIn(['titleLine', 'title'])}
@@ -270,10 +264,8 @@ class TitleLine extends PureComponent {
                 />
                 {!header.get('opened') && hasContent ? '...' : ''}
               </span>
-              {showClockDisplay && header.get('totalTimeLoggedRecursive') !== 0 ? (
-                <span style={clockDisplayStyle}>
-                  {millisDuration(header.get('totalTimeLoggedRecursive'))}
-                </span>
+              {addition !== null && addition !== undefined && addition !== '' ? (
+                <span style={additionStyle}>{addition}</span>
               ) : null}
             </div>
             {header.getIn(['titleLine', 'tags']).size > 0 && (
@@ -307,7 +299,6 @@ const mapStateToProps = (state, ownProps) => {
     closeSubheadersRecursively: state.base.get('closeSubheadersRecursively'),
     isSelected: state.org.present.get('selectedHeaderId') === ownProps.header.get('id'),
     todoKeywordSets: state.org.present.get('todoKeywordSets'),
-    showClockDisplay: state.org.present.get('showClockDisplay'),
   };
 };
 

--- a/src/components/OrgFile/components/TitleLine/index.js
+++ b/src/components/OrgFile/components/TitleLine/index.js
@@ -264,9 +264,7 @@ class TitleLine extends PureComponent {
                 />
                 {!header.get('opened') && hasContent ? '...' : ''}
               </span>
-              {addition !== null && addition !== undefined ? (
-                <span style={additionStyle}>{addition}</span>
-              ) : null}
+              {addition ? <span style={additionStyle}>{addition}</span> : null}
             </div>
             {header.getIn(['titleLine', 'tags']).size > 0 && (
               <div>

--- a/src/components/OrgFile/components/TitleLine/index.js
+++ b/src/components/OrgFile/components/TitleLine/index.js
@@ -264,7 +264,7 @@ class TitleLine extends PureComponent {
                 />
                 {!header.get('opened') && hasContent ? '...' : ''}
               </span>
-              {addition !== null && addition !== undefined && addition !== '' ? (
+              {addition !== null && addition !== undefined ? (
                 <span style={additionStyle}>{addition}</span>
               ) : null}
             </div>

--- a/src/components/OrgFile/components/TitleLine/stylesheet.css
+++ b/src/components/OrgFile/components/TitleLine/stylesheet.css
@@ -51,3 +51,9 @@
 .insert-timestamp-icon {
   margin-right: 5px;
 }
+
+.title-line-text {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/lib/clocking.js
+++ b/src/lib/clocking.js
@@ -46,3 +46,21 @@ export const updateHeadersTotalTimeLogged = (headers) => {
   });
   return headersWithtotalTimeLoggedRecursive;
 };
+
+export const updateHeadersTotalFilteredTimeLogged = (filters, headers) => {
+  if (!headers) {
+    return headers;
+  }
+  const headersWithtotalTimeLogged = headers.map((header) =>
+    header.set('totalFilteredTimeLogged', totalFilteredTimeLogged(filters, header))
+  );
+  const headersWithtotalTimeLoggedRecursive = headersWithtotalTimeLogged.map((header, index) => {
+    const subheaders = subheadersOfHeaderWithIndex(headersWithtotalTimeLogged, index);
+    const totalTimeLoggedRecursive = subheaders.reduce(
+      (acc, val) => acc + val.get('totalFilteredTimeLogged'),
+      header.get('totalFilteredTimeLogged')
+    );
+    return header.set('totalFilteredTimeLoggedRecursive', totalTimeLoggedRecursive);
+  });
+  return headersWithtotalTimeLoggedRecursive;
+};

--- a/src/lib/clocking.js
+++ b/src/lib/clocking.js
@@ -1,7 +1,7 @@
 import { subheadersOfHeaderWithIndex } from './org_utils';
 import { dateForTimestamp } from './timestamps';
 
-export const totalTimeLogged = (header) => {
+const totalTimeLogged = (header) => {
   const logBookEntries = header.get('logBookEntries', []);
 
   const times = logBookEntries.map((entry) =>
@@ -9,6 +9,21 @@ export const totalTimeLogged = (header) => {
       ? dateForTimestamp(entry.get('end')) - dateForTimestamp(entry.get('start'))
       : 0
   );
+
+  const addedTimes = times.reduce((acc, val) => acc + val, 0);
+  return addedTimes;
+};
+
+export const totalFilteredTimeLogged = (filters, header) => {
+  const clocks = header
+    .get('logBookEntries', [])
+    .map((l) => [l.get('start'), l.get('end')])
+    .filter(
+      ([start, end]) => start !== undefined && start !== null && end !== undefined && end !== null
+    )
+    .filter((ts) => ts.some((t) => filters.every((f) => f(t))));
+
+  const times = clocks.map(([start, end]) => dateForTimestamp(end) - dateForTimestamp(start));
 
   const addedTimes = times.reduce((acc, val) => acc + val, 0);
   return addedTimes;

--- a/src/lib/clocking.js
+++ b/src/lib/clocking.js
@@ -29,7 +29,7 @@ export const totalFilteredTimeLogged = (filters, header) => {
   return addedTimes;
 };
 
-export const updateHeadersTotalTimeLogged = (headers) => {
+export const updateHeadersTotalTimeLoggedRecursive = (headers) => {
   if (!headers) {
     return headers;
   }
@@ -47,7 +47,7 @@ export const updateHeadersTotalTimeLogged = (headers) => {
   return headersWithtotalTimeLoggedRecursive;
 };
 
-export const updateHeadersTotalFilteredTimeLogged = (filters, headers) => {
+export const updateHeadersTotalFilteredTimeLoggedRecursive = (filters, headers) => {
   if (!headers) {
     return headers;
   }

--- a/src/lib/clocking.js
+++ b/src/lib/clocking.js
@@ -1,7 +1,7 @@
 import { subheadersOfHeaderWithIndex } from './org_utils';
 import { dateForTimestamp } from './timestamps';
 
-const totalTimeLogged = (header) => {
+export const totalTimeLogged = (header) => {
   const logBookEntries = header.get('logBookEntries', []);
 
   const times = logBookEntries.map((entry) =>

--- a/src/lib/clocking.js
+++ b/src/lib/clocking.js
@@ -18,9 +18,7 @@ export const totalFilteredTimeLogged = (filters, header) => {
   const clocks = header
     .get('logBookEntries', [])
     .map((l) => [l.get('start'), l.get('end')])
-    .filter(
-      ([start, end]) => start !== undefined && start !== null && end !== undefined && end !== null
-    )
+    .filter(([start, end]) => start && end)
     .filter((ts) => ts.some((t) => filters.every((f) => f(t))));
 
   const times = clocks.map(([start, end]) => dateForTimestamp(end) - dateForTimestamp(start));

--- a/src/lib/headline_filter.js
+++ b/src/lib/headline_filter.js
@@ -137,7 +137,7 @@ const isRelative = (moment) => {
   return moment.type === 'offset' || moment.type === 'unit';
 };
 
-const timeFilter = (filterDescription) => {
+export const timeFilter = (filterDescription) => {
   const timeFilterDescription = filterDescription.field.timerange;
   let lower;
   let upper;

--- a/src/lib/headline_filter.js
+++ b/src/lib/headline_filter.js
@@ -204,7 +204,7 @@ export const isMatch = (filterExpr) => {
     .map((x) => [x.property, x.words]);
   const filterField = filterExpr.filter(filterFilter('field', false));
   const filterDate = filterField.filter((f) => f.field.type === 'date').map(timeFilter);
-  const filterClock = filterField.filter((f) => f.field.type === 'clock').map(timeFilter);
+  //const filterClock = filterField.filter((f) => f.field.type === 'clock').map(timeFilter);
   const filterSchedule = filterField.filter((f) => f.field.type === 'scheduled').map(timeFilter);
   const filterDeadline = filterField.filter((f) => f.field.type === 'deadline').map(timeFilter);
 
@@ -234,10 +234,10 @@ export const isMatch = (filterExpr) => {
     const deadlines = planningItems
       .filter((p) => p.get('type') === 'DEADLINE')
       .map((p) => p.get('timestamp'));
-    const clocks = header
-      .get('logBookEntries')
-      .flatMap((l) => [l.get('start'), l.get('end')])
-      .filter((t) => t !== undefined && t !== null);
+    //const clocks = header
+    //  .get('logBookEntries')
+    //  .flatMap((l) => [l.get('start'), l.get('end')])
+    //  .filter((t) => t !== undefined && t !== null);
     const propertyFilter = ([x, ys]) =>
       !properties
         .filter(([key, val]) => {
@@ -255,7 +255,7 @@ export const isMatch = (filterExpr) => {
       filterIC.every(orChain(headlineText.toLowerCase())) &&
       filterProps.every(propertyFilter) &&
       filterDate.every(orChainDate(dates)) &&
-      filterClock.every(orChainDate(clocks)) &&
+      //filterClock.every(orChainDate(clocks)) &&
       filterSchedule.every(orChainDate(scheduleds)) &&
       filterDeadline.every(orChainDate(deadlines)) &&
       !filterTagsExcl.some(orChain(tags)) &&

--- a/src/lib/parse_org.js
+++ b/src/lib/parse_org.js
@@ -1,5 +1,5 @@
 import generateId from './id_generator';
-import { updateHeadersTotalTimeLogged } from './clocking';
+import { updateHeadersTotalTimeLoggedRecursive } from './clocking';
 
 import { fromJS, List } from 'immutable';
 import _ from 'lodash';
@@ -857,7 +857,7 @@ export const parseOrg = (fileContents) => {
     return _updateHeaderFromDescription(header, description);
   });
 
-  headers = updateHeadersTotalTimeLogged(headers);
+  headers = updateHeadersTotalTimeLoggedRecursive(headers);
 
   return fromJS({
     headers,

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -1080,7 +1080,10 @@ export const setSearchFilterInformation = (state, action) => {
       headersToSearch = headersToSearch.map((header) =>
         header.set('totalFilteredTimeLogged', totalFilteredTimeLogged(filterFunctions, header))
       );
-      headersToSearch = updateHeadersTotalFilteredTimeLogged(filterFunctions, headersToSearch);
+      headersToSearch = updateHeadersTotalFilteredTimeLogged(
+        filterFunctions,
+        headersToSearch
+      ).filter((header) => header.get('totalFilteredTimeLoggedRecursive') !== 0);
 
       const clockedTime = headersToSearch.reduce(
         (acc, val) => acc + val.get('totalFilteredTimeLogged'),

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -1084,15 +1084,17 @@ export const setSearchFilterInformation = (state, action) => {
         filterFunctions,
         headersToSearch
       ).filter((header) => header.get('totalFilteredTimeLoggedRecursive') !== 0);
+    }
 
-      const clockedTime = headersToSearch.reduce(
+    filteredHeaders = headersToSearch.filter(isMatch(searchFilterExpr));
+
+    if (showClockedTimes) {
+      const clockedTime = filteredHeaders.reduce(
         (acc, val) => acc + val.get('totalFilteredTimeLogged'),
         0
       );
       state.setIn(['search', 'clockedTime'], clockedTime);
     }
-
-    filteredHeaders = headersToSearch.filter(isMatch(searchFilterExpr));
 
     // Filter selectedHeader and its subheaders from `headers`,
     // because you don't want to refile a header to itself or to one

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -5,7 +5,7 @@ import _ from 'lodash';
 
 import headline_filter_parser from '../lib/headline_filter_parser';
 import { isMatch, computeCompletionsForDatalist } from '../lib/headline_filter';
-import { updateHeadersTotalTimeLogged } from '../lib/clocking';
+import { updateHeadersTotalTimeLogged, totalTimeLogged } from '../lib/clocking';
 
 import {
   extractAllOrgTags,
@@ -1074,6 +1074,23 @@ export const setSearchFilterInformation = (state, action) => {
       filteredHeaders = filteredHeaders.filter((h) => {
         return !filterIds.includes(h.get('id'));
       });
+    }
+
+    // show clocked times & sum if there is a clock search term
+    const showClockedTimes =
+      searchFilterExpr.filter((f) => f.type === 'field').filter((f) => f.field.type === 'clock')
+        .length !== 0;
+
+    console.debug(searchFilterExpr.filter((f) => f.type === 'field').filter((f) => f.field.type === 'clock'))
+    state.setIn(['search', 'showClockedTimes'], showClockedTimes);
+    if (showClockedTimes) {
+      if (!state.get('showClockDisplay')) {
+        filteredHeaders = headers.map((header) =>
+        header.set('totalTimeLogged', totalTimeLogged(header))
+      );
+      }
+      const clockedTime = filteredHeaders.reduce((acc, val) => acc + val.get('totalTimeLogged'), 0);
+      state.setIn(['search', 'clockedTime'], clockedTime);
     }
 
     state.setIn(['search', 'filteredHeaders'], filteredHeaders);

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -1081,13 +1081,12 @@ export const setSearchFilterInformation = (state, action) => {
       searchFilterExpr.filter((f) => f.type === 'field').filter((f) => f.field.type === 'clock')
         .length !== 0;
 
-    console.debug(searchFilterExpr.filter((f) => f.type === 'field').filter((f) => f.field.type === 'clock'))
     state.setIn(['search', 'showClockedTimes'], showClockedTimes);
     if (showClockedTimes) {
       if (!state.get('showClockDisplay')) {
         filteredHeaders = headers.map((header) =>
-        header.set('totalTimeLogged', totalTimeLogged(header))
-      );
+          header.set('totalTimeLogged', totalTimeLogged(header))
+        );
       }
       const clockedTime = filteredHeaders.reduce((acc, val) => acc + val.get('totalTimeLogged'), 0);
       state.setIn(['search', 'clockedTime'], clockedTime);

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -6,9 +6,9 @@ import _ from 'lodash';
 import headline_filter_parser from '../lib/headline_filter_parser';
 import { isMatch, computeCompletionsForDatalist, timeFilter } from '../lib/headline_filter';
 import {
-  updateHeadersTotalTimeLogged,
+  updateHeadersTotalTimeLoggedRecursive,
   totalFilteredTimeLogged,
-  updateHeadersTotalFilteredTimeLogged,
+  updateHeadersTotalFilteredTimeLoggedRecursive,
 } from '../lib/clocking';
 
 import {
@@ -1080,7 +1080,7 @@ export const setSearchFilterInformation = (state, action) => {
       headersToSearch = headersToSearch.map((header) =>
         header.set('totalFilteredTimeLogged', totalFilteredTimeLogged(filterFunctions, header))
       );
-      headersToSearch = updateHeadersTotalFilteredTimeLogged(
+      headersToSearch = updateHeadersTotalFilteredTimeLoggedRecursive(
         filterFunctions,
         headersToSearch
       ).filter((header) => header.get('totalFilteredTimeLoggedRecursive') !== 0);
@@ -1147,7 +1147,7 @@ const setOrgFileErrorMessage = (state, action) => state.set('orgFileErrorMessage
 
 const setShowClockDisplay = (state, action) => {
   if (action.showClockDisplay) {
-    state = state.update('headers', updateHeadersTotalTimeLogged);
+    state = state.update('headers', updateHeadersTotalTimeLoggedRecursive);
   }
   return state.set('showClockDisplay', action.showClockDisplay);
 };
@@ -1280,7 +1280,7 @@ export default (state = Map(), action) => {
   state = reducer(state, action);
 
   if (action.dirtying && state.get('showClockDisplay')) {
-    state = state.update('headers', updateHeadersTotalTimeLogged);
+    state = state.update('headers', updateHeadersTotalTimeLoggedRecursive);
   }
   return state;
 };


### PR DESCRIPTION
This is a rival PR to #520, relating to the discussion in #504.

In this version the `clock:` search term includes headers that have time logged on their children.