### PR TITLE
fix: use a NixOS-compatible shebang line for bash in compile scripts

### DIFF
--- a/bin/compile_and_upload.sh
+++ b/bin/compile_and_upload.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/bin/compile_doc.sh
+++ b/bin/compile_doc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if ! [ -e README.org ]; then
     echo >&2 "Error: Please run this script from top of the organice repository."

--- a/bin/compile_doc_and_upload.sh
+++ b/bin/compile_doc_and_upload.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Sanity check that all variables are set to upload to FTP
 [ -z ${FTP_HOST+x} ] && (echo "$FTP_HOST needs to be set for uploading to FTP."; exit 1)

--- a/bin/compile_search_parser.sh
+++ b/bin/compile_search_parser.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 npx pegjs -o src/lib/headline_filter_parser.{js,grammar.pegjs}
 


### PR DESCRIPTION
This fixes some shebang lines for NixOS, which does not have a `/bin/bash`. The only thing NixOS has in `/bin` is `/bin/sh`, and the only thing it has in `/usr` is `/usr/bin/env`.