### PR TITLE
Automatic deployments to production and stage instances

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,25 @@
 #
 version: 2
 jobs:
-  deploy:
+  deploy-stage:
+    docker:
+      - image: circleci/node:12.13-buster
+    steps:
+      - checkout
+      - restore_cache:
+          name: Restore Yarn Package Cache
+          keys:
+            - yarn-packages-{{ checksum "yarn.lock" }}
+      - run:
+          name: Install dependencies
+          command: sudo apt-get update -yq && sudo apt install -yq lftp pandoc gvfs emacs
+      - run:
+          name: Deploy to https://staging.organice.200ok.ch
+          command: 'FTP_USER=${FTP_USER_STAGE} FTP_PASSWD=${FTP_PASSWD_STAGE} ./bin/compile_and_upload.sh'
+      - run:
+          name: Deploy documentation to https://staging.organice.200ok.ch/documentation.html
+          command: 'FTP_USER=${FTP_USER_STAGE} FTP_PASSWD=${FTP_PASSWD_STAGE} ./bin/compile_doc_and_upload.sh'
+  deploy-prod:
     docker:
       - image: circleci/node:12.13-buster
     steps:
@@ -26,10 +44,6 @@ jobs:
   build:
     docker:
       - image: circleci/node:12.13-buster
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/mongo:3.4.4
 
     working_directory: ~/repo
 
@@ -75,10 +89,6 @@ jobs:
   build-docs:
     docker:
       - image: circleci/node:12.13-buster
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/mongo:3.4.4
 
     working_directory: ~/repo
 
@@ -111,13 +121,20 @@ workflows:
     jobs:
       - build
       - build-docs
-      - deploy:
+      - deploy-prod:
           requires:
             - build
             - build-docs
           filters:
             branches:
               only: master
+      - deploy-stage:
+          requires:
+            - build
+            - build-docs
+          filters:
+            branches:
+              only: develop
       - push-image:
           requires:
             - build # because of tests

--- a/README.org
+++ b/README.org
@@ -433,6 +433,19 @@ will pause and you can examine the current scope and call stack.
 The "Create React App" upstream docs for this feature are here:
 https://create-react-app.dev/docs/debugging-tests/
 
+** Automatic deployments of reference instance
+
+The productive reference instance of organice is deployed to
+https://organice.200ok.ch/. On merging a pull request to =master=,
+code and documentation are automatically deployed to production.
+
+For more complicated features (aka epics) that require more than one
+pull request, there is a reference stage instance on
+[[https://staging.organice.200ok.ch/]]. When working on epics, we follow
+the popular [[https://nvie.com/posts/a-successful-git-branching-model/][nvie git branching model]] in that we successively create
+feature branches against =develop= until the epic is finished. On
+merging a pull request to =develop=, code and documentation are
+automatically deployed to stage.
 
 ** Contributions
 

--- a/src/components/Settings/index.js
+++ b/src/components/Settings/index.js
@@ -34,6 +34,15 @@ const Settings = ({
   base,
   org,
 }) => {
+  // This looks like hardcoding where it would be possible to dispatch
+  // on the `location.origin`, but here we assure that every instance
+  // of organice has a valid link to documentation. Self-building does
+  // not insure that, because building and hosting docs is not part of
+  // the application itself.
+  const documentationHost = window.location.origin.match(/staging.organice.200ok.ch/)
+    ? 'https://staging.organice.200ok.ch'
+    : 'https://organice.200ok.ch';
+
   const handleSignOutClick = () =>
     window.confirm('Are you sure you want to sign out?') ? syncBackend.signOut() : void 0;
 
@@ -265,7 +274,7 @@ const Settings = ({
         </Link>
 
         <button className="btn settings-btn">
-          <ExternalLink href="https://organice.200ok.ch/documentation.html">
+          <ExternalLink href={`${documentationHost}/documentation.html`}>
             Documentation
             <i className="fas fa-external-link-alt fa-sm" />
           </ExternalLink>{' '}


### PR DESCRIPTION
For regular features, fixes, documentation, nothing changes.

For longer lived features (aka epics), we now have a process and automation to work on those.

The productive reference instance of organice is deployed to <https://organice.200ok.ch/>. On merging a pull request to `master`, code and documentation are automatically deployed to production.

For more complicated features (aka epics) that require more than one pull request, there is a reference stage instance on <https://staging.organice.200ok.ch/>. When working on epics, we follow the popular [nvie git branching model](https://nvie.com/posts/a-successful-git-branching-model/) in that we successively create feature branches against `develop` until the epic is finished. On merging a pull request to `develop`, code and documentation are automatically deployed to stage.
