### PR TITLE
doc: Add `contrib` documentation on how to setup Traefik as WebDAV back-end

### DIFF
--- a/contrib/organice-webdav-traefik/Dockerfile
+++ b/contrib/organice-webdav-traefik/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine
+
+RUN apk add --no-cache nginx-mod-http-dav-ext nginx gettext
+
+VOLUME /data
+VOLUME /var/log/nginx
+EXPOSE 80
+COPY webdav.conf /etc/nginx/nginx.template.conf
+
+COPY run.sh /
+RUN chmod +x run.sh && rm /etc/nginx/nginx.conf
+CMD /run.sh

--- a/contrib/organice-webdav-traefik/LICENSE
+++ b/contrib/organice-webdav-traefik/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2020 Gallo Feliz
+Copyright (c) 2020 Edgar Vincent
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/contrib/organice-webdav-traefik/README.md
+++ b/contrib/organice-webdav-traefik/README.md
@@ -1,0 +1,96 @@
+# Docker Webdav backend for Organice
+
+This Docker image makes it easy for [Traefik](https://traefik.io) users to set up a Webdav backend for [Organice](https://organice.200ok.ch).
+Please note that this is still a WIP. Moreover, my knowledge of network security is very minimal. Use at your own risk.
+
+This repository was forked from https://github.com/gallofeliz/simple-docker-webdav - I have only applied minor modifications to the original version.
+
+## Usage
+
+This is a sample `docker-compose.yml` file which will set up an instance of Organice and a Webdav backend with Traefik.
+Please note that this Webdav backend provides neither authentication nor traffic encryption. You _must_ set up a reverse proxy (such as Traefik) in front of it in order to make it secure.
+
+The following example sets up HTTP Basic Auth (via Traefik) in front of the Webdav container. Other options - such as IP whitelisting - are available.
+Consult the Traefik documentation for more details.
+It also sets up Let's Encrypt certificates automatically.
+
+```yaml
+version: "3.7"
+
+services:
+  traefik:
+    container_name: traefik
+    image: "traefik:latest"
+    command:
+      - --entrypoints.websecure.address=:443
+      - --entrypoints.web.address=:80
+      - --entrypoints.web.http.redirections.entrypoint.to=websecure
+      - --entrypoints.web.http.redirections.entrypoint.scheme=https
+      - --providers.docker
+      - --certificatesresolvers.le.acme.email=${EMAIL}
+      - --certificatesresolvers.le.acme.storage=/acme.json
+      - --certificatesresolvers.le.acme.tlschallenge=true
+      - --api
+      - --log.filePath=/var/log/error.log
+      - --log.level=INFO
+      - --accesslog.filepath=/var/log/access.log
+      - --accesslog=true
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - "./traefik/acme.json:/acme.json"
+      - "./traefik/log:/var/log"
+    labels:
+      - "traefik.http.routers.traefik.tls.certresolver=le"
+      - "traefik.http.routers.traefik.entrypoints=websecure"
+      - "traefik.http.middlewares.auth.basicauth.users=${HTTP_AUTH}"
+    restart: unless-stopped
+
+  organice:
+    image: "twohundredok/organice:latest"
+    container_name: organice
+    restart: unless-stopped
+    labels:
+      - traefik.http.routers.organice.rule=Host(`${DOMAIN}`)
+      - traefik.http.routers.organice.middlewares=auth
+      - traefik.http.routers.organice.tls.certresolver=le
+      - traefik.http.routers.organice.entrypoints=websecure
+      - traefik.http.services.organice.loadbalancer.server.port=5000
+
+  webdav:
+    image: edgarvincent/webdav
+    container_name: webdav
+    environment:
+      - PUID=${PUID}
+      - PGID=${PGID}
+      - WEBDAV_PREFIX=${WEBDAV_PREFIX}
+    volumes:
+      - ${ORG_DIR}:/data
+      - ./webdav/log:/var/log/nginx
+    restart: unless-stopped
+    labels:
+      - traefik.http.routers.webdav.rule=Host(`${DOMAIN}`) && PathPrefix(`/${WEBDAV_PREFIX}`)
+      - traefik.http.routers.webdav.tls.certresolver=le
+      - traefik.http.routers.webdav.entrypoints=websecure
+      - traefik.http.services.webdav.loadbalancer.server.port=80
+      - traefik.http.routers.webdav.middlewares=auth
+```
+
+## Environment variables
+
+Replace the following variables in the example above with the desired values, as described below. You can also define them in your `.env` file (with, for example, `PUID=1000`).
+
+| Container | Variable          | Description                                                                                     | Example value                                                    |
+| :-------: | :---------------: | :--------------------------------------------------------------------------------:              | :--------------------------------------------------------------: |
+| Both      | \${HTTP_AUTH}     | User/password pair for Basic Auth <sup>1</sup>                                                  | Foobar:$$2y$$05\$\$s6HgvuWptDeM9I...                             |
+| Both      | \${DOMAIN}        | Domain name used to access Organice                                                             | https://organice.myserver.org                                    |
+| webdav    | \${PUID}          | UID of the user your Org files belong to                                                        | 1000                                                             |
+| webdav    | \${PGID}          | GID of the group your Org files belong to                                                       | 1000                                                             |
+| Both      | \${WEBDAV_PREFIX} | Subpath of ${DOMAIN} the Webdav server will be providing your Org files from, without slashes. | webdav                                                           |
+| webdav    | \${ORG_DIR}       | Directory which contains your Org files                                                         | /home/foobar/Org                                                 |
+| Traefik   | \${EMAIL}         | Email for Let's Encrypt registration                                                            | foobar@example.com                                               |
+| webdav    | \${DAV_METHODS}   | List of Dav methods, as they would be listed in `nginx.conf`, separated by spaces.              | Set to `off` for read-only. If not set, all methods are enabled. |
+
+<sup>1</sup> See [this article](https://medium.com/@techupbusiness/add-basic-authentication-in-docker-compose-files-with-traefik-34c781234970) for details on how to generate it.

--- a/contrib/organice-webdav-traefik/README.org
+++ b/contrib/organice-webdav-traefik/README.org
@@ -1,0 +1,12 @@
+* Running organice with [[https://traefik.io/][Traefik]]
+
+This uses the [[https://organice.200ok.ch/documentation.html#docker][official organice Docker image]], but adds instructions on
+how to build a Docker image using [[https://traefik.io/][Traefik]] to set up a WebDAV back-end
+for organice.
+
+Author:
+ - Github: https://github.com/edgar-vincent
+ - Sourcehut: https://git.sr.ht/~e-v/
+ - Email: e-v@posteo.net
+
+Upstream repository: https://git.sr.ht/~e-v/docker-organice-webdav

--- a/contrib/organice-webdav-traefik/run.sh
+++ b/contrib/organice-webdav-traefik/run.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+if [ ! -f /etc/nginx/nginx.conf ]; then
+
+    echo "Configure WebDAV"
+
+    export DAV_METHODS=${DAV_METHODS:=PUT DELETE MKCOL COPY MOVE}
+    PUID=${PUID}
+    PGID=${PGID}
+    export WEBDAV_PREFIX=${WEBDAV_PREFIX:=/}
+    #TZ
+
+    export USER
+    export GROUP
+
+    if [ -n "$PGID" ]; then
+        echo "Creating group"
+        addgroup -g "$PGID" group
+        GROUP=group
+    fi
+
+    if [ -n "$PUID" ]; then
+        echo "Creating user"
+        if [ -n "$PGID" ]; then
+            adduser --disabled-password --uid "$PUID" --ingroup group user
+        else
+            adduser --disabled-password --uid "$PUID" user
+        fi
+        USER=user
+    else
+        USER=nginx
+	GROUP=nginx
+    fi
+
+    export LOG_FORMAT='$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for"'
+
+    chown "$USER":"$GROUP" /var/lib/nginx /var/lib/nginx/tmp
+    
+    envsubst < /etc/nginx/nginx.template.conf > /etc/nginx/nginx.conf
+
+fi
+
+echo "Start !"
+
+exec nginx -g "daemon off;"

--- a/contrib/organice-webdav-traefik/webdav.conf
+++ b/contrib/organice-webdav-traefik/webdav.conf
@@ -1,0 +1,42 @@
+include /etc/nginx/modules/http_dav_ext.conf;
+user ${USER} ${GROUP};
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '${LOG_FORMAT}';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+
+    server {
+        listen 80;
+        access_log /var/log/nginx/access.log;
+        error_log /var/log/nginx/error.log info;
+        client_max_body_size 0;
+        location ~ ^/${WEBDAV_PREFIX}(?:/(.*))?$ {
+            alias /data/$1;
+            autoindex on;
+            dav_methods ${DAV_METHODS}; # put "off" for readonly else PUT DELETE MKCOL COPY MOVE
+            dav_access user:rw group:rw all:r;
+            dav_ext_methods PROPFIND OPTIONS;
+        }
+    }
+
+}
+
+
+


### PR DESCRIPTION
This uses the [official organice Docker
image](https://organice.200ok.ch/documentation.html#docker), but adds
instructions on how to build a Docker image using
[Traefik](https://traefik.io/) to set up a WebDAV back-end for organice.

Author:

-   Sourcehut: <https://git.sr.ht/~e-v/>
-   Email: e-v\@posteo.net

Upstream repository: <https://git.sr.ht/~e-v/docker-organice-webdav>