### PR TITLE
Parse and preserve repeater deadlines #277

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -5,6 +5,17 @@ All user visible changes to organice will be documented in this file.
 When there are updates to the changelog, you will be notified and see
 a 'gift' icon appear on the top right corner.
 
+* [2021-05-16 Sun]
+** Added
+   - Parse and preserve habit timestamp ranges
+     - A timestamp may have minimum and maximum ranges specified by
+       using the syntax =.+2d/3d=, which says that you want to do the
+       task at least every three days, but at most every two days.
+     - Upstream documentation:
+       https://orgmode.org/manual/Tracking-your-habits.html
+     - Relevant PR: https://github.com/200ok-ch/organice/pull/674
+     - Thank you [[https://github.com/tomonacci][tomonacci]] for the PR🙏
+
 * [2021-05-13 Thu]
 
 ** Changed

--- a/sample.org
+++ b/sample.org
@@ -184,6 +184,23 @@ Try tapping on the timestamps below to get a feel for the editor:
 [2018-09-17 Sun 10:00-11:30]
 
 <2018-09-17 Sun>--<2018-09-25 Tue>
+
+** Habit tracking
+
+Org has the ability to track the consistency of a special category of
+TODO, called "habits." From the [[https://orgmode.org/manual/Tracking-your-habits.html][upstream doc]]: A timestamp may have
+minimum and maximum ranges specified by using the syntax =.+2d/3d=,
+which says that you want to do the task at least every three days, but
+at most every two days.
+
+Example timestamp: <2009-10-17 Sat .+2d/4d>
+
+organice supports parsing and preserving the minimum/maximum range
+timestamps. Alas, only the minimum range is handled as a [[https://orgmode.org/manual/Repeated-tasks.html][repeated
+task]]. There's no UI for the maximum range, it can be edited as raw
+text. Also, there is no UI to show how well a habit has been
+exercised.
+
 * Automatic/Implicit links
 
 organice recognizes various types of hyperlinks automatically which Emacs Org mode would not necessarily do. That makes sense, because mobile devices, or browsers, enable a different feature set.

--- a/src/lib/parse_org.unit.test.js
+++ b/src/lib/parse_org.unit.test.js
@@ -83,7 +83,7 @@ describe('Parse raw text', () => {
         );
       }
     }
-    function testTimestampText(text, expectedFirstTimestamp, expectedSecondTimestamp?) {
+    function testTimestampText(text, expectedFirstTimestamp, expectedSecondTimestamp) {
       // eslint-disable-next-line jest/expect-expect
       test(`Parse ${text}`, () => {
         const [{ firstTimestamp, secondTimestamp }] = parseRawText(text).toJS();

--- a/src/lib/parse_org.unit.test.js
+++ b/src/lib/parse_org.unit.test.js
@@ -69,6 +69,109 @@ describe('Parse raw text', () => {
   test('Parses simple line', () => {
     expect(parseRawText('test').toJS()).toEqual([{ type: 'text', contents: 'test' }]);
   });
+  describe('Parse various timestamps', () => {
+    function testTimestamp(actual, expected) {
+      if (expected == null) expect(actual).toBeNull();
+      else {
+        // Every key in expected should be present in actual and the values should match
+        Object.keys(expected).forEach((key) => expect(actual[key]).toEqual(expected[key]));
+        // Keys in actual that are not in expected must map to undefined
+        Object.keys(actual).forEach(
+          (key) =>
+            Object.prototype.hasOwnProperty.call(expected, key) ||
+            expect(actual[key]).toBeUndefined()
+        );
+      }
+    }
+    function testTimestampText(text, expectedFirstTimestamp, expectedSecondTimestamp?) {
+      // eslint-disable-next-line jest/expect-expect
+      test(`Parse ${text}`, () => {
+        const [{ firstTimestamp, secondTimestamp }] = parseRawText(text).toJS();
+        testTimestamp(firstTimestamp, expectedFirstTimestamp);
+        testTimestamp(secondTimestamp, expectedSecondTimestamp);
+      });
+    }
+    testTimestampText('<2021-05-16>', { isActive: true, year: '2021', month: '05', day: '16' });
+    testTimestampText('[2021-05-16]', { isActive: false, year: '2021', month: '05', day: '16' });
+    testTimestampText('<2021-05-16 Sun>', {
+      isActive: true,
+      year: '2021',
+      month: '05',
+      day: '16',
+      dayName: 'Sun',
+    });
+    testTimestampText('<2021-05-16 Sun 12:45>', {
+      isActive: true,
+      year: '2021',
+      month: '05',
+      day: '16',
+      dayName: 'Sun',
+      startHour: '12',
+      startMinute: '45',
+    });
+    testTimestampText('<2021-05-16 Sun 12:45-13:15>', {
+      isActive: true,
+      year: '2021',
+      month: '05',
+      day: '16',
+      dayName: 'Sun',
+      startHour: '12',
+      startMinute: '45',
+      endHour: '13',
+      endMinute: '15',
+    });
+    testTimestampText('<2021-05-16 Sun +1w>', {
+      isActive: true,
+      year: '2021',
+      month: '05',
+      day: '16',
+      dayName: 'Sun',
+      repeaterType: '+',
+      repeaterValue: '1',
+      repeaterUnit: 'w',
+    });
+    testTimestampText('<2021-05-16 Sun .+1w>', {
+      isActive: true,
+      year: '2021',
+      month: '05',
+      day: '16',
+      dayName: 'Sun',
+      repeaterType: '.+',
+      repeaterValue: '1',
+      repeaterUnit: 'w',
+    });
+    testTimestampText('<2021-05-16 Sun .+1w -2d>', {
+      isActive: true,
+      year: '2021',
+      month: '05',
+      day: '16',
+      dayName: 'Sun',
+      repeaterType: '.+',
+      repeaterValue: '1',
+      repeaterUnit: 'w',
+      delayType: '-',
+      delayValue: '2',
+      delayUnit: 'd',
+    });
+    testTimestampText('<2021-05-16 Sun -2d .+1w>', {
+      isActive: true,
+      year: '2021',
+      month: '05',
+      day: '16',
+      dayName: 'Sun',
+      repeaterType: '.+',
+      repeaterValue: '1',
+      repeaterUnit: 'w',
+      delayType: '-',
+      delayValue: '2',
+      delayUnit: 'd',
+    });
+    testTimestampText(
+      '<2021-05-16>--<2021-05-23>',
+      { isActive: true, year: '2021', month: '05', day: '16' },
+      { isActive: true, year: '2021', month: '05', day: '23' }
+    );
+  });
 });
 
 describe('Parse headline with planning items and active timestamps', () => {

--- a/src/lib/parse_org.unit.test.js
+++ b/src/lib/parse_org.unit.test.js
@@ -140,6 +140,18 @@ describe('Parse raw text', () => {
       repeaterValue: '1',
       repeaterUnit: 'w',
     });
+    testTimestampText('<2021-05-16 Sun .+2d/4d>', {
+      isActive: true,
+      year: '2021',
+      month: '05',
+      day: '16',
+      dayName: 'Sun',
+      repeaterType: '.+',
+      repeaterValue: '2',
+      repeaterUnit: 'd',
+      repeaterDeadlineValue: '4',
+      repeaterDeadlineUnit: 'd',
+    });
     testTimestampText('<2021-05-16 Sun .+1w -2d>', {
       isActive: true,
       year: '2021',

--- a/src/lib/timestamps.js
+++ b/src/lib/timestamps.js
@@ -29,6 +29,8 @@ export const renderAsText = (timestamp) => {
     repeaterType,
     repeaterValue,
     repeaterUnit,
+    repeaterDeadlineValue,
+    repeaterDeadlineUnit,
     delayType,
     delayValue,
     delayUnit,
@@ -41,6 +43,10 @@ export const renderAsText = (timestamp) => {
   timestampText += !!startHour ? ` ${startHour}:${startMinute}` : '';
   timestampText += !!endHour ? `-${endHour}:${endMinute}` : '';
   timestampText += !!repeaterType ? ` ${repeaterType}${repeaterValue}${repeaterUnit}` : '';
+  timestampText +=
+    !!repeaterType && !!repeaterDeadlineValue
+      ? `/${repeaterDeadlineValue}${repeaterDeadlineUnit}`
+      : '';
   timestampText += !!delayType ? ` ${delayType}${delayValue}${delayUnit}` : '';
   timestampText += isActive ? '>' : ']';
 
@@ -64,6 +70,8 @@ export const timestampForDate = (time, { isActive = true, withStartTime = false 
     repeaterType: null,
     repeaterValue: null,
     repeaterUnit: null,
+    repeaterDeadlineValue: null,
+    repeaterDeadlineUnit: null,
     delayType: null,
     delayValue: null,
     delayUnit: null,


### PR DESCRIPTION
This PR aims to make Organice recognize timestamps with "repeater deadlines" (not sure what the official name is), the `/4d` part of `<2009-10-17 Sat .+2d/4d>`, before org-parser is integrated into Organice. A nongoal is to make repeater deadlines editable in the pretty timestamp UI (which shouldn't be the end of the world for most cases because you can edit timestamps manually).

Explanation of the changes:

- The timestamp structure defined in src/lib/timestamp.js now includes repeater deadlines so that they are preserved across edits and TODO state toggles.
- In the parser, `timestampRegex` is modified to recognize repeater deadlines. This increases the number of captures in this regexp by four.
- To reflect the change in the number of capture groups, some indices are shifted by 4 or 8, depending on how many timestamps are included in the regexp in question.
- I also deleted the occurrences of timestamp regexps in `beginningRegexp` and put them directly in `markupAndCookieRegex` (but this time reusing `timestampRegex` instead of repeating the whole expression).

If tests are required to merge, suggestions re what kind of tests and where to put them would be appreciated. When I run `yarn test`, all but one test cases pass.

```
  ● Render all views › Org Functionality › Renders everything starting from an Org file › TaskList › orders tasks for an Org file

    expect(received).toMatchSnapshot()

    Snapshot name: `Render all views Org Functionality Renders everything starting from an Org file TaskList orders tasks for an Org file 1`

    - Snapshot
    + Received

    @@ -35,11 +35,10 @@
            value=""
          />
        </div>
        <div
          class="task-list__headers-container"
    -     style="overflow: auto;"
        >
          <div
            class="agenda-day__container"
          >
            <div

      402 |           fireEvent.click(getByTitle('Show task list'));
      403 |           const drawerElem = getByTestId('drawer');
    > 404 |           expect(drawerElem).toMatchSnapshot();
          |                              ^
      405 |         });
      406 |
      407 |         test('search in TaskList filters headers (by default only with todoKeywords)', () => {

      at Object.<anonymous> (src/components/OrgFile/OrgFile.integration.test.js:404:30)

 › 1 snapshot failed.
```

This test case fails even on master. I'm wondering if that's the case for others as well? [edit] Apparently at least it isn't the case for CircleCI...