### PR TITLE
Fixed manifest for PWAs, fixes #779

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -48,27 +48,31 @@
     <script>
      var {pathname} = window.location;
 
+     const absoluteUrl = function(path) {
+        return new URL(path, document.baseURI).href;
+     };
+
      var manifest = {
          "short_name": "organice",
          "name": "organice",
          "icons": [
              {
-                 "src": "organice-512x512.png",
+                 "src": absoluteUrl("organice-512x512.png"),
                  "sizes": "512x512",
                  "type": "image/png"
              },
              {
-                 "src": "organice-192x192.png",
+                 "src": absoluteUrl("organice-192x192.png"),
                  "sizes": "192x192",
                  "type": "image/png"
              },
              {
-                 "src": "favicon.ico",
+                 "src": absoluteUrl("favicon.ico"),
                  "sizes": "64x64 32x32 24x24 16x16",
                  "type": "image/x-icon"
              }
          ],
-         "start_url": pathname || "/index.html",
+         "start_url": absoluteUrl(pathname || "/index.html"),
          "display": "standalone",
          "theme_color": "#000000",
          "background_color": "#ffffff"


### PR DESCRIPTION
As discussed in #779 

Since the manifest generation happens inline, `absoluteUrl()` is defined in the global namespace, hopefully does not lead to problems.

I have based the PR on `master`, if it shall be based on another branch, I'm happy to change it!