### PR TITLE
fix: Listen to browser buttons

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -28,7 +28,7 @@ import './base.css';
 
 import Entry from './components/Entry';
 
-import { listenToBrowserButtons } from './lib/initial_setup';
+import { listenToBrowserButtons, syncOnBecomingVisible } from './lib/initial_setup';
 
 import _ from 'lodash';
 import { Map } from 'immutable';
@@ -144,6 +144,7 @@ export default class App extends PureComponent {
     this.store.dispatch(restoreStaticFile('sample'));
 
     listenToBrowserButtons(this.store);
+    syncOnBecomingVisible(this.store);
 
     _.bindAll(this, ['handleDragEnd']);
   }

--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import {
   persistField,
   getPersistedField,
 } from './util/settings_persister';
+
 import runAllMigrations from './migrations';
 import parseQueryString from './util/parse_query_string';
 import { BrowserRouter as Router } from 'react-router-dom';
@@ -26,6 +27,8 @@ import createWebDAVSyncBackendClient from './sync_backend_clients/webdav_sync_ba
 import './base.css';
 
 import Entry from './components/Entry';
+
+import { listenToBrowserButtons } from './lib/initial_setup';
 
 import _ from 'lodash';
 import { Map } from 'immutable';
@@ -139,6 +142,8 @@ export default class App extends PureComponent {
 
     // Initially load the sample file.
     this.store.dispatch(restoreStaticFile('sample'));
+
+    listenToBrowserButtons(this.store);
 
     _.bindAll(this, ['handleDragEnd']);
   }

--- a/src/lib/initial_setup.js
+++ b/src/lib/initial_setup.js
@@ -1,4 +1,7 @@
-import { setPath } from '../actions/org';
+import { debounce } from 'lodash';
+
+import { setPath, sync } from '../actions/org';
+import { STATIC_FILE_PREFIX } from './org_utils';
 
 // Generally, opening files and other routing is done with the
 // `react-router-dom` package (i.e. `<Link/ > tags). However, organice
@@ -24,3 +27,61 @@ export function listenToBrowserButtons(store) {
     }
   };
 }
+
+// BEGIN: Sync on Becoming Visible
+
+const dispatchSync = (store) => {
+  if (
+    store.getState().syncBackend.get('client') &&
+    store.getState().base.get('shouldSyncOnBecomingVisibile')
+  ) {
+    const path = store.getState().org.present.get('path');
+    let filesToLoadOnStartup = store
+      .getState()
+      .org.present.get('fileSettings')
+      .filter((setting) => setting.get('loadOnStartup'))
+      .map((setting) => setting.get('path'));
+    if (
+      path &&
+      !path.startsWith(STATIC_FILE_PREFIX) &&
+      !filesToLoadOnStartup.find((filepath) => path === filepath)
+    ) {
+      filesToLoadOnStartup = filesToLoadOnStartup.push(path);
+    }
+    filesToLoadOnStartup.forEach((path) => {
+      sync({ path, shouldSuppressMessages: true })(store.dispatch, store.getState);
+    });
+  }
+};
+
+// The 'visibilitychange' event might get triggered in some browsers
+// many times for one 'real' event of the browser becoming visible to
+// the user. Debouncing through lodash ensures that it is called at
+// maximum once every second.
+const debouncedDispatchSync = debounce(dispatchSync, 1000);
+
+// Dealing with vendor prefixes
+function getHiddenProp() {
+  const prefixes = ['webkit', 'moz', 'ms', 'o'];
+
+  // if 'hidden' is natively supported just return it
+  if ('hidden' in document) return 'hidden';
+
+  // otherwise loop over all the known prefixes until we find one
+  for (let i = 0; i < prefixes.length; i++) {
+    if (prefixes[i] + 'Hidden' in document) return prefixes[i] + 'Hidden';
+  }
+
+  // otherwise it's not supported
+  return null;
+}
+
+export function syncOnBecomingVisible(store) {
+  let visProp = getHiddenProp();
+  if (visProp) {
+    const evtname = visProp.replace(/[H|h]idden/, '') + 'visibilitychange';
+    document.addEventListener(evtname, () => debouncedDispatchSync(store));
+  }
+}
+
+// END: Sync on Becoming Visible

--- a/src/lib/initial_setup.js
+++ b/src/lib/initial_setup.js
@@ -1,0 +1,26 @@
+import { setPath } from '../actions/org';
+
+// Generally, opening files and other routing is done with the
+// `react-router-dom` package (i.e. `<Link/ > tags). However, organice
+// also should react to browser buttons.
+export function listenToBrowserButtons(store) {
+  const path = store.getState().org.present.get('path');
+
+  const urlPathMatch = window.location.href.match(/.*file(\/.*)/);
+
+  let urlPath = path;
+
+  // The user has gone 'back' or 'forward' and is showing a 'file'
+  // URL.
+  if (urlPathMatch) {
+    urlPath = urlPathMatch[1];
+  }
+
+  window.onpopstate = function () {
+    // If the current 'path' in Redux is not the same as the one in
+    // the URL.
+    if (path !== urlPath) {
+      store.dispatch(setPath(path));
+    }
+  };
+}

--- a/src/store.js
+++ b/src/store.js
@@ -2,7 +2,6 @@ import { createStore, applyMiddleware, compose } from 'redux';
 import thunk from 'redux-thunk';
 import liveSync from './middleware/live_sync';
 import toggleColorScheme from './middleware/toggle_color_scheme';
-import syncOnBecomingVisible from './middleware/sync_on_becoming_visible';
 import rootReducer from './reducers';
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
@@ -11,5 +10,5 @@ export default (initialState) =>
   createStore(
     rootReducer,
     initialState,
-    composeEnhancers(applyMiddleware(thunk, liveSync, toggleColorScheme, syncOnBecomingVisible))
+    composeEnhancers(applyMiddleware(thunk, liveSync, toggleColorScheme))
   );


### PR DESCRIPTION
As a user, when going 'back' or 'forward' in the history, I want the shown Org file and the URL to match.