### PR TITLE
clean up deleted files

### DIFF
--- a/src/actions/org.js
+++ b/src/actions/org.js
@@ -222,7 +222,11 @@ const doSync = ({
     .catch(() => {
       dispatch(hideLoadingMessage());
       dispatch(setIsLoading(false, path));
-      dispatch(setOrgFileErrorMessage(`File ${path} not found`));
+      // the file got deleted. clean it up
+      dispatch(removeOrgFile(path));
+      if (getState().org.present.get('path') === path) {
+        dispatch(setOrgFileErrorMessage(`File ${path} not found`));
+      }
     });
 };
 
@@ -709,4 +713,9 @@ export const deleteBookmark = (context, bookmark) => ({
   type: 'DELETE_BOOKMARK',
   context,
   bookmark,
+});
+
+export const removeOrgFile = (path) => ({
+  type: 'REMOVE_ORG_FILE',
+  path,
 });

--- a/src/actions/sync_backend.js
+++ b/src/actions/sync_backend.js
@@ -2,7 +2,7 @@
 import { ActionCreators } from 'redux-undo';
 
 import { setLoadingMessage, hideLoadingMessage, clearModalStack, setIsLoading } from './base';
-import { parseFile, setDirty, setLastSyncAt, setOrgFileErrorMessage } from './org';
+import { parseFile, setDirty, setLastSyncAt, setOrgFileErrorMessage, removeOrgFile } from './org';
 import { localStorageAvailable, persistField } from '../util/settings_persister';
 import { createGitlabOAuth } from '../sync_backend_clients/gitlab_sync_backend_client';
 
@@ -127,7 +127,11 @@ export const downloadFile = (path) => {
       .catch(() => {
         dispatch(hideLoadingMessage());
         dispatch(setIsLoading(false, path));
-        dispatch(setOrgFileErrorMessage(`File ${path} not found`));
+        // the file got deleted. clean it up
+        dispatch(removeOrgFile(path));
+        if (getState().org.present.get('path') === path) {
+          dispatch(setOrgFileErrorMessage(`File ${path} not found`));
+        }
       });
   };
 };

--- a/src/middleware/live_sync.js
+++ b/src/middleware/live_sync.js
@@ -1,8 +1,21 @@
 import { sync } from '../actions/org';
-import { persistIsDirty, saveFileToLocalStorage } from '../util/file_persister';
+import {
+  persistIsDirty,
+  saveFileToLocalStorage,
+  removeFileFromLocalStorage,
+} from '../util/file_persister';
 import { determineAffectedFiles } from '../reducers/org';
 
 export default (store) => (next) => (action) => {
+  // if a file got deleted in the back end, remove it and continue
+  if (action.type === 'REMOVE_ORG_FILE') {
+    setTimeout(() => {
+      removeFileFromLocalStorage(action.path);
+    }, 0);
+
+    return next(action);
+  }
+
   // middleware is run before the reducer. to persist the result of the action,
   // save and sync are done in a callback so they happen after the state is changed
   setTimeout(() => {

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -1371,6 +1371,11 @@ const deleteBookmark = (state, { context, bookmark }) => {
   );
 };
 
+const removeOrgFile = (state, { path }) =>
+  state
+    .update('files', (files) => files.delete(path))
+    .update('opennessState', (opennessState) => opennessState.delete(path));
+
 const addNewEmptyFileSetting = (state) =>
   state.update('fileSettings', (settings) =>
     settings.push(
@@ -1543,6 +1548,8 @@ const reducer = (state, action) => {
       return saveBookmark(state, action);
     case 'DELETE_BOOKMARK':
       return deleteBookmark(state, action);
+    case 'REMOVE_ORG_FILE':
+      return removeOrgFile(state, action);
     default:
       return state;
   }

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -1374,6 +1374,9 @@ const deleteBookmark = (state, { context, bookmark }) => {
 const removeOrgFile = (state, { path }) =>
   state
     .update('files', (files) => files.delete(path))
+    .update('fileSettings', (fileSettings) =>
+      fileSettings.filter((fileSetting) => fileSetting.path !== path)
+    )
     .update('opennessState', (opennessState) => opennessState.delete(path));
 
 const addNewEmptyFileSetting = (state) =>

--- a/src/sync_backend_clients/dropbox_sync_backend_client.js
+++ b/src/sync_backend_clients/dropbox_sync_backend_client.js
@@ -124,7 +124,7 @@ export default (accessToken) => {
           // https://github.com/200ok-ch/organice/issues/108
           const objectContainsTagErrorP = (function () {
             try {
-              return JSON.parse(error.error).error.path['.tag'] === 'not_found';
+              return error.error.error.path['.tag'] === 'not_found';
             } catch (e) {
               return false;
             }

--- a/src/util/file_persister.js
+++ b/src/util/file_persister.js
@@ -27,13 +27,21 @@ export const saveFileContentsToLocalStorage = (path, contents) => {
 
 export const removeFileFromLocalStorage = (path) => {
   if (localStorageAvailable && !path.startsWith(STATIC_FILE_PREFIX)) {
-    let persistedFiles = JSON.parse(localStorage.getItem('persistedFiles'));
+    let isDirty = JSON.parse(localStorage.getItem('isDirty')) || {};
+    delete isDirty[path];
+    localStorage.setItem('isDirty', JSON.stringify(isDirty));
+
+    let persistedFiles = JSON.parse(localStorage.getItem('persistedFiles')) || {};
     delete persistedFiles[path];
     localStorage.setItem('persistedFiles', JSON.stringify(persistedFiles));
 
-    let headerOpenness = JSON.parse(localStorage.getItem('headerOpenness'));
+    let headerOpenness = JSON.parse(localStorage.getItem('headerOpenness')) || {};
     delete headerOpenness[path];
     localStorage.setItem('headerOpenness', JSON.stringify(headerOpenness));
+
+    let fileSettings = JSON.parse(localStorage.getItem('fileSettings')) || [];
+    fileSettings = fileSettings.filter((fileSetting) => fileSetting.path !== path);
+    localStorage.setItem('fileSettings', JSON.stringify(fileSettings));
 
     localStorage.removeItem('files__' + path);
   }

--- a/src/util/file_persister.js
+++ b/src/util/file_persister.js
@@ -25,6 +25,20 @@ export const saveFileContentsToLocalStorage = (path, contents) => {
   }
 };
 
+export const removeFileFromLocalStorage = (path) => {
+  if (localStorageAvailable && !path.startsWith(STATIC_FILE_PREFIX)) {
+    let persistedFiles = JSON.parse(localStorage.getItem('persistedFiles'));
+    delete persistedFiles[path];
+    localStorage.setItem('persistedFiles', JSON.stringify(persistedFiles));
+
+    let headerOpenness = JSON.parse(localStorage.getItem('headerOpenness'));
+    delete headerOpenness[path];
+    localStorage.setItem('headerOpenness', JSON.stringify(headerOpenness));
+
+    localStorage.removeItem('files__' + path);
+  }
+};
+
 const saveFunctionToDebounce = (state, path) => {
   if (localStorageAvailable && !path.startsWith(STATIC_FILE_PREFIX)) {
     const persistedFiles = JSON.parse(localStorage.getItem('persistedFiles')) || {};


### PR DESCRIPTION
adressing #602

Only tested with the dropbox backend.

There was a bug in the error handling in the dropbox backend implementation (trying to JSON.parse an already deserialized error object).

I'm not sure if there are cases where the backend call fails for other reasons that would also trigger this cleanup behaviour. The case i triggered with the dropbox backend explicitly checks for the error code "not_found" which seems reasonable.