### PR TITLE
bookmark searches

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -7,8 +7,16 @@ All user visible changes to organice will be documented in this file.
 
 When there are updates to the changelog, you will be notified and see a 'gift' icon appear on the top right corner.
 
+* [2021-12-05 Sun]
+** Added
+   - *EPIC* Bookmark functionality for search
+     - After entering a search string, you can bookmark it using the ⭐ button.
+     - Bookmarked search strings populate the suggestions if no search string is entered into the input field.
+     - Bookmarks are saved by context, so there are separate bookmarks for search, task-list, and refile.
+     - There are at most ten bookmarks for a context. Newly saved bookmarks are inserted at the top of the list. If the list gets too long, the last search strings are dropped. Duplicate bookmarks are dropped too. The list of bookmarks is ordered by last used.
+     - Bookmarks are unaware of file context. Therefore, you always have the same bookmarks.
+     - Relevant PR: https://github.com/200ok-ch/organice/pull/758
 * [2021-11-22 Mon]
-
 ** Changed
    - Title and Description fields are not edited as raw text by default.
      - Instead, a semantic editor comes up when editing them.
@@ -19,7 +27,6 @@ When there are updates to the changelog, you will be notified and see a 'gift' i
      that looks like "Search" for =clock:now= without the search input
      field.
    - Notes can be multi-line and are properly indented.
-
 * [2021-11-09 Tue]
 ** Added
    - Setting to respect OS light/dark-mode preferences

--- a/sample.org
+++ b/sample.org
@@ -299,6 +299,18 @@ Using the filter input, you can search for headlines. Specifically, you can sear
 
 When a header is narrowed, and the user uses the 'search' or 'task list' feature, then the searched header list is automatically narrowed to only subheaders of the originally narrowed header.
 
+** Bookmarks
+
+After entering a search string, you can bookmark it using the ⭐ button.
+
+Bookmarked search strings populate the suggestions if no search string is entered into the input field.
+
+Bookmarks are saved by context, so there are separate bookmarks for search, task-list, and refile.
+
+There are at most ten bookmarks for a context. Newly saved bookmarks are inserted at the top of the list. If the list gets too long, the last search strings are dropped. Duplicate bookmarks are dropped too. The list of bookmarks is ordered by last used.
+
+Bookmarks are unaware of file context. Therefore, you always have the same bookmarks.
+
 ** Differences Search and Task List
 
 - In the task list, you can tap on the date to switch to a more readable relative date format.

--- a/src/App.js
+++ b/src/App.js
@@ -62,7 +62,7 @@ const handleGitLabAuthResponse = async (oauthClient) => {
   const syncClient = createGitLabSyncBackendClient(oauthClient);
   const isAccessible = await syncClient.isProjectAccessible();
   if (!isAccessible) {
-    alert('Failed to access GitLab project - is the URL is correct?');
+    alert('Failed to access GitLab project - is the URL correct?');
   } else {
     window.location.search = '';
   }

--- a/src/actions/org.js
+++ b/src/actions/org.js
@@ -698,3 +698,9 @@ export const restoreFileSettings = (newSettings) => ({
   type: 'RESTORE_FILE_SETTINGS',
   newSettings,
 });
+
+export const saveBookmark = (context, bookmark) => ({
+  type: 'SAVE_BOOKMARK',
+  context,
+  bookmark,
+});

--- a/src/components/OrgFile/OrgFile.integration.test.js
+++ b/src/components/OrgFile/OrgFile.integration.test.js
@@ -14,7 +14,7 @@ import rootReducer from '../../reducers/';
 import { setPath, parseFile } from '../../actions/org';
 import { setShouldLogIntoDrawer } from '../../actions/base';
 
-import { Map, Set, fromJS } from 'immutable';
+import { Map, Set, fromJS, List } from 'immutable';
 import { formatDistanceToNow } from 'date-fns';
 
 import { render, fireEvent, cleanup } from '@testing-library/react';
@@ -53,6 +53,11 @@ describe('Render all views', () => {
             search: Map({
               searchFilter: '',
               searchFilterExpr: [],
+            }),
+            bookmarks: Map({
+              search: List(),
+              'task-list': List(),
+              refile: List(),
             }),
           }),
           future: [],

--- a/src/components/OrgFile/__snapshots__/OrgFile.integration.test.js.snap
+++ b/src/components/OrgFile/__snapshots__/OrgFile.integration.test.js.snap
@@ -33,29 +33,30 @@ exports[`Render all views Org Functionality Renders everything starting from an 
   <div
     class="task-list__modal-title_search"
   />
-  <datalist
-    id="task-list__datalist-filter"
-  >
-    <option
-      value="TODO organice"
-    />
-    <option
-      value="-organice :medium"
-    />
-    <option
-      value="-DONE doc|man :assignee:none"
-    />
-  </datalist>
   <div
-    class="task-list__input-container"
+    class="search-input-container"
   >
-    <input
-      class="textfield task-list__filter-input"
-      list="task-list__datalist-filter"
-      placeholder="e.g. -DONE doc|man :simple|easy :assignee:nobody|none"
-      type="text"
-      value=""
-    />
+    <div
+      class="search-input-line"
+    >
+      <datalist
+        id="task-list__datalist-filter"
+      />
+      <div
+        class="search__input-container"
+      >
+        <input
+          class="textfield task-list__filter-input"
+          list="task-list__datalist-filter"
+          placeholder="e.g. -DONE doc|man :simple|easy :assignee:nobody|none"
+          type="text"
+          value=""
+        />
+      </div>
+      <i
+        class="fas fa-lg fa-star bookmark__icon "
+      />
+    </div>
   </div>
   <div
     class="task-list__headers-container"

--- a/src/components/OrgFile/components/SearchModal/index.js
+++ b/src/components/OrgFile/components/SearchModal/index.js
@@ -22,11 +22,15 @@ function SearchModal(props) {
     searchFilter,
     searchFilterValid,
     searchFilterSuggestions,
+    allBookmarks,
     context,
     showClockedTimes,
     clockedTime,
     activeClocks,
   } = props;
+  const bookmarks = allBookmarks.get(context);
+
+  const canSaveBookmark = searchFilterValid && searchFilter.length !== 0;
 
   function handleHeaderClick(path, headerId) {
     props.onClose(path, headerId);
@@ -38,6 +42,12 @@ function SearchModal(props) {
 
   function handleFilterChange(event) {
     props.org.setSearchFilterInformation(event.target.value, event.target.selectionStart, context);
+  }
+
+  function onBookmarkButtonClick() {
+    if (canSaveBookmark) {
+      props.org.saveBookmark(context, searchFilter);
+    }
   }
 
   return (
@@ -57,38 +67,50 @@ function SearchModal(props) {
       )}
 
       {activeClocks ? null : (
-        <>
-          <datalist id="task-list__datalist-filter">
-            {searchFilterSuggestions.map((string, idx) => (
-              <option key={idx} value={string} />
-            ))}
-          </datalist>
+        <div className="search-input-container">
+          <div className="search-input-line">
+            <datalist id="task-list__datalist-filter">
+              {(searchFilter.length === 0 ? bookmarks : searchFilterSuggestions).map(
+                (string, idx) => (
+                  <option key={idx} value={string} />
+                )
+              )}
+            </datalist>
 
-          <div className="task-list__input-container">
-            <input
-              type="text"
-              value={searchFilter}
-              // On iOS, setting autoFocus here will move the contents of
-              // the drawer off the screen, because the keyboard pops up
-              // late when the height is already set to '92%'. Some other
-              // complications: There's no API to check if the keyboard is
-              // open or not. When setting the height of the container to
-              // something like 48% for iOS, this works on iPhone (tested
-              // on Xs and 6S), but when the keyboard is closed, the
-              // container is still small when the user wants to read the
-              // longer list without the keyboard in the way. There might
-              // be a better way: If the drawer wouldn't move, iOS likely
-              // would set the heights correctly automatically.
-              autoFocus={!isIos()}
-              className={classNames('textfield', 'task-list__filter-input', {
-                'task-list__filter-input--invalid': !!searchFilter && !searchFilterValid,
-              })}
-              placeholder="e.g. -DONE doc|man :simple|easy :assignee:nobody|none"
-              list="task-list__datalist-filter"
-              onChange={handleFilterChange}
+            <div className="search__input-container">
+              <input
+                type="text"
+                value={searchFilter}
+                // On iOS, setting autoFocus here will move the contents of
+                // the drawer off the screen, because the keyboard pops up
+                // late when the height is already set to '92%'. Some other
+                // complications: There's no API to check if the keyboard is
+                // open or not. When setting the height of the container to
+                // something like 48% for iOS, this works on iPhone (tested
+                // on Xs and 6S), but when the keyboard is closed, the
+                // container is still small when the user wants to read the
+                // longer list without the keyboard in the way. There might
+                // be a better way: If the drawer wouldn't move, iOS likely
+                // would set the heights correctly automatically.
+                autoFocus={!isIos()}
+                className={classNames('textfield', 'task-list__filter-input', {
+                  'task-list__filter-input--invalid': !!searchFilter && !searchFilterValid,
+                })}
+                placeholder="e.g. -DONE doc|man :simple|easy :assignee:nobody|none"
+                list="task-list__datalist-filter"
+                onChange={handleFilterChange}
+              />
+            </div>
+
+            <i
+              className={
+                'fas fa-lg fa-star bookmark__icon ' +
+                (canSaveBookmark ? 'bookmark__icon__enabled' : '')
+              }
+              onClick={onBookmarkButtonClick}
             />
           </div>
-        </>
+        </div>
       )}
 
       <div
@@ -117,6 +139,7 @@ const mapStateToProps = (state) => {
     searchFilter: state.org.present.getIn(['search', 'searchFilter']),
     searchFilterValid: state.org.present.getIn(['search', 'searchFilterValid']),
     searchFilterSuggestions: state.org.present.getIn(['search', 'searchFilterSuggestions']) || [],
+    allBookmarks: state.org.present.get('bookmarks'),
     showClockedTimes: state.org.present.getIn(['search', 'showClockedTimes']),
     clockedTime: state.org.present.getIn(['search', 'clockedTime']),
   };

--- a/src/components/OrgFile/components/SearchModal/stylesheet.css
+++ b/src/components/OrgFile/components/SearchModal/stylesheet.css
@@ -3,15 +3,37 @@
 /* Currently, the markup is the same as in the AgendaModal component.
  * Hence the CSS rules from there apply. */
 
+.search-input-container{
+  display: flex;
+  margin-bottom: 1em;
+}
+
+.search-input-line {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.bookmark__icon {
+  margin-left: 10px;
+
+  cursor: pointer;
+}
+
+.bookmark__icon__enabled {
+  color: var(--magenta);
+}
+
 .task-list__filter-input,
 .task-list__filter-input-invalid {
   box-sizing: border-box;
   width: 100%;
 }
 
-.task-list__input-container {
+.search__input-container {
   flex-shrink: 0;
-  margin-bottom: 2em;
+  flex-grow: 1;
   display: flex;
   align-items: center;
   flex-direction: column;

--- a/src/components/OrgFile/components/TaskListModal/index.js
+++ b/src/components/OrgFile/components/TaskListModal/index.js
@@ -15,6 +15,9 @@ import * as orgActions from '../../../../actions/org';
 // in structure and partially in logic. When changing one, consider
 // changing all.
 function TaskListModal(props) {
+  const { searchFilter, searchFilterValid, searchFilterSuggestions, bookmarks } = props;
+  const canSaveBookmark = searchFilterValid && searchFilter.length !== 0;
+
   const [dateDisplayType, setdateDisplayType] = useState('absolute');
 
   function handleHeaderClick(path, headerId) {
@@ -34,30 +37,48 @@ function TaskListModal(props) {
     );
   }
 
-  const { searchFilter, searchFilterValid, searchFilterSuggestions } = props;
+  function onBookmarkButtonClick() {
+    if (canSaveBookmark) {
+      props.org.saveBookmark('task-list', searchFilter);
+    }
+  }
 
   return (
     <>
-      <div className="task-list__modal-title" />
-      <datalist id="task-list__datalist-filter">
-        {searchFilterSuggestions.map((string, idx) => (
-          <option key={idx} value={string} />
-        ))}
-      </datalist>
+      <div className="task-list__modal-title_search" />
+      <div className="search-input-container">
+        <div className="search-input-line">
+          <datalist id="task-list__datalist-filter">
+            {(searchFilter.length === 0 ? bookmarks : searchFilterSuggestions).map(
+              (string, idx) => (
+                <option key={idx} value={string} />
+              )
+            )}
+          </datalist>
 
-      <div className="task-list__input-container">
-        <input
-          type="text"
-          value={searchFilter}
-          // Rationale: See SearchModal: index.js
-          autoFocus={!isIos()}
-          className={classNames('textfield', 'task-list__filter-input', {
-            'task-list__filter-input--invalid': !!searchFilter && !searchFilterValid,
-          })}
-          placeholder="e.g. -DONE doc|man :simple|easy :assignee:nobody|none"
-          list="task-list__datalist-filter"
-          onChange={handleFilterChange}
-        />
+          <div className="search__input-container">
+            <input
+              type="text"
+              value={searchFilter}
+              // Rationale: See SearchModal: index.js
+              autoFocus={!isIos()}
+              className={classNames('textfield', 'task-list__filter-input', {
+                'task-list__filter-input--invalid': !!searchFilter && !searchFilterValid,
+              })}
+              placeholder="e.g. -DONE doc|man :simple|easy :assignee:nobody|none"
+              list="task-list__datalist-filter"
+              onChange={handleFilterChange}
+            />
+          </div>
+
+          <i
+            className={
+              'fas fa-lg fa-star bookmark__icon ' +
+              (canSaveBookmark ? 'bookmark__icon__enabled' : '')
+            }
+            onClick={onBookmarkButtonClick}
+          />
+        </div>
       </div>
 
       <div
@@ -83,6 +104,7 @@ const mapStateToProps = (state) => ({
   searchFilter: state.org.present.getIn(['search', 'searchFilter']) || '',
   searchFilterValid: state.org.present.getIn(['search', 'searchFilterValid']),
   searchFilterSuggestions: state.org.present.getIn(['search', 'searchFilterSuggestions']) || [],
+  bookmarks: state.org.present.getIn(['bookmarks', 'task-list']),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/components/OrgFile/components/TaskListModal/stylesheet.css
+++ b/src/components/OrgFile/components/TaskListModal/stylesheet.css
@@ -19,7 +19,6 @@
 
 .task-list__input-container {
   flex-shrink: 0;
-  margin-bottom: 2em;
   display: flex;
   align-items: center;
   flex-direction: column;

--- a/src/lib/headline_filter.js
+++ b/src/lib/headline_filter.js
@@ -371,7 +371,6 @@ export const computeCompletionsForDatalist = (todoKeywords, tagNames, allPropert
     filterString,
     curserPosition
   );
-  console.debug(completions)
   return completions.map(
     (x) => filterString.substring(0, curserPosition) + x + filterString.substring(curserPosition)
   );

--- a/src/lib/headline_filter.js
+++ b/src/lib/headline_filter.js
@@ -371,6 +371,7 @@ export const computeCompletionsForDatalist = (todoKeywords, tagNames, allPropert
     filterString,
     curserPosition
   );
+  console.debug(completions)
   return completions.map(
     (x) => filterString.substring(0, curserPosition) + x + filterString.substring(curserPosition)
   );

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -1294,20 +1294,8 @@ export const setSearchFilterInformation = (state, action) => {
 
   state.setIn(['search', 'searchFilter'], searchFilter);
 
-  // INFO: This is a POC draft of a future feature
-  // This could come from the last session, hence from localStorage.
-  // Just some more examples for now:
-  const lastUsedFilterStrings = [
-    'TODO organice',
-    '-organice :medium',
-    '-DONE doc|man :assignee:none',
-  ];
-
   let searchFilterSuggestions = [];
-  if (_.isEmpty(searchFilter)) {
-    // Only for an empty filter string,  provide last used filters as suggestions.
-    searchFilterSuggestions = lastUsedFilterStrings;
-  } else {
+  if (!_.isEmpty(searchFilter)) {
     // TODO: Currently only showing suggestions based on opened file.
     // Decide if they should be based on all files.
     const currentFile = files.get(path);
@@ -1356,6 +1344,15 @@ const deleteFileSetting = (state, action) => {
   const settingIndex = indexOfFileSettingWithId(state.get('fileSettings'), action.settingId);
 
   return state.update('fileSettings', (settings) => settings.delete(settingIndex));
+};
+
+const saveBookmark = (state, { context, bookmark }) => {
+  return state.updateIn(['bookmarks', context], (bookmarks) =>
+    bookmarks
+      .filterNot((x) => x === bookmark)
+      .unshift(bookmark)
+      .take(10)
+  );
 };
 
 const addNewEmptyFileSetting = (state) =>
@@ -1526,6 +1523,8 @@ const reducer = (state, action) => {
       return addNewEmptyFileSetting(state, action);
     case 'RESTORE_FILE_SETTINGS':
       return restoreFileSettings(state, action);
+    case 'SAVE_BOOKMARK':
+      return saveBookmark(state, action);
     default:
       return state;
   }

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -1312,6 +1312,16 @@ export const setSearchFilterInformation = (state, action) => {
 
   state.setIn(['search', 'searchFilterSuggestions'], searchFilterSuggestions);
 
+  // update bookmarks to order them by 'last used'
+  let bookmarks = state.getIn(['bookmarks', context]);
+  if (bookmarks.contains(searchFilter)) {
+    bookmarks = bookmarks
+      .filter((x) => x !== searchFilter)
+      .unshift(searchFilter)
+      .take(10);
+  }
+  state.setIn(['bookmarks', context], bookmarks);
+
   return state.asImmutable();
 };
 
@@ -1349,7 +1359,7 @@ const deleteFileSetting = (state, action) => {
 const saveBookmark = (state, { context, bookmark }) => {
   return state.updateIn(['bookmarks', context], (bookmarks) =>
     bookmarks
-      .filterNot((x) => x === bookmark)
+      .filter((x) => x !== bookmark)
       .unshift(bookmark)
       .take(10)
   );

--- a/src/util/settings_persister.js
+++ b/src/util/settings_persister.js
@@ -205,7 +205,11 @@ export const persistableFields = [
     category: 'org',
     name: 'bookmarks',
     type: 'json',
-    default: Map(),
+    default: Map({
+      search: List(),
+      'task-list': List(),
+      refile: List(),
+    }),
   },
 ];
 
@@ -282,8 +286,9 @@ const getInitialStateWithDefaultValues = () => {
           searchFilterExpr: [],
         }),
         bookmarks: Map({
-          search: [],
-          'task-list': [],
+          search: List(),
+          'task-list': List(),
+          refile: List(),
         }),
       }),
       future: [],

--- a/src/util/settings_persister.js
+++ b/src/util/settings_persister.js
@@ -201,6 +201,12 @@ export const persistableFields = [
     name: 'preferEditRawValues',
     type: 'boolean',
   },
+  {
+    category: 'org',
+    name: 'bookmarks',
+    type: 'json',
+    default: Map(),
+  },
 ];
 
 export const readOpennessState = () => {
@@ -274,6 +280,10 @@ const getInitialStateWithDefaultValues = () => {
         search: Map({
           searchFilter: '',
           searchFilterExpr: [],
+        }),
+        bookmarks: Map({
+          search: [],
+          'task-list': [],
         }),
       }),
       future: [],


### PR DESCRIPTION
Simple search string bookmarking.

The initial idea of saving the last 10 used search strings is not practical because we search on every keystroke. The most obvious way to identify useful complete search strings is to let the user decide when to bookmark.

Bookmarked search strings populate the suggestions if no search string is entered into the input field.
Bookmarks are saved by context, so there are separate bookmarks for search, task-list and refile.
There are at most 10 bookmarks for a context. New saved bookmarks are inserted at the top of the list. If the list gets too long, the last search strings are dropped. Duplicate bookmarks are dropped too. The list of bookmarks is ordered by last used.

Bookmarks are at the moment unaware of file context. You always have the same bookmarks. It would be possible to change that, but I think it would not be intuitive to use.