### PR TITLE
Enable hosting from subdirectory

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "engines": {
     "node": "^12.13.1"
   },
+  "homepage": "",
   "dependencies": {
     "@bity/oauth2-auth-code-pkce": "^2.13.0",
     "bowser": "^2.11.0",

--- a/src/App.js
+++ b/src/App.js
@@ -216,7 +216,7 @@ export default class App extends PureComponent {
   render() {
     return (
       <DragDropContext onDragEnd={this.handleDragEnd}>
-        <Router>
+        <Router basename={process.env.PUBLIC_URL}>
           <Provider store={this.store}>
             <div className="App">
               <Entry />

--- a/src/components/SyncServiceSignIn/index.js
+++ b/src/components/SyncServiceSignIn/index.js
@@ -35,7 +35,7 @@ function WebDAVForm() {
             persistField('webdavEndpoint', url);
             persistField('webdavUsername', username);
             persistField('webdavPassword', password);
-            window.location = window.location.origin + '/';
+            window.location = window.location.origin + process.env.PUBLIC_URL;
           }}
         >
           <p>
@@ -165,9 +165,11 @@ export default class SyncServiceSignIn extends PureComponent {
       clientId: process.env.REACT_APP_DROPBOX_CLIENT_ID,
       fetch: fetch.bind(window),
     });
-    dropbox.auth.getAuthenticationUrl(window.location.origin + '/').then((authURL) => {
-      window.location = authURL;
-    });
+    dropbox.auth
+      .getAuthenticationUrl(window.location.origin + process.env.PUBLIC_URL)
+      .then((authURL) => {
+        window.location = authURL;
+      });
   }
 
   handleGoogleDriveClick() {
@@ -185,7 +187,7 @@ export default class SyncServiceSignIn extends PureComponent {
 
             gapi.auth2.getAuthInstance().signIn({
               ux_mode: 'redirect',
-              redirect_uri: window.location.origin,
+              redirect_uri: window.location.origin + process.env.PUBLIC_URL,
             });
           });
       });

--- a/src/sync_backend_clients/gitlab_sync_backend_client.js
+++ b/src/sync_backend_clients/gitlab_sync_backend_client.js
@@ -15,7 +15,7 @@ export const createGitlabOAuth = () => {
     authorizationUrl: 'https://gitlab.com/oauth/authorize',
     tokenUrl: 'https://gitlab.com/oauth/token',
     clientId: process.env.REACT_APP_GITLAB_CLIENT_ID,
-    redirectUrl: window.location.origin,
+    redirectUrl: window.location.origin + process.env.PUBLIC_URL,
     scopes: ['api'],
     extraAuthorizationParams: {
       clientSecret: process.env.REACT_APP_GITLAB_SECRET,


### PR DESCRIPTION
As a server admin I want to host organice from a subdirectory URL in order to arrange my server's routes to my liking and to have more technical flexibility (i.e. host organice from the same domain as nextcloud so that I don't have to set up CORS).

This fixes issue #732.

This implementation uses [CRA's `homepage` feature in `package.json`](https://create-react-app.dev/docs/deployment/#building-for-relative-paths). The person wanting to host organice from a subdomain should then adjust the `homepage` value to the full desired domain and path, for example `"homepage": "https://example.com/organice/"`.

After running `yarn build` as usual, they can then upload the resulting build output to that subdirectory on their server. Before this change, this was not possible because the router would have kept redirecting to the "/" route, the assets were not found, etc.

Internally, CRA takes the `homepage` value and extracts the path part of it, which is then assigned to `PUBLIC_URL`. It would also be possible to build organice without adjusting the `homepage` value and instead just calling `PUBLIC_URL=/organice yarn build`.

In my PR I left the `homepage` value as `""` which should be safe as that should lead to the same behaviour as not specifying it. See the relevant implementation in CRA [here](https://github.com/facebook/create-react-app/blob/9673858a3715287c40aef9e800c431c7d45c05a2/packages/react-dev-utils/getPublicUrlOrPath.js#L47) (the code doesn't check for undefined, it just casts to bool). 

Do you want me to add some documentation for this? If yes, where? Should I add a new section in the FAQ for this?
