### PR TITLE
persist files to localStorage

### DIFF
--- a/src/actions/base.js
+++ b/src/actions/base.js
@@ -1,4 +1,5 @@
-import { parseFile, resetFileDisplay } from './org';
+import { parseFile, resetFileDisplay, setPath } from './org';
+import { STATIC_FILE_PREFIX } from '../lib/org_utils';
 
 import raw from 'raw.macro';
 
@@ -22,24 +23,22 @@ export const setDisappearingLoadingMessage = (loadingMessage, delay) => (dispatc
   setTimeout(() => dispatch(hideLoadingMessage()), delay);
 };
 
-export const setLastViewedFile = (lastViewedPath, lastViewedContents) => ({
+export const setLastViewedFile = (lastViewedPath) => ({
   type: 'SET_LAST_VIEWED_FILE',
   lastViewedPath,
-  lastViewedContents,
 });
 
 export const loadStaticFile = (staticFile) => {
   return (dispatch, getState) => {
-    dispatch(
-      setLastViewedFile(getState().org.present.get('path'), getState().org.present.get('contents'))
-    );
+    dispatch(setLastViewedFile(getState().org.present.get('path')));
 
     const fileContents = {
       changelog: raw('../../changelog.org'),
       sample: raw('../../sample.org'),
     }[staticFile];
 
-    dispatch(parseFile(null, fileContents));
+    dispatch(parseFile(STATIC_FILE_PREFIX + staticFile, fileContents));
+    dispatch(setPath(STATIC_FILE_PREFIX + staticFile));
   };
 };
 
@@ -47,10 +46,9 @@ export const unloadStaticFile = () => {
   return (dispatch, getState) => {
     dispatch(resetFileDisplay());
 
-    if (!!getState().base.get('lastViewedPath')) {
-      dispatch(
-        parseFile(getState().base.get('lastViewedPath'), getState().base.get('lastViewedContents'))
-      );
+    const path = getState().base.get('lastViewedPath');
+    if (!!path) {
+      dispatch(setPath(path));
     }
   };
 };

--- a/src/actions/org.js
+++ b/src/actions/org.js
@@ -16,7 +16,7 @@ import sampleCaptureTemplates from '../lib/sample_capture_templates';
 
 import { isAfter, addSeconds } from 'date-fns';
 import { parseISO } from 'date-fns';
-import { saveFileContentsToLocalStorage } from '../util/file_persister';
+import { persistIsDirty, saveFileContentsToLocalStorage } from '../util/file_persister';
 
 export const parseFile = (path, contents) => (dispatch) => {
   saveFileContentsToLocalStorage(path, contents);
@@ -381,11 +381,14 @@ export const applyOpennessState = () => ({
   type: 'APPLY_OPENNESS_STATE',
 });
 
-export const setDirty = (isDirty, path) => ({
-  type: 'SET_DIRTY',
-  isDirty,
-  path,
-});
+export const setDirty = (isDirty, path) => (dispatch) => {
+  persistIsDirty(isDirty, path);
+  dispatch({
+    type: 'SET_DIRTY',
+    isDirty,
+    path,
+  });
+};
 
 export const setSelectedTableCellId = (cellId) => (dispatch) => {
   dispatch({ type: 'SET_SELECTED_TABLE_CELL_ID', cellId });

--- a/src/actions/org.js
+++ b/src/actions/org.js
@@ -10,7 +10,7 @@ import {
 } from './base';
 import { exportOrg } from '../lib/export_org';
 import substituteTemplateVariables from '../lib/capture_template_substitution';
-import { headerWithPath } from '../lib/org_utils';
+import { headerWithPath, STATIC_FILE_PREFIX } from '../lib/org_utils';
 
 import sampleCaptureTemplates from '../lib/sample_capture_templates';
 
@@ -106,7 +106,7 @@ const doSync = ({
   const client = getState().syncBackend.get('client');
   const currentPath = getState().org.present.get('path');
   path = path || currentPath;
-  if (!path) {
+  if (!path || path.startsWith(STATIC_FILE_PREFIX)) {
     return;
   }
 

--- a/src/actions/org.js
+++ b/src/actions/org.js
@@ -38,6 +38,7 @@ export const resetFileDisplay = () => {
     dispatch(widenHeader());
     dispatch(closePopup());
     dispatch({ type: 'CLEAR_SEARCH' });
+    dispatch(setPath(null));
     dispatch(ActionCreators.clearHistory());
   };
 };
@@ -381,13 +382,15 @@ export const applyOpennessState = () => ({
   type: 'APPLY_OPENNESS_STATE',
 });
 
+export const dirtyAction = (isDirty, path) => ({
+  type: 'SET_DIRTY',
+  isDirty,
+  path,
+});
+
 export const setDirty = (isDirty, path) => (dispatch) => {
   persistIsDirty(isDirty, path);
-  dispatch({
-    type: 'SET_DIRTY',
-    isDirty,
-    path,
-  });
+  dispatch(dirtyAction(isDirty, path));
 };
 
 export const setSelectedTableCellId = (cellId) => (dispatch) => {

--- a/src/actions/sync_backend.js
+++ b/src/actions/sync_backend.js
@@ -106,7 +106,7 @@ export const pushBackup = (pathOrFileId, contents) => {
 
 export const downloadFile = (path) => {
   return (dispatch, getState) => {
-    dispatch(setLoadingMessage('Downloading file...'));
+    dispatch(setLoadingMessage(`Downloading file ${path}...`));
     getState()
       .syncBackend.get('client')
       .getFileContents(path)

--- a/src/components/Entry/index.js
+++ b/src/components/Entry/index.js
@@ -10,7 +10,7 @@ import { List, Set } from 'immutable';
 import _ from 'lodash';
 import classNames from 'classnames';
 
-import { changelogHash } from '../../lib/org_utils';
+import { changelogHash, STATIC_FILE_PREFIX } from '../../lib/org_utils';
 import PrivacyPolicy from '../PrivacyPolicy';
 import HeaderBar from '../HeaderBar';
 import Landing from '../Landing';
@@ -117,7 +117,11 @@ class Entry extends PureComponent {
     if (!!path) {
       path = '/' + path;
     }
-    if (this.props.path && this.props.path !== path) {
+    if (
+      this.props.path &&
+      !this.props.path.startsWith(STATIC_FILE_PREFIX) &&
+      this.props.path !== path
+    ) {
       return <Redirect push to={'/file' + this.props.path} />;
     } else {
       return (
@@ -132,7 +136,12 @@ class Entry extends PureComponent {
   }
 
   shouldPromptWhenLeaving() {
-    return this.props.location.pathname.startsWith('/file/') && this.props.isDirty;
+    return (
+      this.props.location.pathname.startsWith('/file/') &&
+      this.props.path &&
+      !this.props.path.startsWith(STATIC_FILE_PREFIX) &&
+      this.props.isDirty
+    );
   }
 
   render() {

--- a/src/components/HeaderBar/index.js
+++ b/src/components/HeaderBar/index.js
@@ -26,7 +26,7 @@ class HeaderBar extends PureComponent {
       'handleChangelogClick',
       'handleModalPageDoneClick',
       'handleHeaderBarTitleClick',
-      'handleSettingsSubPageBackClick',
+      'handleBackClick',
       'handleUndoClick',
       'handleRedoClick',
       'handleHelpClick',
@@ -86,7 +86,11 @@ class HeaderBar extends PureComponent {
     const directoryPath = pathParts.slice(0, pathParts.length - 1).join('/');
 
     return (
-      <Link to={`/files${directoryPath}`} className="header-bar__back-button">
+      <Link
+        to={`/files${directoryPath}`}
+        onClick={this.handleBackClick}
+        className="header-bar__back-button"
+      >
         <i className="fas fa-chevron-left" />
         <span className="header-bar__back-button__directory-path">File browser</span>
       </Link>
@@ -120,13 +124,13 @@ class HeaderBar extends PureComponent {
     );
   }
 
-  handleSettingsSubPageBackClick() {
+  handleBackClick() {
     this.props.base.popModalPage();
   }
 
   renderSettingsSubPageBackButton() {
     return (
-      <div className="header-bar__back-button" onClick={this.handleSettingsSubPageBackClick}>
+      <div className="header-bar__back-button" onClick={this.handleBackClick}>
         <i className="fas fa-chevron-left" />
         <span className="header-bar__back-button__directory-path">Settings</span>
       </div>
@@ -146,7 +150,7 @@ class HeaderBar extends PureComponent {
       case 'file_settings_editor':
         return this.renderSettingsSubPageBackButton();
       case 'sample':
-        return this.renderSettingsSubPageBackButton();
+        return this.renderOrgFileBackButton();
       default:
     }
 
@@ -229,7 +233,6 @@ class HeaderBar extends PureComponent {
   }
 
   handleHelpClick() {
-    this.props.base.pushModalPage('settings');
     this.props.base.pushModalPage('sample');
   }
 

--- a/src/components/OrgFile/OrgFile.integration.test.js
+++ b/src/components/OrgFile/OrgFile.integration.test.js
@@ -14,7 +14,7 @@ import rootReducer from '../../reducers/';
 import { setPath, parseFile } from '../../actions/org';
 import { setShouldLogIntoDrawer } from '../../actions/base';
 
-import { Map, fromJS } from 'immutable';
+import { Map, Set, fromJS } from 'immutable';
 import { formatDistanceToNow } from 'date-fns';
 
 import { render, fireEvent, cleanup } from '@testing-library/react';
@@ -46,7 +46,14 @@ describe('Render all views', () => {
       {
         org: {
           past: [],
-          present: Map(),
+          present: Map({
+            files: Map(),
+            fileSettings: [],
+            search: Map({
+              searchFilter: '',
+              searchFilterExpr: [],
+            }),
+          }),
           future: [],
         },
         syncBackend: Map({
@@ -56,6 +63,7 @@ describe('Render all views', () => {
         base: new fromJS({
           customKeybindings: {},
           shouldTapTodoToAdvance: true,
+          isLoading: Set(),
         }),
       },
       applyMiddleware(thunk)

--- a/src/components/OrgFile/components/AgendaModal/components/AgendaDay/AgendaDay.unit.test.js
+++ b/src/components/OrgFile/components/AgendaModal/components/AgendaDay/AgendaDay.unit.test.js
@@ -2,16 +2,10 @@ import { parseOrg } from '../../../../../../lib/parse_org';
 
 import AgendaDay from './index';
 
+import { Map } from 'immutable';
 import { parseISO } from 'date-fns';
 
 import readFixture from '../../../../../../../test_helpers/index';
-
-function parseOrgFile(testOrgFile) {
-  const parsedFile = parseOrg(testOrgFile);
-  const headers = parsedFile.get('headers');
-  const todoKeywordSets = parsedFile.get('todoKeywordSets');
-  return { headers, todoKeywordSets };
-}
 
 describe('Unit Tests for AgendaDay', () => {
   const component = new AgendaDay();
@@ -47,6 +41,7 @@ describe('Unit Tests for AgendaDay', () => {
           rawDescription: '\n',
           description: [{ type: 'text', contents: '\n' }],
           opened: false,
+          path: '/testfile.org',
           id: 4,
           logNotes: [],
           nestingLevel: 1,
@@ -65,9 +60,8 @@ describe('Unit Tests for AgendaDay', () => {
       ],
     ];
     const testOrgFile = readFixture('multiple_headlines_with_timestamps_simple');
-    const parsedOrgFile = parseOrgFile(testOrgFile);
-    input.headers = parsedOrgFile.headers;
-    input.todoKeywordSets = parsedOrgFile.todoKeywordSets;
+    const parsedOrgFile = parseOrg(testOrgFile);
+    input.files = Map({ '/testfile.org': parsedOrgFile });
 
     expect(JSON.parse(JSON.stringify(component.getPlanningItemsAndHeaders(input)))).toEqual(output);
   });

--- a/src/components/OrgFile/index.js
+++ b/src/components/OrgFile/index.js
@@ -91,7 +91,9 @@ class OrgFile extends PureComponent {
       setTimeout(() => (document.querySelector('html').scrollTop = 0), 0);
     } else if (!_.isEmpty(path)) {
       if (this.props.fileIsLoaded(path)) {
-        this.props.org.sync({ path, shouldSuppressMessages: true });
+        if (this.props.shouldLiveSync) {
+          this.props.org.sync({ path, shouldSuppressMessages: true });
+        }
       } else {
         this.props.syncBackend.downloadFile(path);
       }
@@ -528,6 +530,7 @@ const mapStateToProps = (state) => {
     selectedHeader: headers && headers.find((header) => header.get('id') === selectedHeaderId),
     customKeybindings: state.base.get('customKeybindings'),
     shouldLogIntoDrawer: state.base.get('shouldLogIntoDrawer'),
+    shouldLiveSync: state.base.get('shouldLiveSync'),
     inEditMode: !!file ? file.get('editMode') : null,
     activePopupType: !!activePopup ? activePopup.get('type') : null,
     activePopupData: !!activePopup ? activePopup.get('data') : null,

--- a/src/components/OrgFile/index.js
+++ b/src/components/OrgFile/index.js
@@ -76,7 +76,7 @@ class OrgFile extends PureComponent {
   }
 
   componentDidMount() {
-    const { staticFile, path, loadedPath } = this.props;
+    const { staticFile, path } = this.props;
 
     if (!!staticFile) {
       this.props.base.loadStaticFile(staticFile);
@@ -89,9 +89,9 @@ class OrgFile extends PureComponent {
       }
 
       setTimeout(() => (document.querySelector('html').scrollTop = 0), 0);
-    } else if (!_.isEmpty(path) && path !== loadedPath) {
+    } else if (!_.isEmpty(path)) {
       if (this.props.fileIsLoaded(path)) {
-        this.props.org.sync({ path });
+        this.props.org.sync({ path, shouldSuppressMessages: true });
       } else {
         this.props.syncBackend.downloadFile(path);
       }
@@ -511,10 +511,10 @@ class OrgFile extends PureComponent {
 
 const mapStateToProps = (state) => {
   const files = state.org.present.get('files');
-  const loadedPath = state.org.present.get('path');
+  const path = state.org.present.get('path');
   const loadedFiles = Set.fromKeys(files);
   const fileIsLoaded = (path) => loadedFiles.includes(path);
-  const file = state.org.present.getIn(['files', loadedPath]);
+  const file = state.org.present.getIn(['files', path]);
   const headers = file ? file.get('headers') : null;
   const selectedHeaderId = file ? file.get('selectedHeaderId') : null;
   const activePopup = state.base.get('activePopup');
@@ -524,7 +524,6 @@ const mapStateToProps = (state) => {
     headers,
     selectedHeaderId,
     isDirty: file ? file.get('isDirty') : null,
-    loadedPath,
     fileIsLoaded,
     selectedHeader: headers && headers.find((header) => header.get('id') === selectedHeaderId),
     customKeybindings: state.base.get('customKeybindings'),

--- a/src/components/OrgFile/index.js
+++ b/src/components/OrgFile/index.js
@@ -298,8 +298,8 @@ class OrgFile extends PureComponent {
             lastServerModifiedAt={activePopupData.get('lastServerModifiedAt')}
             lastSyncAt={activePopupData.get('lastSyncAt')}
             path={activePopupData.get('path')}
-            onPull={this.handleSyncConfirmationPull}
-            onPush={this.handleSyncConfirmationPush}
+            onPull={() => this.handleSyncConfirmationPull(activePopupData.get('path'))}
+            onPush={() => this.handleSyncConfirmationPush(activePopupData.get('path'))}
             onCancel={this.handleSyncConfirmationCancel}
           />
         );

--- a/src/components/OrgFile/index.js
+++ b/src/components/OrgFile/index.js
@@ -311,7 +311,6 @@ class OrgFile extends PureComponent {
           const file = files.get(path);
           headersOfCaptureTarget = file ? file.get('headers') : List();
         }
-        console.debug(headersOfCaptureTarget);
         return (
           <CaptureModal
             template={template}

--- a/src/lib/org_utils.js
+++ b/src/lib/org_utils.js
@@ -7,6 +7,8 @@ import generateId from './id_generator';
 import { attributedStringToRawText } from './export_org';
 import substituteTemplateVariables from './capture_template_substitution';
 
+export const STATIC_FILE_PREFIX = 'organice_internal_';
+
 function generateHash(list) {
   return new Promise((resolve, reject) => {
     if (crypto.subtle) {
@@ -706,7 +708,13 @@ const getBreadcrumbs = (headers, headerId) => {
 
 export const getBreadcrumbsStringFunction = (allHeaders, path) => {
   const allHeadersOfFile = allHeaders.get(path);
-  const filename = path.substring(path.lastIndexOf('/') + 1, path.lastIndexOf('.'));
+
+  let filename;
+  if (path.startsWith(STATIC_FILE_PREFIX)) {
+    filename = path.substring(STATIC_FILE_PREFIX.length);
+  } else {
+    filename = path.substring(path.lastIndexOf('/') + 1, path.lastIndexOf('.'));
+  }
 
   return (header) => {
     let breadcrumbs = getBreadcrumbs(allHeadersOfFile, header.get('id'));

--- a/src/middleware/live_sync.js
+++ b/src/middleware/live_sync.js
@@ -1,5 +1,5 @@
 import { sync } from '../actions/org';
-import { saveFileToLocalStorage } from '../util/file_persister';
+import { persistIsDirty, saveFileToLocalStorage } from '../util/file_persister';
 import { determineAffectedFiles } from '../reducers/org';
 
 export default (store) => (next) => (action) => {
@@ -9,6 +9,7 @@ export default (store) => (next) => (action) => {
     let dirtyFiles = determineAffectedFiles(store.getState().org.present, action);
 
     dirtyFiles.forEach((path) => saveFileToLocalStorage(store.getState(), path));
+    dirtyFiles.forEach((path) => persistIsDirty(true, path));
 
     if (store.getState().base.get('shouldLiveSync')) {
       dirtyFiles.forEach((path) => store.dispatch(sync({ shouldSuppressMessages: true, path })));

--- a/src/migrations/migrate_access_token_to_dropbox_access_token.js
+++ b/src/migrations/migrate_access_token_to_dropbox_access_token.js
@@ -1,7 +1,7 @@
-import { isLocalStorageAvailable } from '../util/settings_persister';
+import { localStorageAvailable } from '../util/settings_persister';
 
 export default () => {
-  if (!isLocalStorageAvailable) {
+  if (!localStorageAvailable) {
     return;
   }
 

--- a/src/migrations/migrate_store_in_dropbox_to_store_in_sync_backend.js
+++ b/src/migrations/migrate_store_in_dropbox_to_store_in_sync_backend.js
@@ -1,7 +1,7 @@
-import { isLocalStorageAvailable } from '../util/settings_persister';
+import { localStorageAvailable } from '../util/settings_persister';
 
 export default () => {
-  if (!isLocalStorageAvailable) {
+  if (!localStorageAvailable) {
     return;
   }
 

--- a/src/reducers/base.js
+++ b/src/reducers/base.js
@@ -53,10 +53,7 @@ const setHasUnseenChangelog = (state, action) =>
 const setLastSeenChangelogHeader = (state, action) =>
   state.set('lastSeenChangelogHash', action.newLastSeenChangelogHash);
 
-const setLastViewedFile = (state, action) =>
-  state
-    .set('lastViewedPath', action.lastViewedPath)
-    .set('lastViewedContents', action.lastViewedContents);
+const setLastViewedFile = (state, action) => state.set('lastViewedPath', action.lastViewedPath);
 
 const setCustomKeybinding = (state, action) => {
   if (!state.get('customKeybindings')) {

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -55,12 +55,9 @@ import { timestampForDate, getTimestampAsText, applyRepeater } from '../lib/time
 import generateId from '../lib/id_generator';
 import { formatTextWrap } from '../util/misc';
 import { applyFileSettingsFromConfig } from '../util/settings_persister';
-import { saveFileContentsToLocalStorage } from '../util/file_persister';
 
 export const parseFile = (state, action) => {
   const { path, contents } = action;
-
-  saveFileContentsToLocalStorage(path, contents);
 
   const parsedFile = parseOrg(contents);
 

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -1116,7 +1116,7 @@ export const setSearchFilterInformation = (state, action) => {
     state.setIn(['search', 'showClockedTimes'], showClockedTimes);
 
     // Only search subheaders if a header is narrowed
-    const narrowedHeaderId = state.get('narrowedHeaderId');
+    const narrowedHeaderId = state.getIn(['files', path, 'narrowedHeaderId']);
     let headersToSearch;
     if (!narrowedHeaderId || context === 'refile') {
       headersToSearch = headers;

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -1158,8 +1158,9 @@ export const setSearchFilterInformation = (state, action) => {
     // Filter selectedHeader and its subheaders from `headers`,
     // because you don't want to refile a header to itself or to one
     // of its subheaders.
+    console.debug('SEARCHING');
     if (context === 'refile') {
-      const selectedHeaderId = state.get('selectedHeaderId');
+      const selectedHeaderId = state.getIn(['files', path, 'selectedHeaderId']);
       const subheaders = subheadersOfHeaderWithId(headers.get(path), selectedHeaderId);
       let filterIds = subheaders.map((s) => s.get('id')).toJS();
       filterIds.push(selectedHeaderId);

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -68,7 +68,7 @@ export const parseFile = (state, action) => {
     .setIn(['files', path, 'linesBeforeHeadings'], parsedFile.get('linesBeforeHeadings'));
 };
 
-const clearSearch = (state) => state.set('path', null).setIn(['search', 'filteredHeaders'], null);
+const clearSearch = (state) => state.setIn(['search', 'filteredHeaders'], null);
 
 const openHeader = (state, action) => {
   const headers = state.get('headers');

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -1158,7 +1158,6 @@ export const setSearchFilterInformation = (state, action) => {
     // Filter selectedHeader and its subheaders from `headers`,
     // because you don't want to refile a header to itself or to one
     // of its subheaders.
-    console.debug('SEARCHING');
     if (context === 'refile') {
       const selectedHeaderId = state.getIn(['files', path, 'selectedHeaderId']);
       const subheaders = subheadersOfHeaderWithId(headers.get(path), selectedHeaderId);
@@ -1414,7 +1413,9 @@ export default (state = Map(), action) => {
   state = reducer(state, action);
 
   if (action.dirtying && state.get('showClockDisplay')) {
-    state = state.update('headers', updateHeadersTotalTimeLoggedRecursive);
+    affectedFiles.forEach((path) => {
+      state = state.updateIn(['files', path, 'headers'], updateHeadersTotalTimeLoggedRecursive);
+    });
   }
   return state;
 };

--- a/src/util/file_persister.js
+++ b/src/util/file_persister.js
@@ -1,0 +1,66 @@
+import { debounce } from 'lodash';
+import { localStorageAvailable } from '../util/settings_persister';
+import { exportOrg } from '../lib/export_org';
+import { parseFile } from '../reducers/org';
+
+export const saveFileContentsToLocalStorage = (path, contents) => {
+  if (localStorageAvailable) {
+    let persistedFiles = JSON.parse(localStorage.getItem('persistedFiles'));
+    persistedFiles = persistedFiles || [];
+
+    localStorage.setItem('files__' + path, contents);
+    if (persistedFiles.indexOf(path) === -1) {
+      persistedFiles.push(path);
+    }
+
+    localStorage.setItem('persistedFiles', JSON.stringify(persistedFiles));
+  }
+};
+
+const saveFunctionToDebounce = (state, path) => {
+  if (localStorageAvailable) {
+    let persistedFiles = JSON.parse(localStorage.getItem('persistedFiles'));
+    persistedFiles = persistedFiles || [];
+
+    const contents = exportOrg({
+      headers: state.org.present.getIn(['files', path, 'headers']),
+      linesBeforeHeadings: state.org.present.getIn(['files', path, 'linesBeforeHeadings']),
+      dontIndent: state.base.get('shouldNotIndentOnExport'),
+    });
+    localStorage.setItem('files__' + path, contents);
+    if (persistedFiles.indexOf(path) === -1) {
+      persistedFiles.push(path);
+    }
+
+    localStorage.setItem('persistedFiles', JSON.stringify(persistedFiles));
+  }
+};
+const getDebouncedSaveFunction = () =>
+  debounce(saveFunctionToDebounce, 3000, {
+    leading: true,
+    trailing: true,
+  });
+const debouncedSaveFunctions = {};
+export const saveFileToLocalStorage = (state, path) => {
+  // to make sure no file is skipped when multiple files are dirty
+  // a seperately debounced function is used per file
+  let debouncedSaveFunction = debouncedSaveFunctions[path];
+  if (!debouncedSaveFunction) {
+    debouncedSaveFunctions[path] = getDebouncedSaveFunction();
+    debouncedSaveFunction = debouncedSaveFunctions[path];
+  }
+  debouncedSaveFunction(state, path);
+};
+
+export const loadFilesFromLocalStorage = (state) => {
+  if (localStorageAvailable) {
+    const persistedFiles = JSON.parse(localStorage.getItem('persistedFiles')) || [];
+    persistedFiles.forEach((path) => {
+      const contents = localStorage.getItem('files__' + path);
+      if (contents) {
+        state.org.present = state.org.present.update((org) => parseFile(org, { path, contents }));
+      }
+    });
+  }
+  return state;
+};

--- a/src/util/file_persister.js
+++ b/src/util/file_persister.js
@@ -3,6 +3,7 @@ import { parseISO, addSeconds } from 'date-fns';
 import { localStorageAvailable } from '../util/settings_persister';
 import { exportOrg } from '../lib/export_org';
 import { parseFile } from '../reducers/org';
+import { STATIC_FILE_PREFIX } from '../lib/org_utils';
 
 export const persistIsDirty = (isDirty, path) => {
   if (localStorageAvailable) {
@@ -13,7 +14,7 @@ export const persistIsDirty = (isDirty, path) => {
 };
 
 export const saveFileContentsToLocalStorage = (path, contents) => {
-  if (localStorageAvailable) {
+  if (localStorageAvailable && !path.startsWith(STATIC_FILE_PREFIX)) {
     let persistedFiles = JSON.parse(localStorage.getItem('persistedFiles'));
     persistedFiles = persistedFiles || {};
 
@@ -25,7 +26,7 @@ export const saveFileContentsToLocalStorage = (path, contents) => {
 };
 
 const saveFunctionToDebounce = (state, path) => {
-  if (localStorageAvailable) {
+  if (localStorageAvailable && !path.startsWith(STATIC_FILE_PREFIX)) {
     const persistedFiles = JSON.parse(localStorage.getItem('persistedFiles')) || {};
 
     const contents = exportOrg({

--- a/src/util/file_persister.js
+++ b/src/util/file_persister.js
@@ -4,6 +4,14 @@ import { localStorageAvailable } from '../util/settings_persister';
 import { exportOrg } from '../lib/export_org';
 import { parseFile } from '../reducers/org';
 
+export const persistIsDirty = (isDirty, path) => {
+  if (localStorageAvailable) {
+    const filesDirty = JSON.parse(localStorage.getItem('isDirty')) || {};
+    filesDirty[path] = isDirty;
+    localStorage.setItem('isDirty', JSON.stringify(filesDirty));
+  }
+};
+
 export const saveFileContentsToLocalStorage = (path, contents) => {
   if (localStorageAvailable) {
     let persistedFiles = JSON.parse(localStorage.getItem('persistedFiles'));
@@ -51,6 +59,7 @@ export const saveFileToLocalStorage = (state, path) => {
 export const loadFilesFromLocalStorage = (state) => {
   if (localStorageAvailable) {
     const persistedFiles = JSON.parse(localStorage.getItem('persistedFiles')) || {};
+    const isDirty = JSON.parse(localStorage.getItem('isDirty')) || {};
     Object.entries(persistedFiles).forEach(([path, lastSyncAt]) => {
       const contents = localStorage.getItem('files__' + path);
       if (contents) {
@@ -59,6 +68,7 @@ export const loadFilesFromLocalStorage = (state) => {
           ['files', path, 'lastSyncAt'],
           parseISO(lastSyncAt)
         );
+        state.org.present = state.org.present.setIn(['files', path, 'isDirty'], isDirty[path]);
       }
     });
   }

--- a/src/util/settings_persister.js
+++ b/src/util/settings_persister.js
@@ -8,15 +8,16 @@ import { restoreCaptureSettings } from '../actions/capture';
 import { restoreFileSettings } from '../actions/org';
 
 import generateId from '../lib/id_generator';
+import { loadFilesFromLocalStorage } from './file_persister';
 
-export const isLocalStorageAvailable = () => {
+export const localStorageAvailable = (() => {
   try {
     localStorage.setItem('test', 'test');
     return localStorage.getItem('test') === 'test';
   } catch (e) {
     return false;
   }
-};
+})();
 
 const debouncedPushConfigToSyncBackend = _.debounce(
   (syncBackendClient, contents) => {
@@ -217,7 +218,7 @@ export const applyFileSettingsFromConfig = (state, config) => {
 };
 
 export const readInitialState = () => {
-  if (!isLocalStorageAvailable()) {
+  if (!localStorageAvailable) {
     return undefined;
   }
 
@@ -289,6 +290,8 @@ export const readInitialState = () => {
     getFieldsToPersist(initialState, persistableFields)
   );
 
+  initialState = loadFilesFromLocalStorage(initialState);
+
   return initialState;
 };
 
@@ -329,7 +332,7 @@ export const loadSettingsFromConfigFile = (dispatch, getState) => {
 };
 
 export const subscribeToChanges = (store) => {
-  if (!isLocalStorageAvailable()) {
+  if (!localStorageAvailable) {
     return () => {};
   } else {
     return () => {
@@ -368,7 +371,7 @@ export const subscribeToChanges = (store) => {
 };
 
 export const persistField = (field, value) => {
-  if (!isLocalStorageAvailable()) {
+  if (!localStorageAvailable) {
     return;
   } else {
     localStorage.setItem(field, value);
@@ -376,7 +379,7 @@ export const persistField = (field, value) => {
 };
 
 export const getPersistedField = (field, nullable = false) => {
-  if (!isLocalStorageAvailable()) {
+  if (!localStorageAvailable) {
     return null;
   } else {
     const value = localStorage.getItem(field);

--- a/src/util/settings_persister.js
+++ b/src/util/settings_persister.js
@@ -218,10 +218,6 @@ export const applyFileSettingsFromConfig = (state, config) => {
 };
 
 export const readInitialState = () => {
-  if (!localStorageAvailable) {
-    return undefined;
-  }
-
   let initialState = {
     syncBackend: Map(),
     org: {
@@ -229,6 +225,7 @@ export const readInitialState = () => {
       present: Map({
         files: Map(),
         fileSettings: [],
+        opennessState: Map(),
         search: Map({
           searchFilter: '',
           searchFilterExpr: [],
@@ -236,9 +233,13 @@ export const readInitialState = () => {
       }),
       future: [],
     },
-    base: Map().set('isLoading', Set()),
+    base: Map({ isLoading: Set() }),
     capture: Map(),
   };
+
+  if (!localStorageAvailable) {
+    return initialState;
+  }
 
   persistableFields.forEach((field) => {
     let value = localStorage.getItem(field.name);


### PR DESCRIPTION
part of #570

This approach saves the text of the files to localStorage. Saving the parsed file is problematic since `generateId` starts over at zero when the application is reset.

Writing to localStorage is debounced, wich is probably not really necessary, but it seemed right to do it the same way as syncing to backend.