### PR TITLE
fix repeater adjusting time of date

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -7,6 +7,12 @@ All user visible changes to organice will be documented in this file.
 
 When there are updates to the changelog, you will be notified and see a 'gift' icon appear on the top right corner.
 
+* [2021-11-09 Tue]
+** Fixed
+   - Fix repeater adjusting time of date when using =.+=
+     - When repeaterUnit is not "h", hour and minutes are never touched.
+     - When repeaterUnit is "h", hour and minutes are set to n hour(s) from now (as it was already implemented before this fix).
+   - Relevant PR: https://github.com/200ok-ch/organice/pull/746
 * [2021-11-03 Wed]
 ** Fixed
    - Fix GitLab OAuth token refresh

--- a/src/lib/timestamps.js
+++ b/src/lib/timestamps.js
@@ -13,6 +13,10 @@ import {
   subYears,
   isBefore,
   differenceInMinutes,
+  getHours,
+  setHours,
+  getMinutes,
+  setMinutes
 } from 'date-fns';
 
 export const renderAsText = (timestamp) => {
@@ -175,6 +179,11 @@ export const applyRepeater = (timestamp, currentDate) => {
         timestamp.get('repeaterValue'),
         timestamp.get('repeaterUnit')
       );
+      if(timestamp.get('repeaterUnit') != "h"){
+        let timestampDate = dateForTimestamp(timestamp);
+        newDate = setHours(newDate, getHours(timestampDate));
+        newDate = setMinutes(newDate, getMinutes(timestampDate));
+      }
       break;
     default:
       console.error(`Unrecognized timestamp repeater type: ${timestamp.get('repeaterType')}`);

--- a/src/lib/timestamps.js
+++ b/src/lib/timestamps.js
@@ -179,7 +179,7 @@ export const applyRepeater = (timestamp, currentDate) => {
         timestamp.get('repeaterValue'),
         timestamp.get('repeaterUnit')
       );
-      if(timestamp.get('repeaterUnit') != "h"){
+      if (timestamp.get('repeaterUnit') != "h") {
         let timestampDate = dateForTimestamp(timestamp);
         newDate = setHours(newDate, getHours(timestampDate));
         newDate = setMinutes(newDate, getMinutes(timestampDate));

--- a/src/lib/timestamps.js
+++ b/src/lib/timestamps.js
@@ -16,7 +16,7 @@ import {
   getHours,
   setHours,
   getMinutes,
-  setMinutes
+  setMinutes,
 } from 'date-fns';
 
 export const renderAsText = (timestamp) => {
@@ -179,7 +179,7 @@ export const applyRepeater = (timestamp, currentDate) => {
         timestamp.get('repeaterValue'),
         timestamp.get('repeaterUnit')
       );
-      if (timestamp.get('repeaterUnit') != "h") {
+      if (timestamp.get('repeaterUnit') != 'h') {
         let timestampDate = dateForTimestamp(timestamp);
         newDate = setHours(newDate, getHours(timestampDate));
         newDate = setMinutes(newDate, getMinutes(timestampDate));


### PR DESCRIPTION
Should fix #683

Since I'm still not using emacs, someone might want to check if my assumptions based on [org mode docs](https://orgmode.org/manual/Repeated-tasks.html#Repeated-tasks) are correct.

using ".+":
- when repeaterUnit is not "h", hour and minutes are never touched.
- when repeaterUnit is "h", hour and minutes are set to n hour(s) from now (as it was already implemented before this fix)