### PR TITLE
fix: Dropbox sign in

### DIFF
--- a/src/components/SyncServiceSignIn/index.js
+++ b/src/components/SyncServiceSignIn/index.js
@@ -128,8 +128,9 @@ export default class SyncServiceSignIn extends PureComponent {
       clientId: process.env.REACT_APP_DROPBOX_CLIENT_ID,
       fetch: fetch.bind(window),
     });
-    const authURL = dropbox.auth.getAuthenticationUrl(window.location.origin + '/');
-    window.location = authURL;
+    dropbox.auth.getAuthenticationUrl(window.location.origin + '/').then((authURL) => {
+      window.location = authURL;
+    });
   }
 
   handleGoogleDriveClick() {


### PR DESCRIPTION
The regression was introduced in https://github.com/200ok-ch/organice/pull/675 when upgrading Dropbox from 7.1.0 to 9.8.0.

Here are the docs from Dropbox with the relevant changes for upgrading: https://github.com/dropbox/dropbox-sdk-js/blob/main/UPGRADING.md#1-unblocking-browser-pkce-flow

Interestingly, I did those before pulling in https://github.com/200ok-ch/organice/pull/675. I distinctly remember. But I must have messed up in the rebasing - or the Dependabot (dependabot-preview) did.

In any case, apologies to those users who experienced issues while trying to login to Dropbox🙏