### PR TITLE
Feat/interpreted style for color schemes

### DIFF
--- a/src/components/OrgFile/OrgFile.integration.test.js
+++ b/src/components/OrgFile/OrgFile.integration.test.js
@@ -211,6 +211,14 @@ describe('Render all views', () => {
 
     describe('Renders everything starting from an Org file', () => {
       test('renders an Org file', () => {
+        // INFO: This snapshot is semantically correct, but it does
+        // not have color theme information. We're implementing the
+        // color themes with an API that mutates the DOM in place (see
+        // `color.js::loadTheme`. We cannot use this API in jest
+        // tests, because calling the API does not yield the same
+        // side-effect as in a browser. Hence, some colors in this
+        // snapshot are off, but that's ok. We do colorScheme testing
+        // by eye and not with automated tests.
         expect(getAllByText(/\*/)).toHaveLength(7);
         expect(container).toMatchSnapshot();
       });

--- a/src/components/OrgFile/__snapshots__/OrgFile.integration.test.js.snap
+++ b/src/components/OrgFile/__snapshots__/OrgFile.integration.test.js.snap
@@ -331,7 +331,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
         >
           <div
             class="left-swipe-action-container"
-            style="width: 0px; background-color: rgb(211, 211, 211);"
+            style="width: 0px; background-color: rgba(0, 0, 0, 0);"
           >
             <i
               class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
@@ -340,7 +340,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
           </div>
           <div
             class="right-swipe-action-container"
-            style="width: 0px; background-color: rgb(211, 211, 211);"
+            style="width: 0px; background-color: rgba(0, 0, 0, 0);"
           >
             <i
               class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
@@ -382,7 +382,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
         >
           <div
             class="left-swipe-action-container"
-            style="width: 0px; background-color: rgb(211, 211, 211);"
+            style="width: 0px; background-color: rgba(0, 0, 0, 0);"
           >
             <i
               class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
@@ -391,7 +391,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
           </div>
           <div
             class="right-swipe-action-container"
-            style="width: 0px; background-color: rgb(211, 211, 211);"
+            style="width: 0px; background-color: rgba(0, 0, 0, 0);"
           >
             <i
               class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
@@ -433,7 +433,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
         >
           <div
             class="left-swipe-action-container"
-            style="width: 0px; background-color: rgb(211, 211, 211);"
+            style="width: 0px; background-color: rgba(0, 0, 0, 0);"
           >
             <i
               class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
@@ -442,7 +442,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
           </div>
           <div
             class="right-swipe-action-container"
-            style="width: 0px; background-color: rgb(211, 211, 211);"
+            style="width: 0px; background-color: rgba(0, 0, 0, 0);"
           >
             <i
               class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
@@ -496,7 +496,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
         >
           <div
             class="left-swipe-action-container"
-            style="width: 0px; background-color: rgb(211, 211, 211);"
+            style="width: 0px; background-color: rgba(0, 0, 0, 0);"
           >
             <i
               class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
@@ -505,7 +505,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
           </div>
           <div
             class="right-swipe-action-container"
-            style="width: 0px; background-color: rgb(211, 211, 211);"
+            style="width: 0px; background-color: rgba(0, 0, 0, 0);"
           >
             <i
               class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
@@ -554,7 +554,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
         >
           <div
             class="left-swipe-action-container"
-            style="width: 0px; background-color: rgb(211, 211, 211);"
+            style="width: 0px; background-color: rgba(0, 0, 0, 0);"
           >
             <i
               class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
@@ -563,7 +563,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
           </div>
           <div
             class="right-swipe-action-container"
-            style="width: 0px; background-color: rgb(211, 211, 211);"
+            style="width: 0px; background-color: rgba(0, 0, 0, 0);"
           >
             <i
               class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
@@ -605,7 +605,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
         >
           <div
             class="left-swipe-action-container"
-            style="width: 0px; background-color: rgb(211, 211, 211);"
+            style="width: 0px; background-color: rgba(0, 0, 0, 0);"
           >
             <i
               class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
@@ -614,7 +614,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
           </div>
           <div
             class="right-swipe-action-container"
-            style="width: 0px; background-color: rgb(211, 211, 211);"
+            style="width: 0px; background-color: rgba(0, 0, 0, 0);"
           >
             <i
               class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"
@@ -656,7 +656,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
         >
           <div
             class="left-swipe-action-container"
-            style="width: 0px; background-color: rgb(211, 211, 211);"
+            style="width: 0px; background-color: rgba(0, 0, 0, 0);"
           >
             <i
               class="fas fa-check swipe-action-container__icon swipe-action-container__icon--left"
@@ -665,7 +665,7 @@ exports[`Render all views Org Functionality Renders everything starting from an 
           </div>
           <div
             class="right-swipe-action-container"
-            style="width: 0px; background-color: rgb(211, 211, 211);"
+            style="width: 0px; background-color: rgba(0, 0, 0, 0);"
           >
             <i
               class="fas fa-times swipe-action-container__icon swipe-action-container__icon--right"

--- a/src/components/OrgFile/components/Header/index.js
+++ b/src/components/OrgFile/components/Header/index.js
@@ -18,7 +18,7 @@ import HeaderContent from '../HeaderContent';
 import HeaderActionDrawer from './components/HeaderActionDrawer';
 
 import { headerWithId } from '../../../../lib/org_utils';
-import { interpolateColors, rgbaObject, rgbaString } from '../../../../lib/color';
+import { interpolateColors, rgbaObject, rgbaString, readRgbaVariable } from '../../../../lib/color';
 import { getCurrentTimestamp, millisDuration } from '../../../../lib/timestamps';
 
 class Header extends PureComponent {
@@ -378,7 +378,7 @@ ${header.get('rawDescription')}`;
           const isRightActionActivated =
             -1 * swipedDistance >= this.SWIPE_ACTION_ACTIVATION_DISTANCE;
 
-          const disabledBackgroundColor = rgbaObject(211, 211, 211, 1);
+          const disabledBackgroundColor = readRgbaVariable('--base3');
           const leftActivatedBackgroundColor = rgbaObject(0, 128, 0, 1);
           const rightActivatedBackgroundColor = rgbaObject(255, 0, 0, 1);
 

--- a/src/components/OrgFile/components/Header/index.js
+++ b/src/components/OrgFile/components/Header/index.js
@@ -63,6 +63,7 @@ class Header extends PureComponent {
       containerWidth: null,
       isPlayingRemoveAnimation: false,
       heightBeforeRemove: null,
+      disabledBackgroundColor: readRgbaVariable('--base3'),
     };
   }
 
@@ -378,7 +379,6 @@ ${header.get('rawDescription')}`;
           const isRightActionActivated =
             -1 * swipedDistance >= this.SWIPE_ACTION_ACTIVATION_DISTANCE;
 
-          const disabledBackgroundColor = readRgbaVariable('--base3');
           const leftActivatedBackgroundColor = rgbaObject(0, 128, 0, 1);
           const rightActivatedBackgroundColor = rgbaObject(255, 0, 0, 1);
 
@@ -421,7 +421,7 @@ ${header.get('rawDescription')}`;
                     width: leftInterpolatedStyle.width,
                     backgroundColor: rgbaString(
                       interpolateColors(
-                        disabledBackgroundColor,
+                        this.state.disabledBackgroundColor,
                         leftActivatedBackgroundColor,
                         leftInterpolatedStyle.backgroundColorFactor
                       )
@@ -455,7 +455,7 @@ ${header.get('rawDescription')}`;
                     width: rightInterpolatedStyle.width,
                     backgroundColor: rgbaString(
                       interpolateColors(
-                        disabledBackgroundColor,
+                        this.state.disabledBackgroundColor,
                         rightActivatedBackgroundColor,
                         rightInterpolatedStyle.backgroundColorFactor
                       )

--- a/src/lib/color.js
+++ b/src/lib/color.js
@@ -20,6 +20,29 @@ export const rgbaString = (rgba) => {
   return `rgba(${rgba.r}, ${rgba.g}, ${rgba.b}, ${rgba.a})`;
 };
 
+// assumes var is either a longform-hex or rgb(a) color value
+export const readRgbaVariable = (varName) => {
+  const varValue = getComputedStyle(document.documentElement).getPropertyValue(varName);
+  if (varValue.charAt(0) === '#') {
+    const hexValue = varValue.substring(1, 7);
+    return rgbaObject(
+      parseInt(hexValue.substring(0, 2), 16),
+      parseInt(hexValue.substring(2, 4), 16),
+      parseInt(hexValue.substring(4, 6), 16),
+      1
+    );
+  } else {
+    const rgbaValues = [...varValue.matchAll(/[0-9.]+/g)].map((a) => +a[0]);
+    if (rgbaValues.length === 3) {
+      return rgbaObject(...rgbaValues, 0);
+    } else if (rgbaValues.length === 4) {
+      return rgbaObject(...rgbaValues);
+    } else {
+      return rgbaObject(0, 0, 0, 0);
+    }
+  }
+};
+
 export const solarizedDark = () => {
   const root = document.documentElement;
   // backgrounds
@@ -31,7 +54,7 @@ export const solarizedDark = () => {
   root.style.setProperty('--base0', '#657b83');
   root.style.setProperty('--base1', '#586e75');
   root.style.setProperty('--base2', '#073642');
-  root.style.setProperty('--base3', '#002b36');
+  root.style.setProperty('--base3', 'rgb(0,0,0)'); // #002b36
   // shadows
   root.style.setProperty('--base0-soft', 'rgba(101, 123, 131, 0.75)');
   // highlighted backgrounds

--- a/src/lib/color.js
+++ b/src/lib/color.js
@@ -54,7 +54,7 @@ export const solarizedDark = () => {
   root.style.setProperty('--base0', '#657b83');
   root.style.setProperty('--base1', '#586e75');
   root.style.setProperty('--base2', '#073642');
-  root.style.setProperty('--base3', 'rgb(0,0,0)'); // #002b36
+  root.style.setProperty('--base3', '#002b36');
   // shadows
   root.style.setProperty('--base0-soft', 'rgba(101, 123, 131, 0.75)');
   // highlighted backgrounds

--- a/src/util/settings_persister.js
+++ b/src/util/settings_persister.js
@@ -139,6 +139,7 @@ export const persistableFields = [
     category: 'base',
     name: 'colorScheme',
     type: 'string',
+    default: 'Light',
     shouldStoreInConfig: true,
   },
   {

--- a/src/util/settings_persister.js
+++ b/src/util/settings_persister.js
@@ -153,6 +153,7 @@ export const persistableFields = [
     name: 'theme',
     type: 'string',
     default: 'Solarized',
+    shouldStoreInConfig: true,
   },
   {
     category: 'capture',


### PR DESCRIPTION
Style interpolation for the swipe action assumed light mode background color as a starting point. I added a function that reads out the defined background color.

It's not the most elegant fix. Maybe there is a pure css solution to the whole style interpolation but I have no expertise in this area.