### PR TITLE
Implement an equivalent of org-agenda-start-on-weekday #266

### DIFF
--- a/src/actions/base.js
+++ b/src/actions/base.js
@@ -82,6 +82,11 @@ export const setAgendaDefaultDeadlineDelayValue = (newAgendaDefaultDeadlineDelay
   newAgendaDefaultDeadlineDelayValue,
 });
 
+export const setAgendaStartOnWeekday = (newAgendaStartOnWeekday) => ({
+  type: 'SET_AGENDA_START_ON_WEEKDAY',
+  newAgendaStartOnWeekday,
+});
+
 export const setShouldLiveSync = (shouldLiveSync) => ({
   type: 'SET_SHOULD_LIVE_SYNC',
   shouldLiveSync,

--- a/src/components/OrgFile/components/AgendaModal/index.js
+++ b/src/components/OrgFile/components/AgendaModal/index.js
@@ -18,6 +18,7 @@ import {
   addDays,
   addWeeks,
   addMonths,
+  getDay,
   subDays,
   subWeeks,
   subMonths,
@@ -38,10 +39,13 @@ function AgendaModal(props) {
     agendaTimeframe,
     agendaDefaultDeadlineDelayValue,
     agendaDefaultDeadlineDelayUnit,
+    agendaStartOnWeekday,
   } = props;
 
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [dateDisplayType, setDateDisplayType] = useState('absolute');
+
+  const weekStartsOn = agendaStartOnWeekday === null ? getDay(selectedDate) : agendaStartOnWeekday;
 
   function handleTimeframeTypeChange(agendaTimeframe) {
     props.base.setAgendaTimeframe(agendaTimeframe);
@@ -93,7 +97,7 @@ function AgendaModal(props) {
       case 'Day':
         return format(selectedDate, 'MMMM do');
       case 'Week':
-        const weekStart = startOfWeek(selectedDate);
+        const weekStart = startOfWeek(selectedDate, { weekStartsOn });
         const weekEnd = addWeeks(weekStart, 1);
         return `${format(weekStart, 'MMM do')} - ${format(weekEnd, 'MMM do')} (W${format(
           weekStart,
@@ -112,7 +116,7 @@ function AgendaModal(props) {
       dates = [selectedDate];
       break;
     case 'Week':
-      const weekStart = startOfWeek(selectedDate);
+      const weekStart = startOfWeek(selectedDate, { weekStartsOn });
       dates = _.range(7).map((daysAfter) => addDays(weekStart, daysAfter));
       break;
     case 'Month':
@@ -172,12 +176,14 @@ const mapStateToProps = (state) => {
   const file = state.org.present.getIn(['files', path]);
   const allFiles = state.org.present.get('files');
   const fileSettings = state.org.present.get('fileSettings');
+  const agendaStartOnWeekday = state.base.get('agendaStartOnWeekday');
   return {
     files: determineIncludedFiles(allFiles, fileSettings, path, 'includeInAgenda', false),
     todoKeywordSets: file.get('todoKeywordSets'),
     agendaTimeframe: state.base.get('agendaTimeframe'),
     agendaDefaultDeadlineDelayValue: state.base.get('agendaDefaultDeadlineDelayValue') || 5,
     agendaDefaultDeadlineDelayUnit: state.base.get('agendaDefaultDeadlineDelayUnit') || 'd',
+    agendaStartOnWeekday: agendaStartOnWeekday === undefined ? 1 : +agendaStartOnWeekday,
   };
 };
 

--- a/src/components/OrgFile/components/AgendaModal/index.js
+++ b/src/components/OrgFile/components/AgendaModal/index.js
@@ -45,7 +45,7 @@ function AgendaModal(props) {
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [dateDisplayType, setDateDisplayType] = useState('absolute');
 
-  const weekStartsOn = agendaStartOnWeekday === null ? getDay(selectedDate) : agendaStartOnWeekday;
+  const weekStartsOn = agendaStartOnWeekday < 0 ? getDay(selectedDate) : agendaStartOnWeekday;
 
   function handleTimeframeTypeChange(agendaTimeframe) {
     props.base.setAgendaTimeframe(agendaTimeframe);
@@ -183,7 +183,7 @@ const mapStateToProps = (state) => {
     agendaTimeframe: state.base.get('agendaTimeframe'),
     agendaDefaultDeadlineDelayValue: state.base.get('agendaDefaultDeadlineDelayValue') || 5,
     agendaDefaultDeadlineDelayUnit: state.base.get('agendaDefaultDeadlineDelayUnit') || 'd',
-    agendaStartOnWeekday: agendaStartOnWeekday === undefined ? 1 : +agendaStartOnWeekday,
+    agendaStartOnWeekday: agendaStartOnWeekday == null ? 1 : +agendaStartOnWeekday,
   };
 };
 

--- a/src/components/Settings/index.js
+++ b/src/components/Settings/index.js
@@ -71,8 +71,7 @@ const Settings = ({
   const handleAgendaDefaultDeadlineDelayUnitChange = (newDelayUnit) =>
     base.setAgendaDefaultDeadlineDelayUnit(newDelayUnit);
 
-  const handleAgendaStartOnWeekdayChange = (value) =>
-    base.setAgendaStartOnWeekday(value);
+  const handleAgendaStartOnWeekdayChange = (value) => base.setAgendaStartOnWeekday(value);
 
   const handleShouldLiveSyncChange = () => base.setShouldLiveSync(!shouldLiveSync);
 

--- a/src/components/Settings/index.js
+++ b/src/components/Settings/index.js
@@ -27,6 +27,7 @@ const Settings = ({
   shouldNotIndentOnExport,
   agendaDefaultDeadlineDelayValue,
   agendaDefaultDeadlineDelayUnit,
+  agendaStartOnWeekday,
   hasUnseenChangelog,
   syncBackend,
   showClockDisplay,
@@ -69,6 +70,9 @@ const Settings = ({
 
   const handleAgendaDefaultDeadlineDelayUnitChange = (newDelayUnit) =>
     base.setAgendaDefaultDeadlineDelayUnit(newDelayUnit);
+
+  const handleAgendaStartOnWeekdayChange = (value) =>
+    base.setAgendaStartOnWeekday(value);
 
   const handleShouldLiveSyncChange = () => base.setShouldLiveSync(!shouldLiveSync);
 
@@ -262,6 +266,24 @@ const Settings = ({
 
       <div className="setting-container">
         <div className="setting-label">
+          Start of week for weekly agenda
+          <div className="setting-label__description">
+            Akin to{' '}
+            <ExternalLink href="https://orgmode.org/manual/Weekly_002fdaily-agenda.html">
+              <code>org-agenda-start-on-weekday</code>
+            </ExternalLink>
+          </div>
+        </div>
+        <TabButtons
+          buttons={['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Today']}
+          values={[0, 1, 2, 3, 4, 5, 6, null]}
+          selectedButton={agendaStartOnWeekday}
+          onSelect={handleAgendaStartOnWeekdayChange}
+        />
+      </div>
+
+      <div className="setting-container">
+        <div className="setting-label">
           Display time summaries
           <div className="setting-label__description">
             This puts overlays at the end of each headline, showing the total time recorded under
@@ -326,12 +348,14 @@ const mapStateToProps = (state) => {
   // The default values here only relate to the settings view. To set
   // defaults which get loaded on an initial run of organice, look at
   // `util/settings_persister.js::persistableFields`.
+  const agendaStartOnWeekday = state.base.get('agendaStartOnWeekday');
   return {
     fontSize: state.base.get('fontSize') || 'Regular',
     bulletStyle: state.base.get('bulletStyle'),
     shouldTapTodoToAdvance: state.base.get('shouldTapTodoToAdvance'),
     agendaDefaultDeadlineDelayValue: state.base.get('agendaDefaultDeadlineDelayValue') || 5,
     agendaDefaultDeadlineDelayUnit: state.base.get('agendaDefaultDeadlineDelayUnit') || 'd',
+    agendaStartOnWeekday: agendaStartOnWeekday === undefined ? 1 : +agendaStartOnWeekday,
     shouldStoreSettingsInSyncBackend: state.base.get('shouldStoreSettingsInSyncBackend'),
     shouldLiveSync: state.base.get('shouldLiveSync'),
     shouldSyncOnBecomingVisibile: state.base.get('shouldSyncOnBecomingVisibile'),

--- a/src/components/Settings/index.js
+++ b/src/components/Settings/index.js
@@ -274,8 +274,8 @@ const Settings = ({
           </div>
         </div>
         <TabButtons
-          buttons={['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Today']}
-          values={[0, 1, 2, 3, 4, 5, 6, null]}
+          buttons={['S', 'M', 'T', 'W', 'T', 'F', 'S', 'Today']}
+          values={[0, 1, 2, 3, 4, 5, 6, -1]}
           selectedButton={agendaStartOnWeekday}
           onSelect={handleAgendaStartOnWeekdayChange}
         />
@@ -354,7 +354,7 @@ const mapStateToProps = (state) => {
     shouldTapTodoToAdvance: state.base.get('shouldTapTodoToAdvance'),
     agendaDefaultDeadlineDelayValue: state.base.get('agendaDefaultDeadlineDelayValue') || 5,
     agendaDefaultDeadlineDelayUnit: state.base.get('agendaDefaultDeadlineDelayUnit') || 'd',
-    agendaStartOnWeekday: agendaStartOnWeekday === undefined ? 1 : +agendaStartOnWeekday,
+    agendaStartOnWeekday: agendaStartOnWeekday == null ? 1 : +agendaStartOnWeekday,
     shouldStoreSettingsInSyncBackend: state.base.get('shouldStoreSettingsInSyncBackend'),
     shouldLiveSync: state.base.get('shouldLiveSync'),
     shouldSyncOnBecomingVisibile: state.base.get('shouldSyncOnBecomingVisibile'),

--- a/src/components/UI/TabButtons/index.js
+++ b/src/components/UI/TabButtons/index.js
@@ -18,7 +18,7 @@ export default ({ buttons, titles, values, selectedButton, useEqualWidthTabs, on
   return (
     <div className={containerClassName} style={style}>
       {buttons.map((buttonName, index) => {
-        const value = values ? values[index] : buttonName
+        const value = values ? values[index] : buttonName;
         const className = classNames('tab-buttons__btn', {
           'tab-buttons__btn--selected': value === selectedButton,
         });

--- a/src/components/UI/TabButtons/index.js
+++ b/src/components/UI/TabButtons/index.js
@@ -4,7 +4,7 @@ import './stylesheet.css';
 
 import classNames from 'classnames';
 
-export default ({ buttons, titles, selectedButton, useEqualWidthTabs, onSelect }) => {
+export default ({ buttons, titles, values, selectedButton, useEqualWidthTabs, onSelect }) => {
   const handleButtonClick = (buttonName) => () => onSelect(buttonName);
 
   const containerClassName = classNames('tab-buttons', {
@@ -18,8 +18,9 @@ export default ({ buttons, titles, selectedButton, useEqualWidthTabs, onSelect }
   return (
     <div className={containerClassName} style={style}>
       {buttons.map((buttonName, index) => {
+        const value = values ? values[index] : buttonName
         const className = classNames('tab-buttons__btn', {
-          'tab-buttons__btn--selected': buttonName === selectedButton,
+          'tab-buttons__btn--selected': value === selectedButton,
         });
         // Optionally add a title
         let title = '';
@@ -32,7 +33,7 @@ export default ({ buttons, titles, selectedButton, useEqualWidthTabs, onSelect }
             key={buttonName}
             title={title}
             className={className}
-            onClick={handleButtonClick(buttonName)}
+            onClick={handleButtonClick(value)}
           >
             {buttonName}
           </div>

--- a/src/reducers/base.js
+++ b/src/reducers/base.js
@@ -19,6 +19,9 @@ const setAgendaDefaultDeadlineDelayUnit = (state, action) =>
 const setAgendaDefaultDeadlineDelayValue = (state, action) =>
   state.set('agendaDefaultDeadlineDelayValue', action.newAgendaDefaultDeadlineDelayValue);
 
+const setAgendaStartOnWeekday = (state, action) =>
+  state.set('agendaStartOnWeekday', action.newAgendaStartOnWeekday);
+
 const setShouldStoreSettingsInSyncBackend = (state, action) =>
   state.set('shouldStoreSettingsInSyncBackend', action.newShouldStoreSettingsInSyncBackend);
 
@@ -147,6 +150,8 @@ export default (state = Map(), action) => {
       return setAgendaDefaultDeadlineDelayUnit(state, action);
     case 'SET_AGENDA_DEFAULT_DEADLINE_DELAY_VALUE':
       return setAgendaDefaultDeadlineDelayValue(state, action);
+    case 'SET_AGENDA_START_ON_WEEKDAY':
+      return setAgendaStartOnWeekday(state, action);
     case 'SET_SHOULD_STORE_SETTINGS_IN_SYNC_BACKEND':
       return setShouldStoreSettingsInSyncBackend(state, action);
     case 'SET_COLOR_SCHEME':

--- a/src/util/settings_persister.js
+++ b/src/util/settings_persister.js
@@ -74,6 +74,11 @@ export const persistableFields = [
     name: 'agendaDefaultDeadlineDelayValue',
     type: 'nullable',
   },
+  {
+    category: 'base',
+    name: 'agendaStartOnWeekday',
+    type: 'nullable',
+  },
 
   {
     category: 'base',


### PR DESCRIPTION
WISOTT. One caveat is that I changed the default start of the week to Monday from Sunday to align with the default in Org to minimize surprise for people coming from Org (at the expense of surprising longtime Organice users).

Controls in the settings: 
<img width="315" alt="Screen Shot 2021-05-12 at 3 18 05 AM" src="https://user-images.githubusercontent.com/201557/117934427-acfaee80-b2d0-11eb-9904-6d3fe52af449.png">
