### PR TITLE
fix title editor text loss

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -7,6 +7,12 @@ All user visible changes to organice will be documented in this file.
 
 When there are updates to the changelog, you will be notified and see a 'gift' icon appear on the top right corner.
 
+
+* [2021-12-09 Thu]
+** Fixed
+   - Title editor text loss.
+     - Since the introduction of the semantic Title editor on [2021-11-22 Mon], if you modified the text of a title and then click a todo, the todo keyword got saved which triggers a rerender before the text got saved. Therefore the text is reset to the state it was in when the title editor was opened.
+     - This is fixed, now.
 * [2021-12-05 Sun]
 ** Added
    - *EPIC* Bookmark functionality for search

--- a/src/components/OrgFile/components/TitleEditorModal/index.js
+++ b/src/components/OrgFile/components/TitleEditorModal/index.js
@@ -51,9 +51,9 @@ export default class TitleEditorModal extends PureComponent {
     const { header, editRawValues } = this.props;
     if (prevProps.header !== header || prevProps.editRawValues !== editRawValues) {
       this.setState({
-        titleValue: this.props.editRawValues
+        titleValue: editRawValues
           ? this.calculateRawTitle(header)
-          : this.props.header.getIn(['titleLine', 'rawTitle']),
+          : header.getIn(['titleLine', 'rawTitle']),
       });
       this.textarea.focus();
     }
@@ -112,6 +112,7 @@ export default class TitleEditorModal extends PureComponent {
   }
 
   handleTodoChange(newTodoKeyword) {
+    this.props.saveTitle(this.state.titleValue);
     this.props.onTodoClicked(newTodoKeyword);
   }
 

--- a/src/components/OrgFile/index.js
+++ b/src/components/OrgFile/index.js
@@ -72,6 +72,7 @@ class OrgFile extends PureComponent {
       'handleSearchPopupClose',
       'handleRefilePopupClose',
       'handleTitlePopupClose',
+      'saveTitle',
       'handleTodoChange',
       'handleDescriptionPopupClose',
       'handleTablePopupClose',
@@ -256,7 +257,7 @@ class OrgFile extends PureComponent {
     }
   }
 
-  handleTitlePopupClose(titleValue) {
+  saveTitle(titleValue) {
     const { selectedHeader } = this.props;
     if (this.state.editRawValues) {
       if (generateTitleLine(selectedHeader.toJS(), false) !== titleValue) {
@@ -273,6 +274,10 @@ class OrgFile extends PureComponent {
         );
       }
     }
+  }
+
+  handleTitlePopupClose(titleValue) {
+    this.saveTitle(titleValue);
     this.props.base.closePopup();
   }
 
@@ -514,6 +519,7 @@ class OrgFile extends PureComponent {
             editRawValues={this.state.editRawValues}
             todoKeywordSets={todoKeywordSets}
             onClose={this.getPopupCloseAction('title-editor')}
+            saveTitle={this.saveTitle}
             onTodoClicked={this.handleTodoChange}
             header={selectedHeader}
             setPopupCloseActionValuesAccessor={setPopupCloseActionValuesAccessor}


### PR DESCRIPTION
The title editor modal in semantic edit mode persists its content on different schedules.
- the todo keyword is saved on click
- the title text is saved on close

This leads to the following behaviour:
If you modify the text of a title and then click a todo, the todo keyword gets saved which triggers a rerender before the text got saved. Therefore the text is reset to the state it was in when the title editor was opened.

As a solution I save the title text before updating the todo-keyword.