### PR TITLE
disable swipe if not mobile | adjusted swipe response

### DIFF
--- a/src/components/Entry/index.js
+++ b/src/components/Entry/index.js
@@ -10,6 +10,7 @@ import { List, Set } from 'immutable';
 import _ from 'lodash';
 import classNames from 'classnames';
 
+import { isMobileBrowser } from '../../lib/browser_utils'
 import { changelogHash, STATIC_FILE_PREFIX } from '../../lib/org_utils';
 import PrivacyPolicy from '../PrivacyPolicy';
 import HeaderBar from '../HeaderBar';
@@ -96,6 +97,7 @@ class Entry extends PureComponent {
         shouldDisableDirtyIndicator={true}
         shouldDisableActionDrawer={false}
         shouldDisableSyncButtons={true}
+        shouldDisableSwipe={!isMobileBrowser}
         parsingErrorMessage={
           "The contents of sample.org couldn't be loaded. You probably forgot to set the environment variable - see the Development section of README.org for details!"
         }
@@ -139,6 +141,7 @@ class Entry extends PureComponent {
           shouldDisableDirtyIndicator={false}
           shouldDisableActionDrawer={false}
           shouldDisableSyncButtons={false}
+          shouldDisableSwipe={!isMobileBrowser}
         />
       );
     }

--- a/src/components/OrgFile/components/Header/components/HeaderActionDrawer/index.js
+++ b/src/components/OrgFile/components/Header/components/HeaderActionDrawer/index.js
@@ -35,6 +35,9 @@ export default class HeaderActionDrawer extends PureComponent {
       onShareHeader,
       onRefileHeader,
       onAddNote,
+      onAdvanceToDoState,
+      onDeleteHeader,
+      swipeDisabled,
     } = this.props;
 
     return (
@@ -85,6 +88,15 @@ export default class HeaderActionDrawer extends PureComponent {
             testId: 'header-action-plus',
             title: 'Create new header below',
           })}
+          
+          { swipeDisabled 
+            ? this.iconWithFFClickCatcher({
+                className: 'fas btn fa-lg',
+                onClick: onDeleteHeader,
+                title: 'Remove Header',
+              })
+            : null
+          }
         </div>
 
         <div className="header-action-drawer__row">
@@ -129,6 +141,14 @@ export default class HeaderActionDrawer extends PureComponent {
             onClick: onAddNote,
             title: 'Add a note',
           })}
+          { swipeDisabled
+            ? this.iconWithFFClickCatcher({
+                className: 'fas btn fa-lg',
+                onClick: onAdvanceToDoState,
+                title: 'Advance ToDo State',
+              })
+            : null 
+          }
         </div>
       </div>
     );

--- a/src/components/OrgFile/components/Header/index.js
+++ b/src/components/OrgFile/components/Header/index.js
@@ -22,8 +22,8 @@ import { interpolateColors, rgbaObject, rgbaString, readRgbaVariable } from '../
 import { getCurrentTimestamp, millisDuration } from '../../../../lib/timestamps';
 
 class Header extends PureComponent {
-  SWIPE_ACTION_ACTIVATION_DISTANCE = 80;
-  FREE_DRAG_ACTIVATION_DISTANCE = 10;
+  SWIPE_ACTION_ACTIVATION_DISTANCE = 240;
+  FREE_DRAG_ACTIVATION_DISTANCE = 30;
 
   constructor(props) {
     super(props);
@@ -53,6 +53,8 @@ class Header extends PureComponent {
       'handleShareHeaderClick',
       'handleRefileHeaderRequest',
       'handleAddNoteClick',
+      'handleAdvanceToDoState',
+      'handleRemoveHeader',
     ]);
 
     this.state = {
@@ -79,6 +81,9 @@ class Header extends PureComponent {
   }
 
   handleDragStart(event, dragX, dragY) {
+    if (this.props.shouldDisableSwipe) {
+      return;
+    }
     if (this.props.shouldDisableActions) {
       return;
     }
@@ -225,6 +230,17 @@ class Header extends PureComponent {
     this.props.org.addHeaderAndEdit(this.props.header.get('id'));
   }
 
+  handleRemoveHeader() {
+    this.props.org.removeHeader(this.props.header.get('id'));
+  }
+
+  handleAdvanceToDoState() {
+    this.props.org.advanceTodoState(
+      this.props.header.get('id'),
+      this.props.shouldLogIntoDrawer
+    );
+  }
+
   handleRest() {
     if (this.state.isPlayingRemoveAnimation) {
       this.props.org.removeHeader(this.props.header.get('id'));
@@ -333,6 +349,7 @@ ${header.get('rawDescription')}`;
       narrowedHeader,
       isNarrowed,
       shouldDisableActions,
+      shouldDisableSwipe,
       showClockDisplay,
     } = this.props;
     const indentLevel = !!narrowedHeader
@@ -521,6 +538,9 @@ ${header.get('rawDescription')}`;
                   onShareHeader={this.handleShareHeaderClick}
                   onRefileHeader={this.handleRefileHeaderRequest}
                   onAddNote={this.handleAddNoteClick}
+                  onAdvanceToDoState={this.handleAdvanceToDoState}
+                  onDeleteHeader={this.handleRemoveHeader}
+                  swipeDisabled={shouldDisableSwipe}
                 />
               </Collapse>
 

--- a/src/components/OrgFile/components/HeaderList/index.js
+++ b/src/components/OrgFile/components/HeaderList/index.js
@@ -38,7 +38,7 @@ class HeaderList extends PureComponent {
   }
 
   render() {
-    const { headers, selectedHeaderId, narrowedHeaderId, shouldDisableActions } = this.props;
+    const { headers, selectedHeaderId, narrowedHeaderId, shouldDisableActions, shouldDisableSwipe } = this.props;
     const headerRenderData = headers
       .map((header) => {
         return {
@@ -125,7 +125,8 @@ class HeaderList extends PureComponent {
               isSelected={header.get('id') === selectedHeaderId}
               onRef={this.handleHeaderRef(header.get('id'))}
               shouldDisableActions={shouldDisableActions}
-            />
+              shouldDisableSwipe={shouldDisableSwipe}
+              />
           );
         })}
       </div>

--- a/src/components/OrgFile/index.js
+++ b/src/components/OrgFile/index.js
@@ -390,6 +390,7 @@ class OrgFile extends PureComponent {
       shouldDisableDirtyIndicator,
       shouldDisableSyncButtons,
       shouldDisableActions,
+      shouldDisableSwipe,
       isDirty,
       parsingErrorMessage,
       path,
@@ -488,7 +489,7 @@ class OrgFile extends PureComponent {
               )}
             </div>
           ) : (
-            <HeaderList shouldDisableActions={shouldDisableActions} />
+            <HeaderList shouldDisableActions={shouldDisableActions} shouldDisableSwipe={shouldDisableSwipe} />
           )}
 
           {isDirty && !shouldDisableDirtyIndicator && (


### PR DESCRIPTION
Here is what I have regarding fix #586. 

I used the isMobileBrowser tool, injecting it into Entry since it contained other props being set to disable tools. Carried that through to Header and used it in handleDragStart to avoid setting state.dragStart* values.

I decided to add buttons for removing header and advancing todo state in the HeaderActionDrawer with handlers and a flag passed in from the Header. Not sure if that is wanted but it was good practice for me and seemed reasonable. Would need feedback on icons and placement if it should stay.
 
I also multiplied the *_ACTIVATION_DISTANCE values by three and it seems like it might be a bit better regarding unintentional swipes/deletes/state changes.  I thought increasing both would help to avoid initiating free drag when scrolling and making sure you want to delete or change state by increasing the swipe activation distance.


*I am questioning now naming the prop passed in from Entry, "shouldDisableSwipe", as it is set by isMobileBrowser which may be desirable to use in other situations within OrgFile in the future?