### PR TITLE
fix: Parser does not swallow property values

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -4,6 +4,13 @@ All user visible changes to organice will be documented in this file.
 
 When there are updates to the changelog, you will be notified and see a 'gift' icon appear on the top right corner.
 
+* [2020-11-20 Fri]
+** Fixed
+   - organice understands =:PROPERTIES:= drawers and smartly parses the values in case one of the values is a timestamp.
+     - However, parsing all the values and saving the parsed result in any case will lead to wrong results. Most values of properties are just plain text and non-interactive things in Org mode.
+     - For example, a value like =something_with_underscores= would have been treated as 'underlined text' which doesn't make sense for a property drawer. When saving the value back, organice would have squashed the underlines.
+     - Now, the values are used and preserved as they are. Timestamps still work, of course.
+     - Relevant PR: https://github.com/200ok-ch/organice/pull/578
 * [2020-11-15 Sun]
 ** Fixed
    - When repeating a task, an active date timestamp was logged instead of an inactive datetime timestamp.

--- a/src/components/OrgFile/OrgFile.unit.test.js
+++ b/src/components/OrgFile/OrgFile.unit.test.js
@@ -127,7 +127,7 @@ ${text}`;
 
   describe('Parsing and exporting should not alter the original file', () => {
     test("Parsing and exporting shouldn't alter the original file", () => {
-      const testOrgFile = readFixture('indented_list');
+      const testOrgFile = readFixture('all_the_features');
       const exportedFile = parseAndExportOrgFile(testOrgFile);
 
       // Should have the same amount of lines. Safeguard for the next
@@ -167,6 +167,12 @@ ${text}`;
 
     test('Parse very basic file with one header, one line of description', () => {
       const testOrgFile = '* Header\nabc\n';
+      const exportedFile = parseAndExportOrgFile(testOrgFile);
+      expect(exportedFile).toEqual(testOrgFile);
+    });
+
+    test('Parse a header with PROPERTIES', () => {
+      const testOrgFile = '* Header\n  :PROPERTIES:\n  :CUSTOM_ID: link_to_me\n  :END:\n';
       const exportedFile = parseAndExportOrgFile(testOrgFile);
       expect(exportedFile).toEqual(testOrgFile);
     });

--- a/src/lib/parse_org.js
+++ b/src/lib/parse_org.js
@@ -562,7 +562,14 @@ const parsePropertyList = (rawText) => {
           return null;
         }
 
-        const value = !!match[2] ? parseMarkupAndCookies(match[2]) : null;
+        // Parse the properties value even though most values would
+        // not need parsing. Only timestamps are interactive, the rest
+        // will be saved as plain text.
+        let value = !!match[2] ? parseMarkupAndCookies(match[2]) : null;
+
+        if (value && value[0].type !== 'timestamp') {
+          value = [{ contents: match[2], type: 'text' }];
+        }
 
         return {
           property: match[1],

--- a/test_helpers/fixtures/all_the_features.org
+++ b/test_helpers/fixtures/all_the_features.org
@@ -20,7 +20,10 @@
 
 # Complex TODO with priority, active timestamp, link to an email and a tag
 **** TODO [#B] <2019-05-02 Thu> Some Person [[mu4e:msgid:CAN6MX5o-i9koRnBXGOFQ-wLUhp82mGCwFSxo0b2i0+TROYNZkg@mail.gmail.com][Re: HÖCHENSCHWAND 05.Februar 2019]] :200ok:
-
+*** Header with =CUSTOM_ID= property
+    :PROPERTIES:
+    :CUSTOM_ID: link_to_me
+    :END:
 *** Planning items
 
 **** TODO I am scheduled
@@ -102,7 +105,7 @@ qui dolorem eum fugiat quo voluptas nulla pariatur?"
    CLOCK: [2019-11-11 Mon 13:12]--[2019-11-12 Tue 13:12] => 24:00
    CLOCK: [2019-10-13 Sun 12:15]--[2019-10-13 Sun 14:12] =>  1:57
    :END:
-** A messy headline with trailing whitespace                    
+** A messy headline with trailing whitespace
 
 organice's parser is build on the premise that it should not produce a
 diff on users Org files. Lets say there's a new user with a big file.

--- a/test_helpers/fixtures/all_the_features.org
+++ b/test_helpers/fixtures/all_the_features.org
@@ -105,7 +105,7 @@ qui dolorem eum fugiat quo voluptas nulla pariatur?"
    CLOCK: [2019-11-11 Mon 13:12]--[2019-11-12 Tue 13:12] => 24:00
    CLOCK: [2019-10-13 Sun 12:15]--[2019-10-13 Sun 14:12] =>  1:57
    :END:
-** A messy headline with trailing whitespace
+** A messy headline with trailing whitespace                    
 
 organice's parser is build on the premise that it should not produce a
 diff on users Org files. Lets say there's a new user with a big file.


### PR DESCRIPTION
organice understands `:PROPERTIES:` drawers and smartly parses the values in case one of the values is a timestamp. However, parsing _all the values_ and saving the parsed result in any case will lead to wrong results. Most values of properties are just plain text and non-interactive things in Org mode.

Hence, before this fix, we'd have problems like:

![image](https://user-images.githubusercontent.com/505721/99795381-fe010580-2b2b-11eb-9d5c-2aa2788e3ee6.png)

Because organice believed this to be text with `_` which yields underlined text.