### PR TITLE
disable user select

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -4,7 +4,15 @@ All user visible changes to organice will be documented in this file.
 
 When there are updates to the changelog, you will be notified and see a 'gift' icon appear on the top right corner.
 
+* [2020-11-08 Sun]
+
+** Changed
+
 * [2020-11-06 Fri]
+  - Safeguard against selecting text by accident.
+    - Before this change, it was possible to select text when doing a 'swipe'.
+    - Now, selecting/copying text is only possible in 'edit mode', effectively safeguarding against accidentally selecting text.
+    - Thank you [[https://github.com/tarnung][tarnung]] for your [[https://github.com/200ok-ch/organice/pull/557][PR]] 🙏
 
 ** Added
    - Additional themes. You now can choose between:

--- a/src/base.css
+++ b/src/base.css
@@ -31,6 +31,7 @@ body,
   background: var(--base3);
   height: 100%;
   overflow-y: hidden;
+  user-select: none;
 }
 
 a {


### PR DESCRIPTION
This one surely needs some discussion.
One of the main points that contributes to a bit of a clunky feel for me when using organice is accidentally selecting text - especially but not only on desktop browsers.

It might come in handy from time to time to copy things straight out of the browser without having to enter edit mode and copy things piecemeal, but - at least for me - the negative effect on regular use outweigh this rare benefit.

If there is a bunch of users that like the ability to copy text out of the main header list, we could add this behind a setting by switching a css variable. If I'm the only one that is bothered by accidentally selecting text, then I will humbly close this pr unmerged ;)