### PR TITLE
file settings & sync

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,7 +15,7 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import { DragDropContext } from 'react-beautiful-dnd';
 
 import { reorderCaptureTemplate } from './actions/capture';
-import { reorderTags, reorderPropertyList } from './actions/org';
+import { reorderTags, reorderPropertyList, reorderFileSetting } from './actions/org';
 import { signOut } from './actions/sync_backend';
 import { setDisappearingLoadingMessage } from './actions/base';
 
@@ -145,12 +145,14 @@ export default class App extends PureComponent {
       return;
     }
 
-    if (result.type === 'CAPTURE-TEMPLATE') {
-      this.store.dispatch(reorderCaptureTemplate(result.source.index, result.destination.index));
-    } else if (result.type === 'TAG') {
+    if (result.type === 'TAG') {
       this.store.dispatch(reorderTags(result.source.index, result.destination.index));
     } else if (result.type === 'PROPERTY-LIST') {
       this.store.dispatch(reorderPropertyList(result.source.index, result.destination.index));
+    } else if (result.type === 'CAPTURE-TEMPLATE') {
+      this.store.dispatch(reorderCaptureTemplate(result.source.index, result.destination.index));
+    } else if (result.type === 'FILE-SETTING') {
+      this.store.dispatch(reorderFileSetting(result.source.index, result.destination.index));
     }
   }
 

--- a/src/actions/base.js
+++ b/src/actions/base.js
@@ -1,4 +1,4 @@
-import { displayFile, stopDisplayingFile } from './org';
+import { parseFile, stopDisplayingFile } from './org';
 
 import raw from 'raw.macro';
 
@@ -39,7 +39,7 @@ export const loadStaticFile = (staticFile) => {
       sample: raw('../../sample.org'),
     }[staticFile];
 
-    dispatch(displayFile(null, fileContents));
+    dispatch(parseFile(null, fileContents));
   };
 };
 
@@ -49,10 +49,7 @@ export const unloadStaticFile = () => {
 
     if (!!getState().base.get('lastViewedPath')) {
       dispatch(
-        displayFile(
-          getState().base.get('lastViewedPath'),
-          getState().base.get('lastViewedContents')
-        )
+        parseFile(getState().base.get('lastViewedPath'), getState().base.get('lastViewedContents'))
       );
     }
   };

--- a/src/actions/base.js
+++ b/src/actions/base.js
@@ -11,9 +11,10 @@ export const hideLoadingMessage = () => ({
   type: 'HIDE_LOADING_MESSAGE',
 });
 
-export const setIsLoading = (isLoading) => ({
+export const setIsLoading = (isLoading, path) => ({
   type: 'SET_IS_LOADING',
   isLoading,
+  path,
 });
 
 export const setDisappearingLoadingMessage = (loadingMessage, delay) => (dispatch) => {

--- a/src/actions/base.js
+++ b/src/actions/base.js
@@ -1,4 +1,4 @@
-import { parseFile, stopDisplayingFile } from './org';
+import { parseFile, resetFileDisplay } from './org';
 
 import raw from 'raw.macro';
 
@@ -45,7 +45,7 @@ export const loadStaticFile = (staticFile) => {
 
 export const unloadStaticFile = () => {
   return (dispatch, getState) => {
-    dispatch(stopDisplayingFile());
+    dispatch(resetFileDisplay());
 
     if (!!getState().base.get('lastViewedPath')) {
       dispatch(

--- a/src/actions/org.js
+++ b/src/actions/org.js
@@ -18,7 +18,7 @@ import { isAfter, addSeconds } from 'date-fns';
 import { parseISO } from 'date-fns';
 
 export const parseFile = (path, contents) => ({
-  type: 'DISPLAY_FILE',
+  type: 'PARSE_FILE',
   path,
   contents,
 });
@@ -229,14 +229,14 @@ export const selectHeader = (headerId) => (dispatch) => {
 
 // TODO: this should dispatch(ActionCreators.clearHistory()) and maybe trigger a sync like parseFile
 // Maybe selectHeader or whatever is used in search etc modals to jump to a header should be path aware so this extra step is not necessary
-export const changePath = (path) => ({
-  type: 'CHANGE_PATH',
+export const setPath = (path) => ({
+  type: 'SET_PATH',
   path,
 });
 
 export const selectHeaderAndOpenParents = (path, headerId) => (dispatch) => {
   // TODO: change path does not change the browser path
-  dispatch(changePath(path));
+  dispatch(setPath(path));
   dispatch(selectHeader(headerId));
   dispatch({ type: 'OPEN_PARENTS_OF_HEADER', headerId });
 };

--- a/src/actions/org.js
+++ b/src/actions/org.js
@@ -615,6 +615,6 @@ export const addNewEmptyFileSetting = () => (dispatch) =>
   dispatch({ type: 'ADD_NEW_EMPTY_FILE_SETTING' });
 
 export const restoreFileSettings = (newSettings) => ({
-  type: 'RESTORE_File_SETTINGS',
+  type: 'RESTORE_FILE_SETTINGS',
   newSettings,
 });

--- a/src/actions/org.js
+++ b/src/actions/org.js
@@ -227,15 +227,12 @@ export const selectHeader = (headerId) => (dispatch) => {
   }
 };
 
-// TODO: this should dispatch(ActionCreators.clearHistory()) and maybe trigger a sync like parseFile
-// Maybe selectHeader or whatever is used in search etc modals to jump to a header should be path aware so this extra step is not necessary
 export const setPath = (path) => ({
   type: 'SET_PATH',
   path,
 });
 
 export const selectHeaderAndOpenParents = (path, headerId) => (dispatch) => {
-  // TODO: change path does not change the browser path
   dispatch(setPath(path));
   dispatch(selectHeader(headerId));
   dispatch({ type: 'OPEN_PARENTS_OF_HEADER', headerId });

--- a/src/actions/org.js
+++ b/src/actions/org.js
@@ -29,11 +29,11 @@ export const setLastSyncAt = (lastSyncAt, path) => ({
   lastSyncAt,
 });
 
-export const stopDisplayingFile = () => {
+export const resetFileDisplay = () => {
   return (dispatch) => {
     dispatch(widenHeader());
     dispatch(closePopup());
-    dispatch({ type: 'STOP_DISPLAYING_FILE' });
+    dispatch({ type: 'CLEAR_SEARCH' });
     dispatch(ActionCreators.clearHistory());
   };
 };

--- a/src/actions/org.js
+++ b/src/actions/org.js
@@ -592,3 +592,29 @@ export const setShowClockDisplay = (showClockDisplay) => ({
   type: 'TOGGLE_CLOCK_DISPLAY',
   showClockDisplay,
 });
+
+export const updateFileSettingFieldPathValue = (settingId, fieldPath, newValue) => ({
+  type: 'UPDATE_FILE_SETTING_FIELD_PATH_VALUE',
+  settingId,
+  fieldPath,
+  newValue,
+});
+
+export const reorderFileSetting = (fromIndex, toIndex) => ({
+  type: 'REORDER_FILE_SETTING',
+  fromIndex,
+  toIndex,
+});
+
+export const deleteFileSetting = (settingId) => ({
+  type: 'DELETE_FILE_SETTING',
+  settingId,
+});
+
+export const addNewEmptyFileSetting = () => (dispatch) =>
+  dispatch({ type: 'ADD_NEW_EMPTY_FILE_SETTING' });
+
+export const restoreFileSettings = (newSettings) => ({
+  type: 'RESTORE_File_SETTINGS',
+  newSettings,
+});

--- a/src/actions/org.js
+++ b/src/actions/org.js
@@ -17,7 +17,7 @@ import sampleCaptureTemplates from '../lib/sample_capture_templates';
 import { isAfter, addSeconds } from 'date-fns';
 import { parseISO } from 'date-fns';
 
-export const displayFile = (path, contents) => ({
+export const parseFile = (path, contents) => ({
   type: 'DISPLAY_FILE',
   path,
   contents,
@@ -102,7 +102,8 @@ const doSync = ({
   path,
 } = {}) => (dispatch, getState) => {
   const client = getState().syncBackend.get('client');
-  path = path || getState().org.present.get('path');
+  const currentPath = getState().org.present.get('path');
+  path = path || currentPath;
   if (!path) {
     return;
   }
@@ -187,8 +188,10 @@ const doSync = ({
           dispatch(setIsLoading(false, path));
           dispatch(activatePopup('sync-confirmation', { lastServerModifiedAt, lastSyncAt, path }));
         } else {
-          dispatch(displayFile(path, contents));
-          dispatch(applyOpennessState());
+          if (path === currentPath) {
+            dispatch(parseFile(path, contents));
+            dispatch(applyOpennessState());
+          }
           dispatch(setDirty(false, path));
           dispatch(setLastSyncAt(addSeconds(new Date(), 5), path));
           if (!shouldSuppressMessages) {
@@ -224,9 +227,9 @@ export const selectHeader = (headerId) => (dispatch) => {
   }
 };
 
-// TODO: this should dispatch(ActionCreators.clearHistory()) and maybe trigger a sync like displayFile
+// TODO: this should dispatch(ActionCreators.clearHistory()) and maybe trigger a sync like parseFile
 // Maybe selectHeader or whatever is used in search etc modals to jump to a header should be path aware so this extra step is not necessary
-const changePath = (path) => ({
+export const changePath = (path) => ({
   type: 'CHANGE_PATH',
   path,
 });

--- a/src/actions/sync_backend.js
+++ b/src/actions/sync_backend.js
@@ -114,14 +114,14 @@ export const downloadFile = (path) => {
         dispatch(hideLoadingMessage());
         dispatch(pushBackup(path, fileContents));
         dispatch(displayFile(path, fileContents));
-        dispatch(setLastSyncAt(addSeconds(new Date(), 5)));
-        dispatch(setDirty(false));
+        dispatch(setLastSyncAt(addSeconds(new Date(), 5), path));
+        dispatch(setDirty(false, path));
         dispatch(applyOpennessState());
         dispatch(ActionCreators.clearHistory());
       })
       .catch(() => {
         dispatch(hideLoadingMessage());
-        dispatch(setIsLoading(false));
+        dispatch(setIsLoading(false, path));
         dispatch(setOrgFileErrorMessage('File not found'));
       });
   };

--- a/src/actions/sync_backend.js
+++ b/src/actions/sync_backend.js
@@ -8,7 +8,7 @@ import {
   setDirty,
   setLastSyncAt,
   setOrgFileErrorMessage,
-  changePath,
+  setPath,
 } from './org';
 import { persistField } from '../util/settings_persister';
 
@@ -115,7 +115,6 @@ export const downloadFile = (path) => {
         dispatch(hideLoadingMessage());
         dispatch(pushBackup(path, fileContents));
         dispatch(parseFile(path, fileContents));
-        dispatch(changePath(path));
         dispatch(setLastSyncAt(addSeconds(new Date(), 5), path));
         dispatch(setDirty(false, path));
         dispatch(applyOpennessState());
@@ -124,7 +123,7 @@ export const downloadFile = (path) => {
       .catch(() => {
         dispatch(hideLoadingMessage());
         dispatch(setIsLoading(false, path));
-        dispatch(setOrgFileErrorMessage('File not found'));
+        dispatch(setOrgFileErrorMessage(`File ${path} not found`));
       });
   };
 };

--- a/src/actions/sync_backend.js
+++ b/src/actions/sync_backend.js
@@ -3,11 +3,12 @@ import { ActionCreators } from 'redux-undo';
 
 import { setLoadingMessage, hideLoadingMessage, clearModalStack, setIsLoading } from './base';
 import {
-  displayFile,
+  parseFile,
   applyOpennessState,
   setDirty,
   setLastSyncAt,
   setOrgFileErrorMessage,
+  changePath,
 } from './org';
 import { persistField } from '../util/settings_persister';
 
@@ -113,7 +114,8 @@ export const downloadFile = (path) => {
       .then((fileContents) => {
         dispatch(hideLoadingMessage());
         dispatch(pushBackup(path, fileContents));
-        dispatch(displayFile(path, fileContents));
+        dispatch(parseFile(path, fileContents));
+        dispatch(changePath(path));
         dispatch(setLastSyncAt(addSeconds(new Date(), 5), path));
         dispatch(setDirty(false, path));
         dispatch(applyOpennessState());

--- a/src/actions/sync_backend.js
+++ b/src/actions/sync_backend.js
@@ -8,7 +8,6 @@ import {
   setDirty,
   setLastSyncAt,
   setOrgFileErrorMessage,
-  setPath,
 } from './org';
 import { persistField } from '../util/settings_persister';
 

--- a/src/components/CaptureTemplatesEditor/components/CaptureTemplate/stylesheet.css
+++ b/src/components/CaptureTemplatesEditor/components/CaptureTemplate/stylesheet.css
@@ -104,7 +104,7 @@
 .multi-textfield-container {
   width: 75%;
   margin-top: 5px;
-  pdisplay: flex;
+  display: flex;
 }
 
 .multi-textfield-field {

--- a/src/components/Entry/index.js
+++ b/src/components/Entry/index.js
@@ -116,15 +116,18 @@ class Entry extends PureComponent {
     if (!!path) {
       path = '/' + path;
     }
-
-    return (
-      <OrgFile
-        path={path}
-        shouldDisableDirtyIndicator={false}
-        shouldDisableActionDrawer={false}
-        shouldDisableSyncButtons={false}
-      />
-    );
+    if (this.props.path && this.props.path !== path) {
+      return <Redirect push to={'/file' + this.props.path} />;
+    } else {
+      return (
+        <OrgFile
+          path={path}
+          shouldDisableDirtyIndicator={false}
+          shouldDisableActionDrawer={false}
+          shouldDisableSyncButtons={false}
+        />
+      );
+    }
   }
 
   shouldPromptWhenLeaving() {

--- a/src/components/Entry/index.js
+++ b/src/components/Entry/index.js
@@ -209,6 +209,7 @@ const mapStateToProps = (state) => {
   const path = state.org.present.get('path');
   const file = state.org.present.getIn(['files', path]);
   return {
+    path,
     loadingMessage: state.base.get('loadingMessage'),
     isAuthenticated: state.syncBackend.get('isAuthenticated'),
     fontSize: state.base.get('fontSize'),

--- a/src/components/Entry/index.js
+++ b/src/components/Entry/index.js
@@ -26,6 +26,7 @@ import * as syncBackendActions from '../../actions/sync_backend';
 import * as orgActions from '../../actions/org';
 import * as baseActions from '../../actions/base';
 import { loadTheme } from '../../lib/color';
+import FileSettingsEditor from '../FileSettingsEditor';
 
 class Entry extends PureComponent {
   constructor(props) {
@@ -164,12 +165,17 @@ class Entry extends PureComponent {
         {activeModalPage === 'changelog' ? (
           this.renderChangelogFile()
         ) : isAuthenticated ? (
-          ['keyboard_shortcuts_editor', 'settings', 'capture_templates_editor', 'sample'].includes(
-            activeModalPage
-          ) ? (
+          [
+            'keyboard_shortcuts_editor',
+            'settings',
+            'capture_templates_editor',
+            'file_settings_editor',
+            'sample',
+          ].includes(activeModalPage) ? (
             <Fragment>
               {activeModalPage === 'keyboard_shortcuts_editor' && <KeyboardShortcutsEditor />}
               {activeModalPage === 'capture_templates_editor' && <CaptureTemplatesEditor />}
+              {activeModalPage === 'file_settings_editor' && <FileSettingsEditor />}
               {activeModalPage === 'sample' && this.renderSampleFile()}
             </Fragment>
           ) : (

--- a/src/components/FileSettingsEditor/components/FileSetting/index.js
+++ b/src/components/FileSettingsEditor/components/FileSetting/index.js
@@ -1,0 +1,175 @@
+import React, { Fragment, useState } from 'react';
+import { UnmountClosed as Collapse } from 'react-collapse';
+
+import { Draggable } from 'react-beautiful-dnd';
+
+import './stylesheet.css';
+
+import Switch from '../../../UI/Switch';
+
+import classNames from 'classnames';
+
+export default ({ setting, index, onFieldPathUpdate, onDeleteSetting }) => {
+  const [isCollapsed, setIsCollapsed] = useState(!!setting.get('description'));
+  const handleHeaderBarClick = () => setIsCollapsed(!isCollapsed);
+
+  const updateField = (fieldName) => (event) =>
+    onFieldPathUpdate(setting.get('id'), [fieldName], event.target.value);
+
+  const toggleLoadOnStartup = () =>
+    onFieldPathUpdate(setting.get('id'), ['loadOnStartup'], !setting.get('loadOnStartup'));
+
+  const toggleIncludeInAgenda = () =>
+    onFieldPathUpdate(setting.get('id'), ['includeInAgenda'], !setting.get('includeInAgenda'));
+
+  const toggleIncludeInSearch = () =>
+    onFieldPathUpdate(setting.get('id'), ['includeInSearch'], !setting.get('includeInSearch'));
+
+  const toggleIncludeInTasklist = () =>
+    onFieldPathUpdate(setting.get('id'), ['includeInTasklist'], !setting.get('includeInTasklist'));
+
+  const handleDeleteClick = () => {
+    if (
+      window.confirm(`Are you sure you want to delete the settings for "${setting.get('path')}"?`)
+    ) {
+      onDeleteSetting(setting.get('id'));
+    }
+  };
+
+  const renderPathField = (setting) => (
+    <div className="capture-template__field-container">
+      <div className="capture-template__field">
+        <div>Path: </div>
+        <input
+          type="text"
+          className="textfield"
+          style={{ width: '90%' }}
+          value={setting.get('path', '')}
+          onChange={updateField('path')}
+          placeholder="e.g. /org/todo.org"
+        />
+      </div>
+    </div>
+  );
+
+  const renderOptionFields = (setting) => (
+    <>
+      <div className="capture-template__field-container">
+        <div className="capture-template__field">
+          <div>Load on startup?</div>
+          <Switch isEnabled={setting.get('loadOnStartup')} onToggle={toggleLoadOnStartup} />
+        </div>
+
+        <div className="capture-template__help-text">
+          By default, only the files you visit are loaded. Enable this setting to always load this
+          file when opening organice.
+        </div>
+      </div>
+
+      <div className="capture-template__field-container">
+        <div className="capture-template__field">
+          <div>Include in Agenda?</div>
+          <Switch isEnabled={setting.get('includeInAgenda')} onToggle={toggleIncludeInAgenda} />
+        </div>
+
+        <div className="capture-template__help-text">
+          By default, all loaded files are included in the agenda. Disable this setting to exclude
+          this file. The currently viewed file is always included.
+        </div>
+      </div>
+
+      <div className="capture-template__field-container">
+        <div className="capture-template__field">
+          <div>Include in Search?</div>
+          <Switch isEnabled={setting.get('includeInSearch')} onToggle={toggleIncludeInSearch} />
+        </div>
+
+        <div className="capture-template__help-text">
+          By default, only the current viewed file is included in search. Enable this setting to
+          always include this file. The currently loaded file is always included.
+        </div>
+      </div>
+
+      <div className="capture-template__field-container">
+        <div className="capture-template__field">
+          <div>Include in Tasklist?</div>
+          <Switch isEnabled={setting.get('includeInTasklist')} onToggle={toggleIncludeInTasklist} />
+        </div>
+
+        <div className="capture-template__help-text">
+          By default, only the current viewed file is included in the tasklist. Enable this setting
+          to always include this file. The currently loaded file is always included.
+        </div>
+      </div>
+    </>
+  );
+
+  const renderDeleteButton = () => (
+    <div className="capture-template__field-container capture-template__delete-button-container">
+      <button
+        className="btn settings-btn capture-template__delete-button"
+        onClick={handleDeleteClick}
+      >
+        Delete setting
+      </button>
+    </div>
+  );
+
+  const caretClassName = classNames(
+    'fas fa-2x fa-caret-right capture-template-container__header__caret',
+    {
+      'capture-template-container__header__caret--rotated': !isCollapsed,
+    }
+  );
+
+  return (
+    <Draggable draggableId={`capture-template--${setting.get('path')}`} index={index}>
+      {(provided, snapshot) => (
+        <div
+          className={classNames('capture-template-container', {
+            'capture-template-container--dragging': snapshot.isDragging,
+          })}
+          ref={provided.innerRef}
+          {...provided.draggableProps}
+        >
+          <div className="capture-template-container__header" onClick={handleHeaderBarClick}>
+            <i className={caretClassName} />
+            <div className="file-setting-icons">
+              <div
+                className={classNames({
+                  'fas fa-sync-alt fa-lg file-setting-icon': setting.get('loadOnStartup'),
+                })}
+              />
+              <div
+                className={classNames({
+                  'fas fa-calendar-alt fa-lg file-setting-icon': setting.get('includeInAgenda'),
+                })}
+              />
+              <div
+                className={classNames({ 'fas fa-search fa-lg file-setting-icon': setting.get('includeInSearch') })}
+              />
+              <div
+                className={classNames({ 'fas fa-tasks fa-lg file-setting-icon': setting.get('includeInTasklist') })}
+              />
+            </div>
+
+            <span className="file_setting-container__header__title">{setting.get('path')}</span>
+
+            <i
+              className="fas fa-bars fa-lg capture-template-container__header__drag-handle"
+              {...provided.dragHandleProps}
+            />
+          </div>
+
+          <Collapse isOpened={!isCollapsed} springConfig={{ stiffness: 300 }}>
+            <div className="capture-template-container__content">
+              {renderPathField(setting)}
+              {renderOptionFields(setting)}
+              {renderDeleteButton()}
+            </div>
+          </Collapse>
+        </div>
+      )}
+    </Draggable>
+  );
+};

--- a/src/components/FileSettingsEditor/components/FileSetting/index.js
+++ b/src/components/FileSettingsEditor/components/FileSetting/index.js
@@ -9,7 +9,7 @@ import Switch from '../../../UI/Switch';
 
 import classNames from 'classnames';
 
-export default ({ setting, index, onFieldPathUpdate, onDeleteSetting }) => {
+export default ({ setting, index, onFieldPathUpdate, onDeleteSetting, loadedFilepaths }) => {
   const [isCollapsed, setIsCollapsed] = useState(!!setting.get('description'));
   const handleHeaderBarClick = () => setIsCollapsed(!isCollapsed);
 
@@ -36,67 +36,71 @@ export default ({ setting, index, onFieldPathUpdate, onDeleteSetting }) => {
     }
   };
 
-  const renderPathField = (setting) => (
-    <div className="capture-template__field-container">
-      <div className="capture-template__field">
-        <div>Path: </div>
-        <input
-          type="text"
-          className="textfield"
-          style={{ width: '90%' }}
-          value={setting.get('path', '')}
-          onChange={updateField('path')}
-          placeholder="e.g. /org/todo.org"
-        />
+  const renderPathField = (setting) => {
+    if (setting.get('path') === '') {
+      updateField('path')({ target: { value: loadedFilepaths[0] } });
+    }
+    return (
+      <div className="file-setting__field-container">
+        <div className="file-setting__field">
+          <div>Path: </div>
+          <select onChange={updateField('path')} style={{ width: '90%' }}>
+            {[setting.get('path'), ...loadedFilepaths].map((path) => (
+              <option key={path} value={path}>
+                {path}
+              </option>
+            ))}
+          </select>
+        </div>
       </div>
-    </div>
-  );
+    );
+  };
 
   const renderOptionFields = (setting) => (
     <>
-      <div className="capture-template__field-container">
-        <div className="capture-template__field">
+      <div className="file-setting__field-container">
+        <div className="file-setting__field">
           <div>Load on startup?</div>
           <Switch isEnabled={setting.get('loadOnStartup')} onToggle={toggleLoadOnStartup} />
         </div>
 
-        <div className="capture-template__help-text">
+        <div className="file-setting__help-text">
           By default, only the files you visit are loaded. Enable this setting to always load this
           file when opening organice.
         </div>
       </div>
 
-      <div className="capture-template__field-container">
-        <div className="capture-template__field">
+      <div className="file-setting__field-container">
+        <div className="file-setting__field">
           <div>Include in Agenda?</div>
           <Switch isEnabled={setting.get('includeInAgenda')} onToggle={toggleIncludeInAgenda} />
         </div>
 
-        <div className="capture-template__help-text">
+        <div className="file-setting__help-text">
           By default, all loaded files are included in the agenda. Disable this setting to exclude
           this file. The currently viewed file is always included.
         </div>
       </div>
 
-      <div className="capture-template__field-container">
-        <div className="capture-template__field">
+      <div className="file-setting__field-container">
+        <div className="file-setting__field">
           <div>Include in Search?</div>
           <Switch isEnabled={setting.get('includeInSearch')} onToggle={toggleIncludeInSearch} />
         </div>
 
-        <div className="capture-template__help-text">
+        <div className="file-setting__help-text">
           By default, only the current viewed file is included in search. Enable this setting to
           always include this file. The currently loaded file is always included.
         </div>
       </div>
 
-      <div className="capture-template__field-container">
-        <div className="capture-template__field">
+      <div className="file-setting__field-container">
+        <div className="file-setting__field">
           <div>Include in Tasklist?</div>
           <Switch isEnabled={setting.get('includeInTasklist')} onToggle={toggleIncludeInTasklist} />
         </div>
 
-        <div className="capture-template__help-text">
+        <div className="file-setting__help-text">
           By default, only the current viewed file is included in the tasklist. Enable this setting
           to always include this file. The currently loaded file is always included.
         </div>
@@ -105,34 +109,31 @@ export default ({ setting, index, onFieldPathUpdate, onDeleteSetting }) => {
   );
 
   const renderDeleteButton = () => (
-    <div className="capture-template__field-container capture-template__delete-button-container">
-      <button
-        className="btn settings-btn capture-template__delete-button"
-        onClick={handleDeleteClick}
-      >
+    <div className="file-setting__field-container file-setting__delete-button-container">
+      <button className="btn settings-btn file-setting__delete-button" onClick={handleDeleteClick}>
         Delete setting
       </button>
     </div>
   );
 
   const caretClassName = classNames(
-    'fas fa-2x fa-caret-right capture-template-container__header__caret',
+    'fas fa-2x fa-caret-right file-setting-container__header__caret',
     {
-      'capture-template-container__header__caret--rotated': !isCollapsed,
+      'file-setting-container__header__caret--rotated': !isCollapsed,
     }
   );
 
   return (
-    <Draggable draggableId={`capture-template--${setting.get('path')}`} index={index}>
+    <Draggable draggableId={`file-setting--${setting.get('path')}`} index={index}>
       {(provided, snapshot) => (
         <div
-          className={classNames('capture-template-container', {
-            'capture-template-container--dragging': snapshot.isDragging,
+          className={classNames('file-setting-container', {
+            'file-setting-container--dragging': snapshot.isDragging,
           })}
           ref={provided.innerRef}
           {...provided.draggableProps}
         >
-          <div className="capture-template-container__header" onClick={handleHeaderBarClick}>
+          <div className="file-setting-container__header" onClick={handleHeaderBarClick}>
             <i className={caretClassName} />
             <div className="file-setting-icons">
               <div
@@ -146,23 +147,27 @@ export default ({ setting, index, onFieldPathUpdate, onDeleteSetting }) => {
                 })}
               />
               <div
-                className={classNames({ 'fas fa-search fa-lg file-setting-icon': setting.get('includeInSearch') })}
+                className={classNames({
+                  'fas fa-search fa-lg file-setting-icon': setting.get('includeInSearch'),
+                })}
               />
               <div
-                className={classNames({ 'fas fa-tasks fa-lg file-setting-icon': setting.get('includeInTasklist') })}
+                className={classNames({
+                  'fas fa-tasks fa-lg file-setting-icon': setting.get('includeInTasklist'),
+                })}
               />
             </div>
 
             <span className="file_setting-container__header__title">{setting.get('path')}</span>
 
             <i
-              className="fas fa-bars fa-lg capture-template-container__header__drag-handle"
+              className="fas fa-bars fa-lg file-setting-container__header__drag-handle"
               {...provided.dragHandleProps}
             />
           </div>
 
           <Collapse isOpened={!isCollapsed} springConfig={{ stiffness: 300 }}>
-            <div className="capture-template-container__content">
+            <div className="file-setting-container__content">
               {renderPathField(setting)}
               {renderOptionFields(setting)}
               {renderDeleteButton()}

--- a/src/components/FileSettingsEditor/components/FileSetting/index.js
+++ b/src/components/FileSettingsEditor/components/FileSetting/index.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useState } from 'react';
+import React, { useState } from 'react';
 import { UnmountClosed as Collapse } from 'react-collapse';
 
 import { Draggable } from 'react-beautiful-dnd';
@@ -10,7 +10,7 @@ import Switch from '../../../UI/Switch';
 import classNames from 'classnames';
 
 export default ({ setting, index, onFieldPathUpdate, onDeleteSetting, loadedFilepaths }) => {
-  const [isCollapsed, setIsCollapsed] = useState(!!setting.get('description'));
+  const [isCollapsed, setIsCollapsed] = useState(true);
   const handleHeaderBarClick = () => setIsCollapsed(!isCollapsed);
 
   const updateField = (fieldName) => (event) =>

--- a/src/components/FileSettingsEditor/components/FileSetting/stylesheet.css
+++ b/src/components/FileSettingsEditor/components/FileSetting/stylesheet.css
@@ -1,0 +1,170 @@
+@import '../../../../colors.css';
+
+.capture-template-container {
+  border-bottom: 2px solid var(--base2);
+  padding: 15px 5px;
+
+  -webkit-tap-highlight-color: var(--base03);
+}
+
+.capture-template-container--dragging {
+  background-color: var(--base1);
+}
+
+.capture-template-container__header {
+  display: flex;
+  align-items: center;
+
+  color: var(--base01);
+}
+
+.capture-template-container__header__title {
+  font-size: 20px;
+  margin-left: -10px;
+
+  max-width: calc(100% - 120px);
+}
+
+.capture-template-container__header__caret {
+  margin-right: 15px;
+  margin-left: 5px;
+
+  transition-property: transform;
+  transition-duration: 0.15s;
+}
+
+.capture-template-container__header__caret--rotated {
+  transform: rotate(90deg);
+}
+
+.capture-template-container__header__drag-handle {
+  margin-left: auto;
+  margin-right: 20px;
+
+  user-select: none;
+}
+
+.capture-template-container__content {
+  margin-top: 10px;
+}
+
+.capture-template__field-container {
+  margin-bottom: 5px;
+  border-bottom: 1px solid var(--base2);
+  padding-bottom: 5px;
+}
+
+.capture-template__field-container:last-of-type {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.capture-template__field {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.capture-template__help-text {
+  color: var(--base0);
+  font-size: 14px;
+  margin-top: 5px;
+  margin-bottom: 5px;
+}
+
+.capture-template__letter-textfield {
+  width: 30px;
+}
+
+.capture-template__field__or-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  color: var(--base01);
+  font-size: 14px;
+
+  margin-bottom: 5px;
+}
+
+.capture-template__field__or-line {
+  width: 20px;
+  height: 1px;
+  background-color: var(--base2);
+  margin-left: 10px;
+  margin-right: 10px;
+}
+
+.multi-textfields-container {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+.multi-textfield-container {
+  width: 75%;
+  margin-top: 5px;
+  pdisplay: flex;
+}
+
+.multi-textfield-field {
+  font-family: Courier;
+
+  flex: 1;
+}
+
+.remove-multi-textfield-button {
+  color: var(--base0);
+  border: 0;
+  background-color: transparent;
+}
+
+.add-new-multi-textfield-button-container {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 5px;
+  margin-right: 8px;
+}
+
+.add-new-multi-textfield-button {
+  background-color: var(--base2);
+  border: 0;
+  color: var(--base00);
+  width: 45px;
+  height: 45px;
+}
+
+.template-textarea {
+  border: 1px solid var(--base2);
+
+  margin-top: 5px;
+}
+
+.capture-template__delete-button-container {
+  display: flex;
+  justify-content: center;
+}
+
+.capture-template__delete-button {
+  background-color: var(--red);
+
+  margin-top: 15px;
+  margin-bottom: 0;
+}
+
+.file-setting-icons {
+  display: grid;
+  grid-template-columns: repeat(2, 20px [col-start]);
+  grid-template-rows: repeat(2, 20px [row-start]);
+}
+
+.file-setting-icon {
+  font-size: small;
+}
+
+.file_setting-container__header__title {
+  font-size: 20px;
+  margin-left: 10px;
+
+  max-width: calc(100% - 120px);
+}

--- a/src/components/FileSettingsEditor/components/FileSetting/stylesheet.css
+++ b/src/components/FileSettingsEditor/components/FileSetting/stylesheet.css
@@ -1,31 +1,31 @@
 @import '../../../../colors.css';
 
-.capture-template-container {
+.file-setting-container {
   border-bottom: 2px solid var(--base2);
   padding: 15px 5px;
 
   -webkit-tap-highlight-color: var(--base03);
 }
 
-.capture-template-container--dragging {
+.file-setting-container--dragging {
   background-color: var(--base1);
 }
 
-.capture-template-container__header {
+.file-setting-container__header {
   display: flex;
   align-items: center;
 
   color: var(--base01);
 }
 
-.capture-template-container__header__title {
+.file_setting-container__header__title {
   font-size: 20px;
-  margin-left: -10px;
+  margin-left: 10px;
 
   max-width: calc(100% - 120px);
 }
 
-.capture-template-container__header__caret {
+.file-setting-container__header__caret {
   margin-right: 15px;
   margin-left: 5px;
 
@@ -33,119 +33,51 @@
   transition-duration: 0.15s;
 }
 
-.capture-template-container__header__caret--rotated {
+.file-setting-container__header__caret--rotated {
   transform: rotate(90deg);
 }
 
-.capture-template-container__header__drag-handle {
+.file-setting-container__header__drag-handle {
   margin-left: auto;
   margin-right: 20px;
 
   user-select: none;
 }
 
-.capture-template-container__content {
+.file-setting-container__content {
   margin-top: 10px;
 }
 
-.capture-template__field-container {
+.file-setting__field-container {
   margin-bottom: 5px;
   border-bottom: 1px solid var(--base2);
   padding-bottom: 5px;
 }
 
-.capture-template__field-container:last-of-type {
+.file-setting__field-container:last-of-type {
   border-bottom: none;
   padding-bottom: 0;
 }
 
-.capture-template__field {
+.file-setting__field {
   display: flex;
   align-items: center;
   justify-content: space-between;
 }
 
-.capture-template__help-text {
+.file-setting__help-text {
   color: var(--base0);
   font-size: 14px;
   margin-top: 5px;
   margin-bottom: 5px;
 }
 
-.capture-template__letter-textfield {
-  width: 30px;
-}
-
-.capture-template__field__or-container {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  color: var(--base01);
-  font-size: 14px;
-
-  margin-bottom: 5px;
-}
-
-.capture-template__field__or-line {
-  width: 20px;
-  height: 1px;
-  background-color: var(--base2);
-  margin-left: 10px;
-  margin-right: 10px;
-}
-
-.multi-textfields-container {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-}
-
-.multi-textfield-container {
-  width: 75%;
-  margin-top: 5px;
-  pdisplay: flex;
-}
-
-.multi-textfield-field {
-  font-family: Courier;
-
-  flex: 1;
-}
-
-.remove-multi-textfield-button {
-  color: var(--base0);
-  border: 0;
-  background-color: transparent;
-}
-
-.add-new-multi-textfield-button-container {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 5px;
-  margin-right: 8px;
-}
-
-.add-new-multi-textfield-button {
-  background-color: var(--base2);
-  border: 0;
-  color: var(--base00);
-  width: 45px;
-  height: 45px;
-}
-
-.template-textarea {
-  border: 1px solid var(--base2);
-
-  margin-top: 5px;
-}
-
-.capture-template__delete-button-container {
+.file-setting__delete-button-container {
   display: flex;
   justify-content: center;
 }
 
-.capture-template__delete-button {
+.file-setting__delete-button {
   background-color: var(--red);
 
   margin-top: 15px;
@@ -160,11 +92,4 @@
 
 .file-setting-icon {
   font-size: small;
-}
-
-.file_setting-container__header__title {
-  font-size: 20px;
-  margin-left: 10px;
-
-  max-width: calc(100% - 120px);
 }

--- a/src/components/FileSettingsEditor/index.js
+++ b/src/components/FileSettingsEditor/index.js
@@ -12,7 +12,7 @@ import FileSetting from './components/FileSetting';
 
 import { List } from 'immutable';
 
-const FileSettingsEditor = ({ fileSettings, org }) => {
+const FileSettingsEditor = ({ fileSettings, loadedFilepaths, org }) => {
   const handleAddNewSettingClick = () => org.addNewEmptyFileSetting();
 
   const handleFieldPathUpdate = (settingId, fieldPath, newValue) =>
@@ -21,24 +21,24 @@ const FileSettingsEditor = ({ fileSettings, org }) => {
   const handleDeleteSetting = (settingId) => org.deleteFileSetting(settingId);
 
   const handleReorderSetting = (fromIndex, toIndex) => org.reorderFileSetting(fromIndex, toIndex);
-
+  console.debug(loadedFilepaths);
   return (
     <div>
-      <Droppable droppableId="capture-templates-editor-droppable" type="CAPTURE-TEMPLATE">
+      <Droppable droppableId="file-setting-editor-droppable" type="CAPTURE-TEMPLATE">
         {(provided) => (
           <div
-            className="capture-templates-container"
+            className="file-setting-container"
             ref={provided.innerRef}
             {...provided.droppableProps}
           >
             {fileSettings.size === 0 ? (
-              <div className="no-capture-templates-message">
+              <div className="no-file-setting-message">
                 You don't currently have any file settings - add one by pressing the{' '}
                 <i className="fas fa-plus" /> button.
                 <br />
                 <br />
                 File settings allow you to configure how specific files are handeled when multiple
-                files are loaded.
+                files are loaded. Make sure a file is loaded to create a setting entry.
               </div>
             ) : (
               <Fragment>
@@ -47,6 +47,7 @@ const FileSettingsEditor = ({ fileSettings, org }) => {
                     key={setting.get('id')}
                     index={index}
                     setting={setting}
+                    loadedFilepaths={loadedFilepaths}
                     onFieldPathUpdate={handleFieldPathUpdate}
                     onDeleteSetting={handleDeleteSetting}
                     onReorder={handleReorderSetting}
@@ -60,16 +61,28 @@ const FileSettingsEditor = ({ fileSettings, org }) => {
         )}
       </Droppable>
 
-      <div className="new-capture-template-button-container">
-        <button className="fas fa-plus fa-lg btn btn--circle" onClick={handleAddNewSettingClick} />
-      </div>
+      {loadedFilepaths.length !== 0 && (
+        <div className="new-capture-template-button-container">
+          <button
+            className="fas fa-plus fa-lg btn btn--circle"
+            onClick={handleAddNewSettingClick}
+          />
+        </div>
+      )}
     </div>
   );
 };
 
 const mapStateToProps = (state) => {
+  const fileSettings = state.org.present.get('fileSettings', List());
+  const existingSettings = fileSettings.map((setting) => setting.get('path'));
+  const paths = state.org.present.get('files', List()).keySeq();
+  const loadedFilepaths = paths
+    .filter((path) => !existingSettings.find((settingPath) => settingPath === path))
+    .toJS();
   return {
-    fileSettings: state.org.present.get('fileSettings', List()),
+    fileSettings,
+    loadedFilepaths,
   };
 };
 

--- a/src/components/FileSettingsEditor/index.js
+++ b/src/components/FileSettingsEditor/index.js
@@ -1,0 +1,82 @@
+import React, { Fragment } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+import { Droppable } from 'react-beautiful-dnd';
+
+import './stylesheet.css';
+
+import * as orgActions from '../../actions/org';
+
+import FileSetting from './components/FileSetting';
+
+import { List } from 'immutable';
+
+const FileSettingsEditor = ({ fileSettings, org }) => {
+  const handleAddNewSettingClick = () => org.addNewEmptyFileSetting();
+
+  const handleFieldPathUpdate = (settingId, fieldPath, newValue) =>
+    org.updateFileSettingFieldPathValue(settingId, fieldPath, newValue);
+
+  const handleDeleteSetting = (settingId) => org.deleteFileSetting(settingId);
+
+  const handleReorderSetting = (fromIndex, toIndex) => org.reorderFileSetting(fromIndex, toIndex);
+
+  return (
+    <div>
+      <Droppable droppableId="capture-templates-editor-droppable" type="CAPTURE-TEMPLATE">
+        {(provided) => (
+          <div
+            className="capture-templates-container"
+            ref={provided.innerRef}
+            {...provided.droppableProps}
+          >
+            {fileSettings.size === 0 ? (
+              <div className="no-capture-templates-message">
+                You don't currently have any file settings - add one by pressing the{' '}
+                <i className="fas fa-plus" /> button.
+                <br />
+                <br />
+                File settings allow you to configure how specific files are handeled when multiple
+                files are loaded.
+              </div>
+            ) : (
+              <Fragment>
+                {fileSettings.map((setting, index) => (
+                  <FileSetting
+                    key={setting.get('id')}
+                    index={index}
+                    setting={setting}
+                    onFieldPathUpdate={handleFieldPathUpdate}
+                    onDeleteSetting={handleDeleteSetting}
+                    onReorder={handleReorderSetting}
+                  />
+                ))}
+
+                {provided.placeholder}
+              </Fragment>
+            )}
+          </div>
+        )}
+      </Droppable>
+
+      <div className="new-capture-template-button-container">
+        <button className="fas fa-plus fa-lg btn btn--circle" onClick={handleAddNewSettingClick} />
+      </div>
+    </div>
+  );
+};
+
+const mapStateToProps = (state) => {
+  return {
+    fileSettings: state.org.present.get('fileSettings', List()),
+  };
+};
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    org: bindActionCreators(orgActions, dispatch),
+  };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(FileSettingsEditor);

--- a/src/components/FileSettingsEditor/index.js
+++ b/src/components/FileSettingsEditor/index.js
@@ -21,10 +21,10 @@ const FileSettingsEditor = ({ fileSettings, loadedFilepaths, org }) => {
   const handleDeleteSetting = (settingId) => org.deleteFileSetting(settingId);
 
   const handleReorderSetting = (fromIndex, toIndex) => org.reorderFileSetting(fromIndex, toIndex);
-  console.debug(loadedFilepaths);
+
   return (
     <div>
-      <Droppable droppableId="file-setting-editor-droppable" type="CAPTURE-TEMPLATE">
+      <Droppable droppableId="file-setting-editor-droppable" type="FILE-SETTING">
         {(provided) => (
           <div
             className="file-setting-container"

--- a/src/components/FileSettingsEditor/stylesheet.css
+++ b/src/components/FileSettingsEditor/stylesheet.css
@@ -1,0 +1,17 @@
+.capture-templates-container {
+  position: relative;
+}
+
+.new-capture-template-button-container {
+  display: flex;
+  justify-content: flex-end;
+
+  margin-top: 10px;
+  margin-right: 10px;
+}
+
+.no-capture-templates-message {
+  text-align: center;
+  color: var(--base0);
+  padding: 20px;
+}

--- a/src/components/FileSettingsEditor/stylesheet.css
+++ b/src/components/FileSettingsEditor/stylesheet.css
@@ -1,16 +1,4 @@
-.capture-templates-container {
-  position: relative;
-}
-
-.new-capture-template-button-container {
-  display: flex;
-  justify-content: flex-end;
-
-  margin-top: 10px;
-  margin-right: 10px;
-}
-
-.no-capture-templates-message {
+.no-file-setting-message {
   text-align: center;
   color: var(--base0);
   padding: 20px;

--- a/src/components/HeaderBar/index.js
+++ b/src/components/HeaderBar/index.js
@@ -143,6 +143,8 @@ class HeaderBar extends PureComponent {
         return this.renderSettingsSubPageBackButton();
       case 'capture_templates_editor':
         return this.renderSettingsSubPageBackButton();
+      case 'file_settings_editor':
+        return this.renderSettingsSubPageBackButton();
       case 'sample':
         return this.renderSettingsSubPageBackButton();
       default:
@@ -182,6 +184,8 @@ class HeaderBar extends PureComponent {
         return titleContainerWithText('Shortcuts');
       case 'capture_templates_editor':
         return titleContainerWithText('Capture');
+      case 'file_settings_editor':
+        return titleContainerWithText('Files');
       case 'sample':
         return titleContainerWithText('Sample');
       default:

--- a/src/components/OrgFile/OrgFile.integration.test.js
+++ b/src/components/OrgFile/OrgFile.integration.test.js
@@ -11,7 +11,7 @@ import readFixture from '../../../test_helpers/index';
 
 import rootReducer from '../../reducers/';
 
-import { changePath, parseFile } from '../../actions/org';
+import { setPath, parseFile } from '../../actions/org';
 import { setShouldLogIntoDrawer } from '../../actions/base';
 
 import { Map, fromJS } from 'immutable';
@@ -61,7 +61,7 @@ describe('Render all views', () => {
       applyMiddleware(thunk)
     );
     store.dispatch(parseFile('fixtureTestFile.org', testOrgFile));
-    store.dispatch(changePath('fixtureTestFile.org'));
+    store.dispatch(setPath('fixtureTestFile.org'));
   });
 
   describe('Org Functionality', () => {

--- a/src/components/OrgFile/OrgFile.integration.test.js
+++ b/src/components/OrgFile/OrgFile.integration.test.js
@@ -11,7 +11,7 @@ import readFixture from '../../../test_helpers/index';
 
 import rootReducer from '../../reducers/';
 
-import { displayFile } from '../../actions/org';
+import { changePath, parseFile } from '../../actions/org';
 import { setShouldLogIntoDrawer } from '../../actions/base';
 
 import { Map, fromJS } from 'immutable';
@@ -60,7 +60,8 @@ describe('Render all views', () => {
       },
       applyMiddleware(thunk)
     );
-    store.dispatch(displayFile('fixtureTestFile.org', testOrgFile));
+    store.dispatch(parseFile('fixtureTestFile.org', testOrgFile));
+    store.dispatch(changePath('fixtureTestFile.org'));
   });
 
   describe('Org Functionality', () => {

--- a/src/components/OrgFile/components/ActionDrawer/index.js
+++ b/src/components/OrgFile/components/ActionDrawer/index.js
@@ -406,7 +406,7 @@ const mapStateToProps = (state) => {
     selectedTableCellId: file.get('selectedTableCellId'),
     captureTemplates: state.capture.get('captureTemplates', List()),
     path,
-    isLoading: state.base.get('isLoading'),
+    isLoading: !state.base.get('isLoading').isEmpty(),
   };
 };
 

--- a/src/components/OrgFile/components/AgendaModal/components/AgendaDay/index.js
+++ b/src/components/OrgFile/components/AgendaModal/components/AgendaDay/index.js
@@ -37,7 +37,6 @@ export default class AgendaDay extends PureComponent {
     const {
       date,
       files,
-      todoKeywordSets,
       dateDisplayType,
       onToggleDateDisplayType,
       agendaDefaultDeadlineDelayValue,

--- a/src/components/OrgFile/components/SearchModal/index.js
+++ b/src/components/OrgFile/components/SearchModal/index.js
@@ -27,7 +27,6 @@ function SearchModal(props) {
     context,
     showClockedTimes,
     clockedTime,
-    path,
   } = props;
 
   function handleHeaderClick(path, headerId) {

--- a/src/components/OrgFile/components/SyncConfirmationModal/index.js
+++ b/src/components/OrgFile/components/SyncConfirmationModal/index.js
@@ -8,8 +8,6 @@ import { customFormatDistanceToNow } from '../../../../lib/org_utils';
 import format from 'date-fns/format';
 
 export default ({ lastServerModifiedAt, lastSyncAt, path, onPull, onPush, onCancel }) => {
-  console.debug(lastSyncAt);
-  console.debug(lastServerModifiedAt);
   return (
     <Drawer>
       <h2 className="sync-confirmation-modal__header">Sync conflict</h2>

--- a/src/components/OrgFile/components/SyncConfirmationModal/index.js
+++ b/src/components/OrgFile/components/SyncConfirmationModal/index.js
@@ -7,17 +7,31 @@ import Drawer from '../../../UI/Drawer/';
 import { customFormatDistanceToNow } from '../../../../lib/org_utils';
 import format from 'date-fns/format';
 
-export default ({ lastServerModifiedAt, onPull, onPush, onCancel }) => {
+export default ({ lastServerModifiedAt, lastSyncAt, path, onPull, onPush, onCancel }) => {
+  console.debug(lastSyncAt);
+  console.debug(lastServerModifiedAt);
   return (
     <Drawer>
       <h2 className="sync-confirmation-modal__header">Sync conflict</h2>
-      Since you last pulled, a newer version of the file has been pushed to the server. The newer
-      version is from:
+      Since you last pulled {path}, a newer version of the file has been pushed to the server. The
+      newer version is from:
       <br />
+      &nbsp;
       <br />
       <div className="sync-confirmation-modal__last-sync-time">
         {format(lastServerModifiedAt, 'MMMM do, yyyy [at] h:mm:ss a')}
         <br />({customFormatDistanceToNow(lastServerModifiedAt)})
+      </div>
+      <br />
+      &nbsp;
+      <br />
+      While your version is from:
+      <br />
+      &nbsp;
+      <br />
+      <div className="sync-confirmation-modal__last-sync-time">
+        {format(lastSyncAt, 'MMMM do, yyyy [at] h:mm:ss a')}
+        <br />({customFormatDistanceToNow(lastSyncAt)})
       </div>
       <div className="sync-confirmation-modal__buttons-container">
         <button className="btn sync-confirmation-modal__button" onClick={onPull}>

--- a/src/components/OrgFile/components/SyncConfirmationModal/stylesheet.css
+++ b/src/components/OrgFile/components/SyncConfirmationModal/stylesheet.css
@@ -7,7 +7,7 @@
 }
 
 .sync-confirmation-modal__last-sync-time {
-  color: var(--base2);
+  color: var(--base0);
 
   text-align: center;
   font-weight: bold;

--- a/src/components/OrgFile/components/TaskListModal/components/TaskListView/index.js
+++ b/src/components/OrgFile/components/TaskListModal/components/TaskListView/index.js
@@ -132,7 +132,7 @@ const mapStateToProps = (state) => {
     // When no filtering has happened, yet (initial state), use all headers.
     headers:
       state.org.present.getIn(['search', 'filteredHeaders']) ||
-      // TODO: this uses only the current file when no search term is entered. Use all of them.
+      // @tarnung TODO: this uses only the current file when no search term is entered. Use all of them.
       new Map().set(path, file.get('headers')),
   };
 };

--- a/src/components/OrgFile/index.js
+++ b/src/components/OrgFile/index.js
@@ -116,7 +116,7 @@ class OrgFile extends PureComponent {
     if (!!staticFile) {
       this.props.base.unloadStaticFile();
     } else {
-      this.props.org.stopDisplayingFile();
+      this.props.org.resetFileDisplay();
     }
   }
 

--- a/src/components/OrgFile/index.js
+++ b/src/components/OrgFile/index.js
@@ -37,7 +37,7 @@ import {
 } from '../../lib/org_utils';
 
 import _ from 'lodash';
-import { fromJS } from 'immutable';
+import { fromJS, Set } from 'immutable';
 
 class OrgFile extends PureComponent {
   constructor(props) {
@@ -90,7 +90,12 @@ class OrgFile extends PureComponent {
 
       setTimeout(() => (document.querySelector('html').scrollTop = 0), 0);
     } else if (!_.isEmpty(path) && path !== loadedPath) {
-      this.props.syncBackend.downloadFile(path);
+      if (this.props.fileIsLoaded(path)) {
+        this.props.org.sync({ path });
+      } else {
+        this.props.syncBackend.downloadFile(path);
+      }
+      this.props.org.setPath(path);
     }
 
     this.activatePopup();
@@ -124,6 +129,7 @@ class OrgFile extends PureComponent {
     const { path } = this.props;
     if (!_.isEmpty(path) && path !== prevProps.path) {
       this.props.syncBackend.downloadFile(path);
+      this.props.org.setPath(path);
     }
   }
 
@@ -497,6 +503,8 @@ class OrgFile extends PureComponent {
 
 const mapStateToProps = (state) => {
   const loadedPath = state.org.present.get('path');
+  const loadedFiles = Set.fromKeys(state.org.present.get('files'));
+  const fileIsLoaded = (path) => loadedFiles.includes(path);
   const file = state.org.present.getIn(['files', loadedPath]);
   const headers = file ? file.get('headers') : null;
   const selectedHeaderId = file ? file.get('selectedHeaderId') : null;
@@ -507,6 +515,7 @@ const mapStateToProps = (state) => {
     selectedHeaderId,
     isDirty: file ? file.get('isDirty') : null,
     loadedPath,
+    fileIsLoaded,
     selectedHeader: headers && headers.find((header) => header.get('id') === selectedHeaderId),
     customKeybindings: state.base.get('customKeybindings'),
     shouldLogIntoDrawer: state.base.get('shouldLogIntoDrawer'),

--- a/src/components/OrgFile/index.js
+++ b/src/components/OrgFile/index.js
@@ -229,13 +229,13 @@ class OrgFile extends PureComponent {
     }
   }
 
-  handleSyncConfirmationPull() {
-    this.props.org.sync({ forceAction: 'pull' });
+  handleSyncConfirmationPull(path) {
+    this.props.org.sync({ path, forceAction: 'pull' });
     this.props.base.closePopup();
   }
 
-  handleSyncConfirmationPush() {
-    this.props.org.sync({ forceAction: 'push' });
+  handleSyncConfirmationPush(path) {
+    this.props.org.sync({ path, forceAction: 'push' });
     this.props.base.closePopup();
   }
 
@@ -287,6 +287,8 @@ class OrgFile extends PureComponent {
         return (
           <SyncConfirmationModal
             lastServerModifiedAt={activePopupData.get('lastServerModifiedAt')}
+            lastSyncAt={activePopupData.get('lastSyncAt')}
+            path={activePopupData.get('path')}
             onPull={this.handleSyncConfirmationPull}
             onPush={this.handleSyncConfirmationPush}
             onCancel={this.handleSyncConfirmationCancel}

--- a/src/components/Settings/index.js
+++ b/src/components/Settings/index.js
@@ -50,6 +50,8 @@ const Settings = ({
 
   const handleCaptureTemplatesClick = () => base.pushModalPage('capture_templates_editor');
 
+  const handleFileSettingsClick = () => base.pushModalPage('file_settings_editor');
+
   const handleFontSizeChange = (newFontSize) => base.setFontSize(newFontSize);
 
   const handleColorSchemeClick = (colorScheme) => base.setColorScheme(colorScheme);
@@ -255,6 +257,9 @@ const Settings = ({
         </button>
         <button className="btn settings-btn" onClick={handleKeyboardShortcutsClick}>
           Keyboard shortcuts
+        </button>
+        <button className="btn settings-btn" onClick={handleFileSettingsClick}>
+          File settings
         </button>
 
         <hr className="settings-button-separator" />

--- a/src/middleware/live_sync.js
+++ b/src/middleware/live_sync.js
@@ -2,7 +2,14 @@ import { sync } from '../actions/org';
 
 export default (store) => (next) => (action) => {
   if (action.dirtying && store.getState().base.get('shouldLiveSync')) {
-    store.dispatch(sync({ shouldSuppressMessages: true }));
+    if (action.type === 'REFILE_SUBTREE') {
+      store.dispatch(sync({ shouldSuppressMessages: true, path: action.sourcePath }));
+      store.dispatch(sync({ shouldSuppressMessages: true, path: action.targetPath }));
+    } else {
+      store.dispatch(
+        sync({ shouldSuppressMessages: true, path: store.getState().org.present.get('path') })
+      );
+    }
   }
 
   return next(action);

--- a/src/reducers/base.js
+++ b/src/reducers/base.js
@@ -4,7 +4,10 @@ import { applyCategorySettingsFromConfig } from '../util/settings_persister';
 
 const setLoadingMessage = (state, action) => state.set('loadingMessage', action.loadingMessage);
 
-const hideLoadingMessage = (state) => state.set('loadingMessage', null);
+const hideLoadingMessage = (state) =>
+  state.update('loadingMessage', (loadingMessage) =>
+    state.get('isLoading').isEmpty() ? null : loadingMessage
+  );
 
 const setFontSize = (state, action) => state.set('fontSize', action.newFontSize);
 
@@ -109,7 +112,13 @@ const closePopup = (state) => {
   return state.set('activePopup', null);
 };
 
-const setIsLoading = (state, action) => state.set('isLoading', action.isLoading);
+const setIsLoading = (state, action) => {
+  if (action.isLoading) {
+    return state.update('isLoading', (isLoading) => isLoading.add(action.path));
+  } else {
+    return state.update('isLoading', (isLoading) => isLoading.delete(action.path));
+  }
+};
 
 const setColorScheme = (state, action) => {
   return state.set('colorScheme', action.colorScheme);

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -56,12 +56,11 @@ import generateId from '../lib/id_generator';
 import { formatTextWrap } from '../util/misc';
 import { applyFileSettingsFromConfig } from '../util/settings_persister';
 
-const displayFile = (state, action) => {
+const parseFile = (state, action) => {
   const { path, contents } = action;
   const parsedFile = parseOrg(contents);
 
   return state
-    .set('path', path)
     .setIn(['files', path, 'contents'], contents)
     .setIn(['files', path, 'headers'], parsedFile.get('headers'))
     .setIn(['files', path, 'todoKeywordSets'], parsedFile.get('todoKeywordSets'))
@@ -1279,7 +1278,7 @@ const reducer = (state, action) => {
 
   switch (action.type) {
     case 'DISPLAY_FILE':
-      return displayFile(state, action);
+      return parseFile(state, action);
     case 'STOP_DISPLAYING_FILE':
       return stopDisplayingFile(state, action);
     case 'TOGGLE_HEADER_OPENED':

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -68,7 +68,7 @@ const parseFile = (state, action) => {
     .setIn(['files', path, 'linesBeforeHeadings'], parsedFile.get('linesBeforeHeadings'));
 };
 
-const stopDisplayingFile = (state) =>
+const clearSearch = (state) =>
   state.set('path', null).setIn(['search', 'filteredHeaders'], null);
 
 const openHeader = (state, action) => {
@@ -1272,8 +1272,8 @@ const reducer = (state, action) => {
   switch (action.type) {
     case 'PARSE_FILE':
       return parseFile(state, action);
-    case 'STOP_DISPLAYING_FILE':
-      return stopDisplayingFile(state, action);
+    case 'CLEAR_SEARCH':
+      return clearSearch(state, action);
     case 'TOGGLE_HEADER_OPENED':
       return inFile(toggleHeaderOpened);
     case 'OPEN_HEADER':

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -69,14 +69,7 @@ const parseFile = (state, action) => {
 };
 
 const stopDisplayingFile = (state) =>
-  state
-    .set('path', null)
-    //.set('contents', null)
-    //.set('headers', null)
-    .setIn(['search', 'filteredHeaders'], null);
-//.set('todoKeywordSets', null)
-//.set('fileConfigLines', null)
-//.set('linesBeforeHeadings', null);
+  state.set('path', null).setIn(['search', 'filteredHeaders'], null);
 
 const openHeader = (state, action) => {
   const headers = state.get('headers');
@@ -1217,7 +1210,7 @@ export const setSearchFilterInformation = (state, action) => {
 
 const setOrgFileErrorMessage = (state, action) => state.set('orgFileErrorMessage', action.message);
 
-const changePath = (state, action) => state.set('path', action.path);
+const setPath = (state, action) => state.set('path', action.path);
 
 const setShowClockDisplay = (state, action) => {
   if (action.showClockDisplay) {
@@ -1277,7 +1270,7 @@ const reducer = (state, action) => {
   const inFile = reduceInFile(state, action, path);
 
   switch (action.type) {
-    case 'DISPLAY_FILE':
+    case 'PARSE_FILE':
       return parseFile(state, action);
     case 'STOP_DISPLAYING_FILE':
       return stopDisplayingFile(state, action);
@@ -1389,8 +1382,8 @@ const reducer = (state, action) => {
       return inFile(updateLogEntryTime);
     case 'SET_SEARCH_FILTER_INFORMATION':
       return setSearchFilterInformation(state, action);
-    case 'CHANGE_PATH':
-      return changePath(state, action);
+    case 'SET_PATH':
+      return setPath(state, action);
     case 'TOGGLE_CLOCK_DISPLAY':
       return setShowClockDisplay(state, action);
     case 'UPDATE_FILE_SETTING_FIELD_PATH_VALUE':

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -1329,7 +1329,7 @@ const reducer = (state, action) => {
     case 'APPLY_OPENNESS_STATE':
       return applyOpennessState(state, action);
     case 'SET_DIRTY':
-      return inFile(setDirty);
+      return action.path ? reduceInFile(state, action, action.path)(setDirty) : inFile(setDirty);
     case 'NARROW_HEADER':
       return inFile(narrowHeader);
     case 'WIDEN_HEADER':
@@ -1361,7 +1361,9 @@ const reducer = (state, action) => {
     case 'ADVANCE_CHECKBOX_STATE':
       return inFile(advanceCheckboxState);
     case 'SET_LAST_SYNC_AT':
-      return inFile(setLastSyncAt);
+      return action.path
+        ? reduceInFile(state, action, action.path)(setLastSyncAt)
+        : inFile(setLastSyncAt);
     case 'SET_HEADER_TAGS':
       return inFile(setHeaderTags);
     case 'REORDER_TAGS':
@@ -1409,8 +1411,14 @@ const reducer = (state, action) => {
 
 export default (state = Map(), action) => {
   if (action.dirtying) {
-    const path = state.get('path');
-    state = state.setIn(['files', path, 'isDirty'], true);
+    if (action.type === 'REFILE_SUBTREE') {
+      const { sourcePath, targetPath } = action;
+      state = state.setIn(['files', sourcePath, 'isDirty'], true);
+      state = state.setIn(['files', targetPath, 'isDirty'], true);
+    } else {
+      const path = state.get('path');
+      state = state.setIn(['files', path, 'isDirty'], true);
+    }
   }
 
   state = reducer(state, action);

--- a/src/util/settings_persister.js
+++ b/src/util/settings_persister.js
@@ -1,4 +1,4 @@
-import { Map, List, fromJS } from 'immutable';
+import { Map, List, Set, fromJS } from 'immutable';
 import _ from 'lodash';
 
 import { getOpenHeaderPaths } from '../lib/org_utils';
@@ -235,7 +235,7 @@ export const readInitialState = () => {
       }),
       future: [],
     },
-    base: Map(),
+    base: Map().set('isLoading', Set()),
     capture: Map(),
   };
 


### PR DESCRIPTION
Most of this is copied and adopted from capture templates.

Options with current defaults:
- Load on startup? --false
- Include in Agenda? --true
- Include in Search? -- false
- Include in Tasklist? -- false

Loaded files without a setting entry would be handled according to these defaults. the currently viewed file will always be included in search, agenda & tasklist.

There is also refile. Should all files always be refile targets or should it be configurable?

The 'Load on startup'-option does not do anything yet.