### PR TITLE
Wip 583 handle empty file

### DIFF
--- a/src/components/OrgFile/OrgFile.integration.test.js
+++ b/src/components/OrgFile/OrgFile.integration.test.js
@@ -683,3 +683,82 @@ describe('Render all views', () => {
     });
   });
 });
+
+
+describe('Render file with no headings', () => {
+  const testOrgFile = readFixture('no_headings');
+
+  let store;
+
+  beforeEach(() => {
+    let capture = Map();
+    capture = capture.set('captureTemplates', []);
+    store = createStore(
+      rootReducer,
+      {
+        org: {
+          past: [],
+          present: Map({
+            files: Map(),
+            fileSettings: [],
+            search: Map({
+              searchFilter: '',
+              searchFilterExpr: [],
+            }),
+          }),
+          future: [],
+        },
+        syncBackend: Map({
+          isAuthenticated: true,
+        }),
+        capture,
+        base: new fromJS({
+          customKeybindings: {},
+          shouldTapTodoToAdvance: true,
+          isLoading: Set(),
+          agendaTimeframe: 'Week',
+        }),
+      },
+      applyMiddleware(thunk)
+    );
+    store.dispatch(parseFile(STATIC_FILE_PREFIX + 'fixtureTestFile.org', testOrgFile));
+    store.dispatch(setPath(STATIC_FILE_PREFIX + 'fixtureTestFile.org'));
+  });
+
+  describe('Org Functionality', () => {
+    let container,
+      getByText,
+      getAllByText,
+      getByTitle,
+      getByTestId,
+      queryByText,
+      queryAllByText,
+      getByPlaceholderText;
+    beforeEach(() => {
+      let res = render(
+        <MemoryRouter keyLength={0} initialEntries={['/file/dir1/dir2/fixtureTestFile.org']}>
+          <Provider store={store}>
+            <HeaderBar />
+            <OrgFile path={STATIC_FILE_PREFIX + 'fixtureTestFile.org'} />
+          </Provider>
+        </MemoryRouter>
+      );
+
+      container = res.container;
+      getByText = res.getByText;
+      getAllByText = res.getAllByText;
+      getByTitle = res.getByTitle;
+      getByTestId = res.getByTestId;
+      queryByText = res.queryByText;
+      queryAllByText = res.queryAllByText;
+      getByPlaceholderText = res.getByPlaceholderText;
+    });
+
+    describe('Renders the empty Org file as a single heading', () => {
+      test('renders an Org file', () => {
+        expect(getAllByText(/\*/)).toHaveLength(1);
+      });
+    });
+
+  });
+});

--- a/src/components/OrgFile/OrgFile.unit.test.js
+++ b/src/components/OrgFile/OrgFile.unit.test.js
@@ -237,7 +237,7 @@ ${text}`;
 
     describe('File with no headings', () => {
       test('Parses a file with no headings', () => {
-        const testOrgFile = readFixture('no-headings');
+        const testOrgFile = readFixture('no_headings');
         const exportedFile = parseAndExportOrgFile(testOrgFile);
         expect(exportedFile).toEqual(testOrgFile);
       });

--- a/src/components/OrgFile/OrgFile.unit.test.js
+++ b/src/components/OrgFile/OrgFile.unit.test.js
@@ -235,6 +235,14 @@ ${text}`;
       });
     });
 
+    describe('File with no headings', () => {
+      test('Parses a file with no headings', () => {
+        const testOrgFile = readFixture('no-headings');
+        const exportedFile = parseAndExportOrgFile(testOrgFile);
+        expect(exportedFile).toEqual(testOrgFile);
+      });
+    });
+
     describe('E-mail address', () => {
       test('Parse a line containing an e-mail address', () => {
         const testOrgFile = readFixture('email');

--- a/src/components/OrgFile/__snapshots__/OrgFile.integration.test.js.snap
+++ b/src/components/OrgFile/__snapshots__/OrgFile.integration.test.js.snap
@@ -40,7 +40,6 @@ exports[`Render all views Org Functionality Renders everything starting from an 
   </div>
   <div
     class="task-list__headers-container"
-    style="overflow: auto;"
   >
     <div
       class="agenda-day__container"

--- a/src/lib/export_org.js
+++ b/src/lib/export_org.js
@@ -259,7 +259,19 @@ export const generateTitleLine = (header, includeStars) => {
  */
 export const exportOrg = ({ headers, linesBeforeHeadings, dontIndent }) => {
   let configContent = linesBeforeHeadings.map((x) => x + '\n').join('');
-  const headerContent = headers.map((x) => createRawDescriptionText(x, true, dontIndent)).join('');
+  let headerContent = headers.map((x) => createRawDescriptionText(x, true, dontIndent)).join('');
+
+  // WIP
+  // Don't export the ORGANICE_DUMMY header.
+  if (/DUMMY/.test(headerContent)) {
+    console.log('headercontent = ');
+    console.log(JSON.stringify(headerContent));
+  }
+  if (headerContent === '* ORGANICE_DUMMY\n') {
+    headerContent = '';
+  }
+  // END WIP
+
   return configContent + headerContent;
 };
 

--- a/src/lib/parse_org.js
+++ b/src/lib/parse_org.js
@@ -879,13 +879,12 @@ export const parseOrg = (fileContents) => {
     }
   });
 
-  // WIP: assuming that we can push an empty header, to allow handling empty files.
+  // WIP: pushing a dummy header to allow handling empty files.
   //
-  // TODO: Note that this will cause organice's parse/export to break
-  // files that *intentionally* contain an empty header ... would a
-  // better design decision be to create a special header token
-  // (e.g. "* SOME_TOKEN_HERE") that is never displayed and never
-  // exported?
+  // Note that I initially had this add an empty header, but that caused
+  // one of the unit tests to break (there's a test with an empty header,
+  // and if I arbitrarily remove the pre-existing empty header then I'm changing
+  // the org file ...).  So, adding a dummy token here instead, to allow for file handling.
   //
   // I'm also not sure what is the best way to handle files that
   // already contain some plain text, as was described initially in
@@ -895,7 +894,7 @@ export const parseOrg = (fileContents) => {
   //
   // end WIP comments.
   if (headers.size === 0) {
-    headers = headers.push(newHeaderWithTitle('', 1, todoKeywordSets));
+    headers = headers.push(newHeaderWithTitle('ORGANICE_DUMMY', 1, todoKeywordSets));
   }
 
   headers = headers.map((header) => {

--- a/src/lib/parse_org.js
+++ b/src/lib/parse_org.js
@@ -879,6 +879,25 @@ export const parseOrg = (fileContents) => {
     }
   });
 
+  // WIP: assuming that we can push an empty header, to allow handling empty files.
+  //
+  // TODO: Note that this will cause organice's parse/export to break
+  // files that *intentionally* contain an empty header ... would a
+  // better design decision be to create a special header token
+  // (e.g. "* SOME_TOKEN_HERE") that is never displayed and never
+  // exported?
+  //
+  // I'm also not sure what is the best way to handle files that
+  // already contain some plain text, as was described initially in
+  // https://github.com/200ok-ch/organice/issues/583 ... if we add a
+  // header, this might cause strange data regroupings.  That scenario
+  // might need its own test fixture.
+  //
+  // end WIP comments.
+  if (headers.size === 0) {
+    headers = headers.push(newHeaderWithTitle('', 1, todoKeywordSets));
+  }
+
   headers = headers.map((header) => {
     // Normally, rawDescription contains the "stripped" raw description text,
     // i.e. no log book, properties, or planning items.


### PR DESCRIPTION
DRAFT PR ONLY to share work.

Tentative work to address empty org files, issue raised in https://github.com/200ok-ch/organice/issues/583

I added a dummy header (with text `* ORGANICE_DUMMY`) because when I added an empty line, some tests started to fail.  There are existing tests that check that org files with an empty header aren't changed ... but if I add and then remove an empty line, things break.

I haven't updated any view code to ignore the "ORGANICE_DUMMY" header line.  I'm actually not sure how the code _should_ handle the case where there aren't any headers.  Since a `.org` file is sort-of-assumed to have a header, maybe the existing failure is actually legit, because adding a dummy line like this code does, or changing structure, could somehow influence an existing org file in a bad way.  Not sure, and I don't know if it's useful thinking about this one too hard!

Cheers, jz