### PR TITLE
Fix GitLab commit message

### DIFF
--- a/src/sync_backend_clients/gitlab_sync_backend_client.js
+++ b/src/sync_backend_clients/gitlab_sync_backend_client.js
@@ -252,8 +252,9 @@ export default (oauthClient) => {
 
   const doCommit = async (action) => {
     const capitalizedAction = action.action.charAt(0).toUpperCase() + action.action.slice(1);
+    // Two newlines because Git commits should have an empty line between title and body.
     const message =
-      `[organice] ${capitalizedAction} ${action.file_path}\n` +
+      `[organice] ${capitalizedAction} ${action.file_path}\n\n` +
       'Automatic commit from organice app.';
     // It's also possible to modify files using the files API instead of commits API. For this use
     // case they're about equal, but I picked commits because it doesn't require non-standard


### PR DESCRIPTION
Ultra trivial PR: need two newlines between title and body for git commits. Oops... my bad.

BTW I meant to mention before, but if you get any bug reports related to the GitLab backend you're welcome to `@mention` me to fix them.