### PR TITLE
default autocrlf & always lf for .org files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Declare files that will always have LF line endings on checkout.
+*.org text eol=lf


### PR DESCRIPTION
#513

the tests expect .org files to have lf line endings so always check out .org files with lf.