### PR TITLE
Feat/scroll layout

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -34,7 +34,6 @@ body,
 #root {
   color: var(--base00);
   background: var(--base3);
-  scroll-padding-top: 60px;
   user-select: none;
 }
 

--- a/src/components/Entry/stylesheet.css
+++ b/src/components/Entry/stylesheet.css
@@ -3,9 +3,9 @@
 
   display: flex;
   flex-direction: column;
-  height: 100%;
-  min-height: 100vh;
-  padding-bottom: 90px;
+  height: calc(100vh - 50px);
+  min-height: calc(100vh - 50px);
+  max-height: calc(100vh - 50px);
   overflow-x: hidden;
 }
 

--- a/src/components/HeaderBar/stylesheet.css
+++ b/src/components/HeaderBar/stylesheet.css
@@ -10,8 +10,6 @@
   grid-template-areas: 'back title actions';
   align-items: center;
 
-  position: sticky;
-  top: 0;
   z-index: 1;
 }
 

--- a/src/components/OrgFile/__snapshots__/OrgFile.integration.test.js.snap
+++ b/src/components/OrgFile/__snapshots__/OrgFile.integration.test.js.snap
@@ -990,6 +990,9 @@ exports[`Render all views Org Functionality Renders everything starting from an 
         </div>
         <div />
       </div>
+      <div
+        style="height: 90px;"
+      />
     </div>
     <div
       class="action-drawer-container nice-scroll"

--- a/src/components/OrgFile/components/HeaderList/index.js
+++ b/src/components/OrgFile/components/HeaderList/index.js
@@ -129,6 +129,7 @@ class HeaderList extends PureComponent {
             />
           );
         })}
+        <div style={{ height: '90px' }} />
       </div>
     );
   }

--- a/src/components/OrgFile/components/HeaderList/stylesheet.css
+++ b/src/components/OrgFile/components/HeaderList/stylesheet.css
@@ -5,6 +5,9 @@
   margin-top: 10px;
 
   z-index: 1;
+
+  height: '100%';
+  overflow: 'auto';
 }
 
 .header-list-container--narrowed {


### PR DESCRIPTION
A year ago I messed around with the bar at the top of the app and the padding at the bottom that would allow you to scroll content above the action buttons at the bottom of the screen. That had some bad consequences. Most notably even when there isn't enough content to fill the screen, the padding at the bottom still is there and allows to scroll content upwards out of sight. This is true even for pages like login and settings that have no need for padding since there are no action buttons. Sometimes a view even starts out scrolled down so that the content comes into view partially obscured.

I tried to fix this again and I seem to have found a better solution. My knowledge of css is lacking so I mostly try things that seem reasonable until I'm happy with the results.

- the app-bar at the top is now an actual element above the content not a sticky box in front of it.
- on mobile everithing seems to be ok
- on desktop this has the effect that the scroll bar now appears at the boarder of the app content, not at the boarder of the browser window. That has a little less of an elegant feel, but if we ever want to allow for an expanded view on desktop machines, we would need to do that anyways.

You can test the effects of this change on staging, where it currently is deployed alongside the "custom queries" feature.