### PR TITLE
Feat/multiple files

### DIFF
--- a/src/actions/org.js
+++ b/src/actions/org.js
@@ -30,11 +30,11 @@ export const setLastSyncAt = (lastSyncAt) => ({
 
 export const stopDisplayingFile = () => {
   return (dispatch) => {
-    dispatch({ type: 'STOP_DISPLAYING_FILE' });
-    dispatch(ActionCreators.clearHistory());
     dispatch(widenHeader());
     dispatch(closePopup());
     dispatch(setLastSyncAt(null));
+    dispatch({ type: 'STOP_DISPLAYING_FILE' });
+    dispatch(ActionCreators.clearHistory());
   };
 };
 

--- a/src/actions/org.js
+++ b/src/actions/org.js
@@ -197,7 +197,14 @@ export const selectHeader = (headerId) => (dispatch) => {
   }
 };
 
-export const selectHeaderAndOpenParents = (headerId) => (dispatch) => {
+const changePath = (path) => ({
+  type: 'CHANGE_PATH',
+  path,
+});
+
+export const selectHeaderAndOpenParents = (path, headerId) => (dispatch) => {
+  // TODO: change path does not change the browser path
+  dispatch(changePath(path));
   dispatch(selectHeader(headerId));
   dispatch({ type: 'OPEN_PARENTS_OF_HEADER', headerId });
 };
@@ -311,9 +318,11 @@ export const moveSubtreeRight = (headerId) => ({
   dirtying: true,
 });
 
-export const refileSubtree = (sourceHeaderId, targetHeaderId) => ({
+export const refileSubtree = (sourcePath, sourceHeaderId, targetPath, targetHeaderId) => ({
   type: 'REFILE_SUBTREE',
+  sourcePath,
   sourceHeaderId,
+  targetPath,
   targetHeaderId,
   dirtying: true,
 });

--- a/src/actions/org.js
+++ b/src/actions/org.js
@@ -112,9 +112,9 @@ const doSync = ({
   client
     .getFileContentsAndMetadata(path)
     .then(({ contents, lastModifiedAt }) => {
-      const isDirty = getState().org.present.get('isDirty');
+      const isDirty = getState().org.present.getIn(['files', path, 'isDirty']);
       const lastServerModifiedAt = parseISO(lastModifiedAt);
-      const lastSyncAt = getState().org.present.get('lastSyncAt');
+      const lastSyncAt = getState().org.present.getIn(['files', path, 'lastSyncAt']);
 
       if (isAfter(lastSyncAt, lastServerModifiedAt) || forceAction === 'push') {
         if (isDirty) {
@@ -122,8 +122,12 @@ const doSync = ({
             .updateFile(
               path,
               exportOrg({
-                headers: getState().org.present.get('headers'),
-                linesBeforeHeadings: getState().org.present.get('linesBeforeHeadings'),
+                headers: getState().org.present.getIn(['files', path, 'headers']),
+                linesBeforeHeadings: getState().org.present.getIn([
+                  'files',
+                  path,
+                  'linesBeforeHeadings',
+                ]),
                 dontIndent: getState().base.get('shouldNotIndentOnExport'),
               })
             )
@@ -409,6 +413,7 @@ export const clearPendingCapture = () => ({
 });
 
 export const insertPendingCapture = () => (dispatch, getState) => {
+  const path = getState().org.present.get('path');
   const pendingCapture = getState().org.present.get('pendingCapture');
   const templateName = pendingCapture.get('captureTemplateName');
   const captureContent = pendingCapture.get('captureContent');
@@ -436,7 +441,7 @@ export const insertPendingCapture = () => (dispatch, getState) => {
   }
 
   const targetHeader = headerWithPath(
-    getState().org.present.get('headers'),
+    getState().org.present.getIn(['files', path, 'headers']),
     template.get('headerPaths')
   );
   if (!targetHeader) {

--- a/src/actions/sync_backend.js
+++ b/src/actions/sync_backend.js
@@ -107,7 +107,6 @@ export const pushBackup = (pathOrFileId, contents) => {
 export const downloadFile = (path) => {
   return (dispatch, getState) => {
     dispatch(setLoadingMessage('Downloading file...'));
-
     getState()
       .syncBackend.get('client')
       .getFileContents(path)

--- a/src/actions/sync_backend.js
+++ b/src/actions/sync_backend.js
@@ -111,11 +111,11 @@ export const downloadFile = (path) => {
       .syncBackend.get('client')
       .getFileContents(path)
       .then((fileContents) => {
-        dispatch(setDirty(false));
         dispatch(hideLoadingMessage());
         dispatch(pushBackup(path, fileContents));
-        dispatch(setLastSyncAt(addSeconds(new Date(), 5)));
         dispatch(displayFile(path, fileContents));
+        dispatch(setLastSyncAt(addSeconds(new Date(), 5)));
+        dispatch(setDirty(false));
         dispatch(applyOpennessState());
         dispatch(ActionCreators.clearHistory());
       })

--- a/src/components/Entry/index.js
+++ b/src/components/Entry/index.js
@@ -200,6 +200,8 @@ class Entry extends PureComponent {
 }
 
 const mapStateToProps = (state) => {
+  const path = state.org.present.get('path');
+  const file = state.org.present.getIn(['files', path]);
   return {
     loadingMessage: state.base.get('loadingMessage'),
     isAuthenticated: state.syncBackend.get('isAuthenticated'),
@@ -207,7 +209,7 @@ const mapStateToProps = (state) => {
     lastSeenChangelogHash: state.base.get('lastSeenChangelogHash'),
     activeModalPage: state.base.get('modalPageStack', List()).last(),
     pendingCapture: state.org.present.get('pendingCapture'),
-    isDirty: state.org.present.get('isDirty'),
+    isDirty: file ? file.get('isDirty') : null,
     colorScheme: state.base.get('colorScheme'),
   };
 };

--- a/src/components/OrgFile/components/ActionDrawer/index.js
+++ b/src/components/OrgFile/components/ActionDrawer/index.js
@@ -396,14 +396,16 @@ const ActionDrawer = ({
 };
 
 const mapStateToProps = (state) => {
+  const path = state.org.present.get('path');
+  const file = state.org.present.getIn(['files', path]);
   return {
-    inEditMode: !!state.org.present.get('editMode'),
-    selectedHeaderId: state.org.present.get('selectedHeaderId'),
-    isDirty: state.org.present.get('isDirty'),
-    isNarrowedHeaderActive: !!state.org.present.get('narrowedHeaderId'),
-    selectedTableCellId: state.org.present.get('selectedTableCellId'),
+    inEditMode: !!file.get('editMode'),
+    selectedHeaderId: file.get('selectedHeaderId'),
+    isDirty: file.get('isDirty'),
+    isNarrowedHeaderActive: !!file.get('narrowedHeaderId'),
+    selectedTableCellId: file.get('selectedTableCellId'),
     captureTemplates: state.capture.get('captureTemplates', List()),
-    path: state.org.present.get('path'),
+    path,
     isLoading: state.base.get('isLoading'),
   };
 };

--- a/src/components/OrgFile/components/AgendaModal/components/AgendaDay/index.js
+++ b/src/components/OrgFile/components/AgendaModal/components/AgendaDay/index.js
@@ -29,8 +29,8 @@ import {
 import classNames from 'classnames';
 
 export default class AgendaDay extends PureComponent {
-  handleHeaderClick(headerId) {
-    return () => this.props.onHeaderClick(headerId);
+  handleHeaderClick(path, headerId) {
+    return () => this.props.onHeaderClick(path, headerId);
   }
 
   render() {
@@ -109,7 +109,7 @@ export default class AgendaDay extends PureComponent {
                           isSelected={false}
                           shouldDisableActions
                           shouldDisableExplicitWidth
-                          onClick={this.handleHeaderClick(header.get('id'))}
+                          onClick={this.handleHeaderClick(path, header.get('id'))}
                         />
                       </div>
                     </div>

--- a/src/components/OrgFile/components/AgendaModal/components/AgendaDay/index.js
+++ b/src/components/OrgFile/components/AgendaModal/components/AgendaDay/index.js
@@ -36,7 +36,7 @@ export default class AgendaDay extends PureComponent {
   render() {
     const {
       date,
-      headers,
+      files,
       todoKeywordSets,
       dateDisplayType,
       onToggleDateDisplayType,
@@ -47,15 +47,17 @@ export default class AgendaDay extends PureComponent {
     const dateStart = startOfDay(date);
     const dateEnd = endOfDay(date);
 
-    const planningItemsAndHeaders = this.getPlanningItemsAndHeaders({
-      headers,
-      todoKeywordSets,
-      date,
-      agendaDefaultDeadlineDelayValue,
-      agendaDefaultDeadlineDelayUnit,
-      dateStart,
-      dateEnd,
-    });
+    const planningItemsAndHeaders = files.map((file) =>
+      this.getPlanningItemsAndHeaders({
+        headers: file.get('headers'),
+        todoKeywordSets: file.get('todoKeywordSets'),
+        date,
+        agendaDefaultDeadlineDelayValue,
+        agendaDefaultDeadlineDelayUnit,
+        dateStart,
+        dateEnd,
+      })
+    );
 
     return (
       <div className="agenda-day__container">
@@ -66,48 +68,56 @@ export default class AgendaDay extends PureComponent {
         </div>
 
         <div className="agenda-day__headers-container">
-          {planningItemsAndHeaders.map(([planningItem, header]) => {
-            const planningItemDate = dateForTimestamp(planningItem.get('timestamp'));
-            const hasTodoKeyword = !!header.getIn(['titleLine', 'todoKeyword']);
+          {Array.from(
+            planningItemsAndHeaders.entries(),
+            ([path, planningItemsAndHeadersOfFile]) => (
+              <div>
+                <span>{path}</span>
+                {planningItemsAndHeadersOfFile.map(([planningItem, header]) => {
+                  const planningItemDate = dateForTimestamp(planningItem.get('timestamp'));
+                  const hasTodoKeyword = !!header.getIn(['titleLine', 'todoKeyword']);
 
-            const dateClassName = classNames('agenda-day__header-planning-date', {
-              'agenda-day__header-planning-date--overdue':
-                hasTodoKeyword && isPast(planningItemDate),
-            });
+                  const dateClassName = classNames('agenda-day__header-planning-date', {
+                    'agenda-day__header-planning-date--overdue':
+                      hasTodoKeyword && isPast(planningItemDate),
+                  });
 
-            return (
-              <div key={planningItem.get('id')} className="agenda-day__header-container">
-                <div className="agenda-day__header__planning-item-container">
-                  <div className="agenda-day__header-planning-type">
-                    {getPlanningItemTypeText(planningItem)}
-                  </div>
-                  <div className={dateClassName} onClick={onToggleDateDisplayType}>
-                    {dateDisplayType === 'absolute'
-                      ? format(planningItemDate, 'MM/dd')
-                      : customFormatDistanceToNow(planningItemDate)}
+                  return (
+                    <div key={planningItem.get('id')} className="agenda-day__header-container">
+                      <div className="agenda-day__header__planning-item-container">
+                        <div className="agenda-day__header-planning-type">
+                          {getPlanningItemTypeText(planningItem)}
+                        </div>
+                        <div className={dateClassName} onClick={onToggleDateDisplayType}>
+                          {dateDisplayType === 'absolute'
+                            ? format(planningItemDate, 'MM/dd')
+                            : customFormatDistanceToNow(planningItemDate)}
 
-                    {planningItem.getIn(['timestamp', 'startHour']) && (
-                      <Fragment>
-                        <br />
-                        {format(planningItemDate, 'h:mma')}
-                      </Fragment>
-                    )}
-                  </div>
-                </div>
-                <div className="agenda-day__header__header-container">
-                  <TitleLine
-                    header={header}
-                    color="var(--base03)"
-                    hasContent={false}
-                    isSelected={false}
-                    shouldDisableActions
-                    shouldDisableExplicitWidth
-                    onClick={this.handleHeaderClick(header.get('id'))}
-                  />
-                </div>
+                          {planningItem.getIn(['timestamp', 'startHour']) && (
+                            <Fragment>
+                              <br />
+                              {format(planningItemDate, 'h:mma')}
+                            </Fragment>
+                          )}
+                        </div>
+                      </div>
+                      <div className="agenda-day__header__header-container">
+                        <TitleLine
+                          header={header}
+                          color="var(--base03)"
+                          hasContent={false}
+                          isSelected={false}
+                          shouldDisableActions
+                          shouldDisableExplicitWidth
+                          onClick={this.handleHeaderClick(header.get('id'))}
+                        />
+                      </div>
+                    </div>
+                  );
+                })}
               </div>
-            );
-          })}
+            )
+          )}
         </div>
       </div>
     );

--- a/src/components/OrgFile/components/AgendaModal/index.js
+++ b/src/components/OrgFile/components/AgendaModal/index.js
@@ -52,9 +52,9 @@ function AgendaModal(props) {
     }
   }
 
-  function handleHeaderClick(headerId) {
+  function handleHeaderClick(path, headerId) {
     props.onClose();
-    props.org.selectHeaderAndOpenParents(headerId);
+    props.org.selectHeaderAndOpenParents(path, headerId);
   }
 
   function handlePreviousDateClick() {

--- a/src/components/OrgFile/components/AgendaModal/index.js
+++ b/src/components/OrgFile/components/AgendaModal/index.js
@@ -97,7 +97,7 @@ function AgendaModal(props) {
 
   const {
     onClose,
-    headers,
+    files,
     todoKeywordSets,
     agendaDefaultDeadlineDelayValue,
     agendaDefaultDeadlineDelayUnit,
@@ -145,7 +145,7 @@ function AgendaModal(props) {
           <AgendaDay
             key={format(date, 'yyyy MM dd')}
             date={date}
-            headers={headers}
+            files={files}
             onHeaderClick={handleHeaderClick}
             todoKeywordSets={todoKeywordSets}
             dateDisplayType={dateDisplayType}
@@ -165,6 +165,7 @@ const mapStateToProps = (state) => {
   const path = state.org.present.get('path');
   const file = state.org.present.getIn(['files',path]);
   return {
+    files: state.org.present.get('files'),
     todoKeywordSets: file.get('todoKeywordSets'),
     agendaDefaultDeadlineDelayValue: state.base.get('agendaDefaultDeadlineDelayValue') || 5,
     agendaDefaultDeadlineDelayUnit: state.base.get('agendaDefaultDeadlineDelayUnit') || 'd',

--- a/src/components/OrgFile/components/AgendaModal/index.js
+++ b/src/components/OrgFile/components/AgendaModal/index.js
@@ -161,11 +161,15 @@ function AgendaModal(props) {
   );
 }
 
-const mapStateToProps = (state) => ({
-  todoKeywordSets: state.org.present.get('todoKeywordSets'),
-  agendaDefaultDeadlineDelayValue: state.base.get('agendaDefaultDeadlineDelayValue') || 5,
-  agendaDefaultDeadlineDelayUnit: state.base.get('agendaDefaultDeadlineDelayUnit') || 'd',
-});
+const mapStateToProps = (state) => {
+  const path = state.org.present.get('path');
+  const file = state.org.present.getIn(['files',path]);
+  return {
+    todoKeywordSets: file.get('todoKeywordSets'),
+    agendaDefaultDeadlineDelayValue: state.base.get('agendaDefaultDeadlineDelayValue') || 5,
+    agendaDefaultDeadlineDelayUnit: state.base.get('agendaDefaultDeadlineDelayUnit') || 'd',
+  };
+};
 
 const mapDispatchToProps = (dispatch) => ({
   org: bindActionCreators(orgActions, dispatch),

--- a/src/components/OrgFile/components/Header/index.js
+++ b/src/components/OrgFile/components/Header/index.js
@@ -334,7 +334,6 @@ ${header.get('rawDescription')}`;
       shouldDisableActions,
       showClockDisplay,
     } = this.props;
-
     const indentLevel = !!narrowedHeader
       ? header.get('nestingLevel') - narrowedHeader.get('nestingLevel') + 1
       : header.get('nestingLevel');
@@ -535,8 +534,10 @@ ${header.get('rawDescription')}`;
 }
 
 const mapStateToProps = (state, ownProps) => {
-  const narrowedHeader = !!state.org.present.get('narrowedHeaderId')
-    ? headerWithId(state.org.present.get('headers'), state.org.present.get('narrowedHeaderId'))
+  const path = state.org.present.get('path');
+  const file = state.org.present.getIn(['files', path]);
+  const narrowedHeader = !!file.get('narrowedHeaderId')
+    ? headerWithId(file.get('headers'), file.get('narrowedHeaderId'))
     : null;
 
   return {
@@ -545,7 +546,7 @@ const mapStateToProps = (state, ownProps) => {
     closeSubheadersRecursively: state.base.get('closeSubheadersRecursively'),
     narrowedHeader,
     isNarrowed: !!narrowedHeader && narrowedHeader.get('id') === ownProps.header.get('id'),
-    inEditMode: !!state.org.present.get('editMode'),
+    inEditMode: !!file.get('editMode'),
     showClockDisplay: state.org.present.get('showClockDisplay'),
   };
 };

--- a/src/components/OrgFile/components/HeaderContent/index.js
+++ b/src/components/OrgFile/components/HeaderContent/index.js
@@ -279,13 +279,15 @@ class HeaderContent extends PureComponent {
 }
 
 const mapStateToProps = (state, ownProps) => {
+  const path = state.org.present.get('path');
+  const file = state.org.present.getIn(['files', path]);
   return {
     inEditMode:
-      state.org.present.get('editMode') === 'description' &&
-      state.org.present.get('selectedHeaderId') === ownProps.header.get('id'),
-    isSelected: state.org.present.get('selectedHeaderId') === ownProps.header.get('id'),
-    selectedTableCellId: state.org.present.get('selectedTableCellId'),
-    inTableEditMode: state.org.present.get('editMode') === 'table',
+      file.get('editMode') === 'description' &&
+      file.get('selectedHeaderId') === ownProps.header.get('id'),
+    isSelected: file.get('selectedHeaderId') === ownProps.header.get('id'),
+    selectedTableCellId: file.get('selectedTableCellId'),
+    inTableEditMode: file.get('editMode') === 'table',
     dontIndent: state.base.get('shouldNotIndentOnExport'),
   };
 };

--- a/src/components/OrgFile/components/HeaderList/index.js
+++ b/src/components/OrgFile/components/HeaderList/index.js
@@ -39,7 +39,6 @@ class HeaderList extends PureComponent {
 
   render() {
     const { headers, selectedHeaderId, narrowedHeaderId, shouldDisableActions } = this.props;
-
     const headerRenderData = headers
       .map((header) => {
         return {
@@ -135,10 +134,12 @@ class HeaderList extends PureComponent {
 }
 
 const mapStateToProps = (state) => {
+  const path = state.org.present.get('path');
+  const file = state.org.present.getIn(['files', path]);
   return {
-    headers: state.org.present.get('headers'),
-    selectedHeaderId: state.org.present.get('selectedHeaderId'),
-    narrowedHeaderId: state.org.present.get('narrowedHeaderId'),
+    headers: file.get('headers'),
+    selectedHeaderId: file.get('selectedHeaderId'),
+    narrowedHeaderId: file.get('narrowedHeaderId'),
   };
 };
 

--- a/src/components/OrgFile/components/SearchModal/components/HeaderListView/index.js
+++ b/src/components/OrgFile/components/SearchModal/components/HeaderListView/index.js
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+import { Map } from 'immutable';
 
 import * as orgActions from '../../../../../../actions/org';
 import './stylesheet.css';

--- a/src/components/OrgFile/components/SearchModal/components/HeaderListView/index.js
+++ b/src/components/OrgFile/components/SearchModal/components/HeaderListView/index.js
@@ -12,8 +12,8 @@ import TitleLine from '../../../TitleLine';
 
 function HeaderListView(props) {
   const { context } = props;
-  function handleHeaderClick(headerId) {
-    return () => props.onHeaderClick(headerId);
+  function handleHeaderClick(path, headerId) {
+    return () => props.onHeaderClick(path, headerId);
   }
 
   // Populate filteredHeaders
@@ -43,7 +43,7 @@ function HeaderListView(props) {
                       isSelected={false}
                       shouldDisableActions
                       shouldDisableExplicitWidth
-                      onClick={handleHeaderClick(header.get('id'))}
+                      onClick={handleHeaderClick(path, header.get('id'))}
                       addition={
                         showClockedTimes && header.get('totalFilteredTimeLoggedRecursive') !== 0
                           ? millisDuration(header.get('totalFilteredTimeLoggedRecursive'))

--- a/src/components/OrgFile/components/SearchModal/components/HeaderListView/index.js
+++ b/src/components/OrgFile/components/SearchModal/components/HeaderListView/index.js
@@ -23,32 +23,38 @@ function HeaderListView(props) {
   }, [context, props.org]);
 
   const { headers, showClockedTimes } = props;
-
+  // TODO: don't just render the filename in a span.
+  // decide on order in which to display headers
   return (
     <div className="agenda-day__container">
       <div className="agenda-day__headers-container">
-        {headers.map((header) => {
-          return (
-            <div key={header.get('id')} className="agenda-day__header-container">
-              <div className="agenda-day__header__header-container">
-                <TitleLine
-                  header={header}
-                  color="var(--base03)"
-                  hasContent={false}
-                  isSelected={false}
-                  shouldDisableActions
-                  shouldDisableExplicitWidth
-                  onClick={handleHeaderClick(header.get('id'))}
-                  addition={
-                    showClockedTimes && header.get('totalFilteredTimeLoggedRecursive') !== 0
-                      ? millisDuration(header.get('totalFilteredTimeLoggedRecursive'))
-                      : null
-                  }
-                />
-              </div>
-            </div>
-          );
-        })}
+        {Array.from(headers.entries(), ([path, headersOfFile]) => (
+          <div>
+            <span>{path}</span>
+            {headersOfFile.map((header) => {
+              return (
+                <div key={header.get('id')} className="agenda-day__header-container">
+                  <div className="agenda-day__header__header-container">
+                    <TitleLine
+                      header={header}
+                      color="var(--base03)"
+                      hasContent={false}
+                      isSelected={false}
+                      shouldDisableActions
+                      shouldDisableExplicitWidth
+                      onClick={handleHeaderClick(header.get('id'))}
+                      addition={
+                        showClockedTimes && header.get('totalFilteredTimeLoggedRecursive') !== 0
+                          ? millisDuration(header.get('totalFilteredTimeLoggedRecursive'))
+                          : null
+                      }
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        ))}
       </div>
     </div>
   );
@@ -56,12 +62,14 @@ function HeaderListView(props) {
 
 const mapStateToProps = (state) => {
   const path = state.org.present.get('path');
-  const file = state.org.present.getIn(['files',path]);
+  const file = state.org.present.getIn(['files', path]);
   return {
     // When no filtering has happened, yet (initial state), use all headers.
+    // TODO: currently only headers of opened file are initially shown.
+    // Decide if it should be all files.
     headers:
       state.org.present.getIn(['search', 'filteredHeaders']) ||
-      file.get('headers'),
+      new Map().set(path, file.get('headers')),
     showClockedTimes: state.org.present.getIn(['search', 'showClockedTimes']),
   };
 };

--- a/src/components/OrgFile/components/SearchModal/components/HeaderListView/index.js
+++ b/src/components/OrgFile/components/SearchModal/components/HeaderListView/index.js
@@ -54,12 +54,17 @@ function HeaderListView(props) {
   );
 }
 
-const mapStateToProps = (state) => ({
-  // When no filtering has happened, yet (initial state), use all headers.
-  headers:
-    state.org.present.getIn(['search', 'filteredHeaders']) || state.org.present.get('headers'),
-  showClockedTimes: state.org.present.getIn(['search', 'showClockedTimes']),
-});
+const mapStateToProps = (state) => {
+  const path = state.org.present.get('path');
+  const file = state.org.present.getIn(['files',path]);
+  return {
+    // When no filtering has happened, yet (initial state), use all headers.
+    headers:
+      state.org.present.getIn(['search', 'filteredHeaders']) ||
+      file.get('headers'),
+    showClockedTimes: state.org.present.getIn(['search', 'showClockedTimes']),
+  };
+};
 
 const mapDispatchToProps = (dispatch) => ({
   org: bindActionCreators(orgActions, dispatch),

--- a/src/components/OrgFile/components/SearchModal/index.js
+++ b/src/components/OrgFile/components/SearchModal/index.js
@@ -27,10 +27,11 @@ function SearchModal(props) {
     context,
     showClockedTimes,
     clockedTime,
+    path,
   } = props;
 
-  function handleHeaderClick(headerId) {
-    props.onClose(headerId);
+  function handleHeaderClick(path, headerId) {
+    props.onClose(path, headerId);
   }
 
   function handleToggleDateDisplayType() {
@@ -109,6 +110,7 @@ function SearchModal(props) {
 }
 
 const mapStateToProps = (state) => ({
+  path: state.org.present.get('path'),
   searchFilter: state.org.present.getIn(['search', 'searchFilter']) || '',
   searchFilterValid: state.org.present.getIn(['search', 'searchFilterValid']),
   searchFilterSuggestions: state.org.present.getIn(['search', 'searchFilterSuggestions']) || [],

--- a/src/components/OrgFile/components/TaskListModal/components/TaskListView/index.js
+++ b/src/components/OrgFile/components/TaskListModal/components/TaskListView/index.js
@@ -17,15 +17,14 @@ import { format, isPast } from 'date-fns';
 import classNames from 'classnames';
 
 function TaskListView(props) {
-  function handleHeaderClick(headerId) {
-    return () => props.onHeaderClick(headerId);
+  function handleHeaderClick(path, headerId) {
+    return () => props.onHeaderClick(path, headerId);
   }
 
   const { dateDisplayType, onToggleDateDisplayType, headers, todoKeywordSets } = props;
 
   // TODO this uses the todokeywordset of the current file for all files
   // use each files own todokeywordset instead
-  console.debug(headers);
   const planningItemsAndHeaders = headers.map((headersForFile) =>
     getPlanningItemsAndHeaders({
       headers: headersForFile,
@@ -83,7 +82,7 @@ function TaskListView(props) {
                       isSelected={false}
                       shouldDisableActions
                       shouldDisableExplicitWidth
-                      onClick={handleHeaderClick(header.get('id'))}
+                      onClick={handleHeaderClick(path, header.get('id'))}
                     />
                     {planningInformation}
                   </div>

--- a/src/components/OrgFile/components/TaskListModal/components/TaskListView/index.js
+++ b/src/components/OrgFile/components/TaskListModal/components/TaskListView/index.js
@@ -114,12 +114,15 @@ function TaskListView(props) {
   }
 }
 
-const mapStateToProps = (state) => ({
-  todoKeywordSets: state.org.present.get('todoKeywordSets'),
-  // When no filtering has happened, yet (initial state), use all headers.
-  headers:
-    state.org.present.getIn(['search', 'filteredHeaders']) || state.org.present.get('headers'),
-});
+const mapStateToProps = (state) => {
+  const path = state.org.present.get('path');
+  const file = state.org.present.getIn(['files', path]);
+  return {
+    todoKeywordSets: file.get('todoKeywordSets'),
+    // When no filtering has happened, yet (initial state), use all headers.
+    headers: state.org.present.getIn(['search', 'filteredHeaders']) || file.get('headers'),
+  };
+};
 
 const getTimeFromPlanningItem = (planningItem) =>
   dateForTimestamp(planningItem.get('timestamp')).getTime();

--- a/src/components/OrgFile/components/TaskListModal/index.js
+++ b/src/components/OrgFile/components/TaskListModal/index.js
@@ -18,9 +18,9 @@ import * as orgActions from '../../../../actions/org';
 function TaskListModal(props) {
   const [dateDisplayType, setdateDisplayType] = useState('absolute');
 
-  function handleHeaderClick(headerId) {
+  function handleHeaderClick(path, headerId) {
     props.onClose();
-    props.org.selectHeaderAndOpenParents(headerId);
+    props.org.selectHeaderAndOpenParents(path, headerId);
   }
 
   function handleToggleDateDisplayType() {

--- a/src/components/OrgFile/components/TimestampEditorModal/components/TimestampEditor/index.js
+++ b/src/components/OrgFile/components/TimestampEditorModal/components/TimestampEditor/index.js
@@ -337,7 +337,9 @@ class TimestampEditor extends PureComponent {
 }
 
 const mapStateToProps = (state) => {
-  const selectedHeaderId = state.org.present.get('selectedHeaderId');
+  const path = state.org.present.get('path');
+  const file = state.org.present.getIn(['files', path]);
+  const selectedHeaderId = file.get('selectedHeaderId');
   return {
     selectedHeaderId,
   };

--- a/src/components/OrgFile/components/TitleLine/index.js
+++ b/src/components/OrgFile/components/TitleLine/index.js
@@ -288,15 +288,17 @@ class TitleLine extends PureComponent {
 }
 
 const mapStateToProps = (state, ownProps) => {
+  const path = state.org.present.get('path');
+  const file = state.org.present.getIn(['files',path]);
   return {
     inEditMode:
-      state.org.present.get('editMode') === 'title' &&
-      state.org.present.get('selectedHeaderId') === ownProps.header.get('id'),
+      file.get('editMode') === 'title' &&
+      file.get('selectedHeaderId') === ownProps.header.get('id'),
     setShouldLogIntoDrawer: state.base.get('shouldLogIntoDrawer'),
     shouldTapTodoToAdvance: state.base.get('shouldTapTodoToAdvance'),
     closeSubheadersRecursively: state.base.get('closeSubheadersRecursively'),
-    isSelected: state.org.present.get('selectedHeaderId') === ownProps.header.get('id'),
-    todoKeywordSets: state.org.present.get('todoKeywordSets'),
+    isSelected: file.get('selectedHeaderId') === ownProps.header.get('id'),
+    todoKeywordSets: file.get('todoKeywordSets'),
   };
 };
 

--- a/src/components/OrgFile/index.js
+++ b/src/components/OrgFile/index.js
@@ -354,9 +354,9 @@ class OrgFile extends PureComponent {
           />
         ) : null;
       case 'agenda':
-        return <AgendaModal onClose={this.handlePopupClose} headers={headers} />;
+        return <AgendaModal onClose={this.handlePopupClose} />;
       case 'task-list':
-        return <TaskListModal onClose={this.handlePopupClose} headers={headers} />;
+        return <TaskListModal onClose={this.handlePopupClose} />;
       case 'search':
         return <SearchModal onClose={this.handleSearchPopupClose} context="search" />;
       case 'refile':

--- a/src/components/OrgFile/index.js
+++ b/src/components/OrgFile/index.js
@@ -214,7 +214,9 @@ class OrgFile extends PureComponent {
 
   handleSearchPopupClose(path, headerId) {
     this.props.base.closePopup();
-    this.props.org.selectHeaderAndOpenParents(path, headerId);
+    if (path && headerId) {
+      this.props.org.selectHeaderAndOpenParents(path, headerId);
+    }
   }
 
   handleRefilePopupClose(targetPath, targetHeaderId) {

--- a/src/components/OrgFile/index.js
+++ b/src/components/OrgFile/index.js
@@ -492,19 +492,21 @@ class OrgFile extends PureComponent {
 }
 
 const mapStateToProps = (state) => {
-  const headers = state.org.present.get('headers');
-  const selectedHeaderId = state.org.present.get('selectedHeaderId');
+  const loadedPath = state.org.present.get('path');
+  const file = state.org.present.getIn(['files', loadedPath]);
+  const headers = file ? file.get('headers') : null;
+  const selectedHeaderId = file ? file.get('selectedHeaderId') : null;
   const activePopup = state.base.get('activePopup');
 
   return {
     headers,
     selectedHeaderId,
-    isDirty: state.org.present.get('isDirty'),
-    loadedPath: state.org.present.get('path'),
+    isDirty: file ? file.get('isDirty') : null,
+    loadedPath,
     selectedHeader: headers && headers.find((header) => header.get('id') === selectedHeaderId),
     customKeybindings: state.base.get('customKeybindings'),
     shouldLogIntoDrawer: state.base.get('shouldLogIntoDrawer'),
-    inEditMode: !!state.org.present.get('editMode'),
+    inEditMode: !!file ? file.get('editMode') : null,
     activePopupType: !!activePopup ? activePopup.get('type') : null,
     activePopupData: !!activePopup ? activePopup.get('data') : null,
     captureTemplates: state.capture.get('captureTemplates').concat(sampleCaptureTemplates),

--- a/src/components/OrgFile/index.js
+++ b/src/components/OrgFile/index.js
@@ -212,18 +212,18 @@ class OrgFile extends PureComponent {
     this.props.base.closePopup();
   }
 
-  handleSearchPopupClose(headerId) {
+  handleSearchPopupClose(path, headerId) {
     this.props.base.closePopup();
-    this.props.org.selectHeaderAndOpenParents(headerId);
+    this.props.org.selectHeaderAndOpenParents(path, headerId);
   }
 
-  handleRefilePopupClose(targetHeaderId) {
+  handleRefilePopupClose(targetPath, targetHeaderId) {
     this.props.base.closePopup();
     // When the user closes the drawer without selecting a header, do
     // not trigger refiling.
     if (targetHeaderId) {
-      const { selectedHeaderId } = this.props;
-      this.props.org.refileSubtree(selectedHeaderId, targetHeaderId);
+      const { loadedPath, selectedHeaderId } = this.props;
+      this.props.org.refileSubtree(loadedPath, selectedHeaderId, targetPath, targetHeaderId);
     }
   }
 

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -1284,9 +1284,9 @@ const reducer = (state, action) => {
     case 'UPDATE_TABLE_CELL_VALUE':
       return inFile(updateTableCellValue);
     case 'INSERT_CAPTURE':
-      return insertCapture(state, action);
+      return inFile(insertCapture);
     case 'CLEAR_PENDING_CAPTURE':
-      return clearPendingCapture(state, action);
+      return inFile(clearPendingCapture);
     case 'ADVANCE_CHECKBOX_STATE':
       return inFile(advanceCheckboxState);
     case 'SET_LAST_SYNC_AT':

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -1042,6 +1042,8 @@ export const setSearchFilterInformation = (state, action) => {
   const { searchFilter, cursorPosition, context } = action;
 
   const path = state.get('path');
+  // TODO: search currently uses all loaded files.
+  // Decide which files should be used based on context or configuration.
   const files = state.get('files');
   state = state.asMutable();
 

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -565,7 +565,8 @@ const narrowHeader = (state, action) => {
 
 const widenHeader = (state) => state.set('narrowedHeaderId', null);
 
-const applyOpennessState = (state, action, path) => {
+const applyOpennessState = (state, action) => {
+  const path = state.get('path');
   const opennessState = state.get('opennessState');
   if (!opennessState) {
     return state;
@@ -576,12 +577,12 @@ const applyOpennessState = (state, action, path) => {
     return state;
   }
 
-  let headers = state.get('headers');
+  let headers = state.getIn(['files', path, 'headers']);
   fileOpennessState.forEach((openHeaderPath) => {
     headers = openHeaderWithPath(headers, openHeaderPath);
   });
 
-  return state.set('headers', headers);
+  return state.setIn(['files', path, 'headers'], headers);
 };
 
 const setDirty = (state, action) => state.set('isDirty', action.isDirty);
@@ -1212,7 +1213,7 @@ const reducer = (state, action) => {
     case 'HEADER_ADD_NOTE':
       return inFile(addNote);
     case 'APPLY_OPENNESS_STATE':
-      return inFile(applyOpennessState, path);
+      return applyOpennessState(state, action);
     case 'SET_DIRTY':
       return inFile(setDirty);
     case 'NARROW_HEADER':
@@ -1283,7 +1284,8 @@ const reducer = (state, action) => {
 
 export default (state = Map(), action) => {
   if (action.dirtying) {
-    state = state.set('isDirty', true);
+    const path = state.get('path');
+    state = state.setIn(['files', path, 'isDirty'], true);
   }
 
   state = reducer(state, action);

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -1198,8 +1198,7 @@ const setShowClockDisplay = (state, action) => {
 };
 
 const reduceInFile = (state, action, path) => (func, ...args) => {
-  let file = state.getIn(['files', path]);
-  return state.setIn(['files', path], func(file ? file : new Map(), action, ...args));
+  return state.updateIn(['files', path], (file) => func(file ? file : Map(), action, ...args));
 };
 
 const reducer = (state, action) => {

--- a/src/util/settings_persister.js
+++ b/src/util/settings_persister.js
@@ -208,6 +208,7 @@ export const readInitialState = () => {
     org: {
       past: [],
       present: Map({
+        files: Map(),
         search: Map({
           searchFilter: '',
           searchFilterExpr: [],
@@ -323,8 +324,9 @@ export const subscribeToChanges = (store) => {
       }
 
       const currentFilePath = state.org.present.get('path');
-      if (!!currentFilePath && state.org.present.get('headers')) {
-        const openHeaderPaths = getOpenHeaderPaths(state.org.present.get('headers'));
+      const headers = state.org.present.getIn(['files', currentFilePath, 'headers']);
+      if (!!currentFilePath && headers) {
+        const openHeaderPaths = getOpenHeaderPaths(headers);
 
         let opennessState = {};
         const opennessStateJSONString = localStorage.getItem('headerOpenness');


### PR DESCRIPTION
What it doesn't do:
- It does not load any files for you. You need to open multiple files in succession to bring them into the application.
- It only synchronizes the currently viewed file
- Capture only works in the currently opened file.
- GUI integration in search/tasklist/agenda is not done. I just throw the data in there to prove that it arrives in the right place. (Data is delivered in a map of pathname to list of filtered headers)
- Switching between files currently works by changing 'path' in the org-reducer. This does not change the browser url.
- A lot of things i will recall soon.

What it does:
- Search/view agenda/view tasklist over multiple files. Jump to headers regardless which file they are in.
- Refile between files (you need to jump through search to the other file and trigger a sync. Opening the target file through the file browser currently causes syncronization issues since it parses the org file again - without the headers refiled there in the meantime).
- org reducer actions are mostly unchanged but scoped to one file. Only chosen actions operate over multiple files.