### PR TITLE
fix: Disable hard wrapping for sample and changelog

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,16 +1,16 @@
+# organice will not reflow if there's hard-wrapped content
+# -*- eval: (auto-fill-mode 0) -*-
+
 * General
 
 All user visible changes to organice will be documented in this file.
 
-When there are updates to the changelog, you will be notified and see
-a 'gift' icon appear on the top right corner.
+When there are updates to the changelog, you will be notified and see a 'gift' icon appear on the top right corner.
 
 * [2021-05-16 Sun]
 ** Added
    - Parse and preserve habit timestamp ranges
-     - A timestamp may have minimum and maximum ranges specified by
-       using the syntax =.+2d/3d=, which says that you want to do the
-       task at least every three days, but at most every two days.
+     - A timestamp may have minimum and maximum ranges specified by using the syntax =.+2d/3d=, which says that you want to do the task at least every three days, but at most every two days.
      - Upstream documentation:
        https://orgmode.org/manual/Tracking-your-habits.html
      - Relevant PR: https://github.com/200ok-ch/organice/pull/674
@@ -23,8 +23,7 @@ a 'gift' icon appear on the top right corner.
 
 ** Added
    - Ability to set the "Start of week for weekly agenda" in the Settings
-     - Akin to the Emacs org mode variable
-       =org-agenda-start-on-weekday=
+     - Akin to the Emacs org mode variable =org-agenda-start-on-weekday=
    - Relevant PRs:
      - https://github.com/200ok-ch/organice/pull/676
        - Thank you [[https://github.com/tomonacci][tomonacci]] for the PR🙏

--- a/sample.org
+++ b/sample.org
@@ -1,3 +1,5 @@
+# organice will not reflow if there's hard-wrapped content
+# -*- eval: (auto-fill-mode 0) -*-
 #+TODO: TODO | DONE
 #+TODO: START INPROGRESS STALLED | FINISHED
 


### PR DESCRIPTION
@schoettl @branch14 @tarnung organice will not reflow if there's hard-wrapped content. This is a small workaround for the time being. It won't do anything if these files are edited with a different editor than Emacs, but at least it'll be a reminder(;
