### PR TITLE
doc: Fix test badge rendering in documentation

### DIFF
--- a/README.org
+++ b/README.org
@@ -11,7 +11,7 @@
   :CUSTOM_ID: general
   :END:
 
-Tests: [[https://circleci.com/gh/200ok-ch/organice][https://circleci.com/gh/200ok-ch/organice.svg?style=svg]]
+#+html: <p>Tests: <a href="https://circleci.com/gh/200ok-ch/organice"><img src="https://circleci.com/gh/200ok-ch/organice.svg?style=svg"></a></p>
 
 Documentation: https://organice.200ok.ch/documentation.html
 


### PR DESCRIPTION
Previously, it worked for the GH readme, but not in the official organice docs. Now it works for both.

![](https://screenshots.200ok.ch/screenshot_2020_11_30-b6f3e18f.png)
