### PR TITLE
Feat/sane defaults for safety

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -5,6 +5,14 @@ All user visible changes to organice will be documented in this file.
 When there are updates to the changelog, you will be notified and see a 'gift' icon appear on the top right corner.
 
 * [2020-11-01 Sun]
+
+** Changed
+   - We have enabled some default settings by default, because they are reasonable for a new user:
+      - =shouldStoreSettingsInSyncBackend=, because it enables using organice on multiple clients
+      - =shouldLiveSync=, because it reduces the chance to have a conflict in the open Org file
+      - =shouldSyncOnBecomingVisibile=, because it reduces the chance to have a conflict in the open Org file
+      - If you personally do not want them enabled, you can disable them separately in the [[/settings][settings]] any time.
+
 ** Fixed
    - organice has various settings that the user can configure. Before manual configuration, there organice loads sane defaults. Loading and persisting some of these defaults was buggy before.
      - Loading and persisting of defaults works now.

--- a/changelog.org
+++ b/changelog.org
@@ -8,10 +8,11 @@ When there are updates to the changelog, you will be notified and see a 'gift' i
 
 ** Changed
    - We have enabled some default settings by default, because they are reasonable for a new user:
-      - =shouldStoreSettingsInSyncBackend=, because it enables using organice on multiple clients
-      - =shouldLiveSync=, because it reduces the chance to have a conflict in the open Org file
-      - =shouldSyncOnBecomingVisibile=, because it reduces the chance to have a conflict in the open Org file
-      - If you personally do not want them enabled, you can disable them separately in the [[/settings][settings]] any time.
+     - =shouldStoreSettingsInSyncBackend=, because it enables using organice on multiple clients.
+     - =shouldLiveSync=, because it reduces the chance to have a conflict in the open Org file.
+     - =shouldSyncOnBecomingVisibile=, because it reduces the chance to have a conflict in the open Org file.
+   - =bulletStyle= is set to "Fancy", because it looks more visually pleasing than an asterisk (*) and hence makes organice look better on a first test run.
+   - If you personally do not want them enabled, you can disable them separately in the [[/settings][settings]] any time.
 
 ** Fixed
    - organice has various settings that the user can configure. Before manual configuration, there organice loads sane defaults. Loading and persisting some of these defaults was buggy before.

--- a/src/components/Settings/index.js
+++ b/src/components/Settings/index.js
@@ -289,9 +289,12 @@ const Settings = ({
 };
 
 const mapStateToProps = (state) => {
+  // The default values here only relate to the settings view. To set
+  // defaults which get loaded on an initial run of organice, look at
+  // `util/settings_persister.js::persistableFields`.
   return {
     fontSize: state.base.get('fontSize') || 'Regular',
-    bulletStyle: state.base.get('bulletStyle') || 'Classic',
+    bulletStyle: state.base.get('bulletStyle'),
     shouldTapTodoToAdvance: state.base.get('shouldTapTodoToAdvance'),
     agendaDefaultDeadlineDelayValue: state.base.get('agendaDefaultDeadlineDelayValue') || 5,
     agendaDefaultDeadlineDelayUnit: state.base.get('agendaDefaultDeadlineDelayUnit') || 'd',

--- a/src/util/settings_persister.js
+++ b/src/util/settings_persister.js
@@ -81,6 +81,7 @@ export const persistableFields = [
     category: 'base',
     name: 'shouldStoreSettingsInSyncBackend',
     type: 'boolean',
+    default: true,
     shouldStoreInConfig: true,
   },
   {
@@ -99,12 +100,14 @@ export const persistableFields = [
     category: 'base',
     name: 'shouldLiveSync',
     type: 'boolean',
+    default: true,
     shouldStoreInConfig: true,
   },
   {
     category: 'base',
     name: 'shouldSyncOnBecomingVisibile',
     type: 'boolean',
+    default: true,
     shouldStoreInConfig: true,
   },
   {

--- a/src/util/settings_persister.js
+++ b/src/util/settings_persister.js
@@ -55,6 +55,7 @@ export const persistableFields = [
     category: 'base',
     name: 'bulletStyle',
     type: 'nullable',
+    default: 'Fancy',
     shouldStoreInConfig: true,
   },
   {
@@ -243,6 +244,9 @@ export const readInitialState = () => {
         value = fromJS(JSON.parse(value));
       }
     }
+
+    // When nothing has been saved to localStorage before, load the default.
+    value = value || field.default;
 
     if (field.category === 'org') {
       initialState[field.category].present = initialState[field.category].present.set(


### PR DESCRIPTION
Closes #235.

-   We have enabled some default settings by default, because they are
    reasonable for a new user:
    -   `shouldStoreSettingsInSyncBackend`, because it enables using
        organice on multiple clients.
    -   `shouldLiveSync`, because it reduces the chance to have a
        conflict in the open Org file.
    -   `shouldSyncOnBecomingVisibile`, because it reduces the chance to
        have a conflict in the open Org file.
-   `bulletStyle` is set to \"Fancy\", because it looks more visually
    pleasing than an asterisk (\*) and hence makes organice look better
    on a first test run.
-   If someone does not want them enabled, you can disable them
    separately in the [settings](file:///settings) any time.
