### PR TITLE
Update Sign In page

### DIFF
--- a/src/components/HeaderBar/index.js
+++ b/src/components/HeaderBar/index.js
@@ -281,7 +281,7 @@ class HeaderBar extends PureComponent {
 
           {!isAuthenticated && (
             <ExternalLink href="https://github.com/200ok-ch/organice">
-              <i className="fab fa-github header-bar__actions__item" />
+              <i className="fab fa-github header-bar__actions__item fa-2x" />
             </ExternalLink>
           )}
 

--- a/src/components/HeaderBar/stylesheet.css
+++ b/src/components/HeaderBar/stylesheet.css
@@ -70,7 +70,7 @@
 .header-bar__actions__item {
   color: var(--base01);
 
-  margin-left: 0.5em;
+  margin-left: 1em;
 }
 
 .header-bar__actions__item--disabled {

--- a/src/components/Landing/__snapshots__/Landing.test.js.snap
+++ b/src/components/Landing/__snapshots__/Landing.test.js.snap
@@ -26,7 +26,7 @@ exports[`<Landing /> renders 1`] = `
       <h2
         class="landing-tagline"
       >
-        Syncs with Dropbox,
+        Syncs with Dropbox, GitLab
         <br />
          Google Drive and WebDAV.
       </h2>

--- a/src/components/Landing/index.js
+++ b/src/components/Landing/index.js
@@ -16,7 +16,7 @@ export default () => {
         <h2 className="landing-tagline">organice organizes Org files nicely!</h2>
 
         <h2 className="landing-tagline">
-          Syncs with Dropbox,
+          Syncs with Dropbox, GitLab
           <br /> Google Drive and WebDAV.
         </h2>
 


### PR DESCRIPTION
## Changes:
- [x]  Make link to Github more dominant
- [x]  Decouple "Sign In" and Github icon. Right now it looks like they are coupled.
- [x]  Bring GitLab into the list of sync back-ends

## Original:
![original](https://user-images.githubusercontent.com/39633205/145705024-69ec57d6-262d-4357-b7e8-7f6d5c6b0222.jpg)

## New:
![1em - 2x](https://user-images.githubusercontent.com/39633205/145705027-92024f6c-267b-4965-b8d0-f455ff65d611.jpg)

--
P.S. Let me know if changes needed.
Referenced Issue: #764 