### PR TITLE
WIP: organice as share target

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -75,8 +75,16 @@
          "start_url": absoluteUrl(pathname || "/index.html"),
          "display": "standalone",
          "theme_color": "#000000",
-         "background_color": "#ffffff"
-     }
+         "background_color": "#ffffff",
+          "share_target": {
+            "action": "/capture",
+            "params": {
+              "title": "captureVariable_v_title",
+              "text": "captureVariable_v_text",
+              "url": "captureVariable_v_url"
+            }
+          },
+     };
 
      const manifestBlob = new Blob([JSON.stringify(manifest)], {type: 'application/json'});
      const manifestURL = URL.createObjectURL(manifestBlob);

--- a/src/components/Capture/index.js
+++ b/src/components/Capture/index.js
@@ -50,7 +50,7 @@ const Capture = ({
           <p>selected template: { template.get('description') }</p>
 
           <Link
-            to={`/share?${getQueryString()}`}
+            to={`/capture?${getQueryString()}`}
           >select different template</Link>
         </div>
       );
@@ -64,7 +64,7 @@ const Capture = ({
             <li>
               <Link
                 key={template.get('id')}
-                to={`/share/${template.get('description')}?${getQueryString()}`}
+                to={`/capture/${template.get('description')}?${getQueryString()}`}
               >{template.get('description')}</Link>
             </li>
           ))}

--- a/src/components/Capture/index.js
+++ b/src/components/Capture/index.js
@@ -1,0 +1,207 @@
+import React, { Fragment, useState, useEffect } from 'react';
+import { connect } from 'react-redux';
+import { useParams, Link, useHistory } from "react-router-dom";
+// import './stylesheet.css';
+
+import { List, Map } from 'immutable';
+import { STATIC_FILE_PREFIX } from '../../lib/org_utils';
+
+import parseQueryString from '../../util/parse_query_string';
+
+const Capture = ({
+  captureTemplates,
+  loadedFilePaths,
+  state,
+}) => {
+
+  /**
+   * Return a list of possible files for a capture template. Some templates
+   * force a certain file, some allow a specific whitelist and some allow all
+   * files
+   */
+  const getPossibleFilesForTemplate = (template) => {
+    if (!template) {
+      return [];
+    }
+
+    if (template.get('file')) {
+      return [template.get('file')];
+    }
+
+    if (!template.get('isAvailableInAllOrgFiles')) {
+      return template.get('orgFilesWhereAvailable').toJS();
+    }
+
+    return loadedFilePaths.filter(path => !!path);
+  };
+
+  /**
+   * Render the template selector or the current template
+   * 
+   * If no template is selected, show the list of all templates and let the user
+   * select one. If a template is selected, show the selected template and a
+   * button to unselect it
+   */
+  const renderTemplateSelector = () => {
+
+    if (template) {
+      return (
+        <div>
+          <p>selected template: { template.get('description') }</p>
+
+          <Link
+            to={`/share?${getQueryString()}`}
+          >select different template</Link>
+        </div>
+      );
+    }
+
+    return (
+      <div>
+        <p>select a template:</p>
+        <ul>
+          {captureTemplates.map((template, index) => (
+            <li>
+              <Link
+                key={template.get('id')}
+                to={`/share/${template.get('description')}?${getQueryString()}`}
+              >{template.get('description')}</Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+    ;
+  }
+
+  /**
+   * Render the file selector, if a template is selected. Depending on the
+   * template, show a dropdown with possible files or just an automatically
+   * selected file
+   */
+  const renderFileSelector = () => {
+
+    if (!template) {
+      return null;
+    }
+
+    return (
+      <select onChange={(e) => setCaptureFile(e.target.value)} style={{ width: '90%' }} value={captureFile}>
+        {getPossibleFilesForTemplate(template).map((path) => (
+          <option key={path} value={path}>
+            {path}
+          </option>
+        ))}
+      </select>
+    );
+  };
+
+  /**
+   * Render the submit button, if submitting is possible
+   */
+  const renderSubmit = () => {
+    if (!template || !captureFile) {
+      return null;
+    }
+
+    return (
+      <button
+        onClick={submit}
+      >capture {template.get('description')} to {captureFile}</button>
+    );
+  };
+
+      // TODO just copied from App.js, make it a reusable function
+  const getCustomCaptureVariables = () => Map(
+    Object.entries(queryStringContents)
+      .map(([key, value]) => {
+        const CUSTOM_VARIABLE_PREFIX = 'captureVariable_';
+        if (key.startsWith(CUSTOM_VARIABLE_PREFIX)) {
+          return [key.substring(CUSTOM_VARIABLE_PREFIX.length), value];
+        }
+
+        return null;
+      })
+      .filter((item) => !!item)
+  );
+
+  /**
+   * Submit the capture. Update the state with target file, capture template &
+   * contents, and redirect to the target file. The actual capture is handled there
+   */
+  const submit = () => {
+
+    let customCaptureVariables = getCustomCaptureVariables();
+
+    state.org.present = state.org.present.set(
+      'pendingCapture',
+      Map({
+        capturePath: captureFile,
+        captureTemplateName: template.get("description"),
+        captureContent: captureContent,
+        customCaptureVariables,
+      })
+    );
+
+    history.push(`/file${captureFile}`);
+  };
+
+  const history = useHistory();
+
+  // get the template from the router
+  const templateName = useParams().template;
+  const template = captureTemplates
+      .find((template) => template.get('description').trim() === templateName);
+
+  const queryStringContents = parseQueryString(window.location.search);
+
+  let captureFilename = queryStringContents.captureFile;
+  if (template && template.get('file')) {
+    captureFilename = template.get('file');
+  }
+
+  const [captureFile, setCaptureFile] = useState(captureFilename);
+  const captureContent = queryStringContents.captureContent;
+
+  const getQueryString = (additionalParams = {}) => new URLSearchParams({...queryStringContents, ...additionalParams});
+
+  // whenever the template changes (by router navigation), reset the capture
+  // file to the first possible one
+  useEffect(() => {
+    setCaptureFile(getPossibleFilesForTemplate(template)[0]);
+  }, [template]);
+
+  return (
+    <div>
+      <h1>Capture</h1>
+
+      <h2>Template</h2>
+      { renderTemplateSelector() }
+
+      <h2>Target file</h2>
+      { renderFileSelector() }
+
+      <p>
+      { renderSubmit() }
+      </p>
+
+    </div>
+  );
+};
+
+const mapStateToProps = (state) => {
+
+  const loadedFilePaths = state.org.present
+    .get('files', List())
+    .keySeq()
+    .toJS()
+    .filter((path) => !path.startsWith(STATIC_FILE_PREFIX));
+  loadedFilePaths.unshift('');
+  return {
+    captureTemplates: state.capture.get('captureTemplates', List()),
+    loadedFilePaths,
+    state,
+  };
+};
+
+export default connect(mapStateToProps)(Capture);

--- a/src/components/Capture/index.js
+++ b/src/components/Capture/index.js
@@ -61,9 +61,8 @@ const Capture = ({
         <p>select a template:</p>
         <ul>
           {captureTemplates.map((template, index) => (
-            <li>
+            <li key={template.get('id')}>
               <Link
-                key={template.get('id')}
                 to={`/capture/${template.get('description')}?${getQueryString()}`}
               >{template.get('description')}</Link>
             </li>

--- a/src/components/Entry/index.js
+++ b/src/components/Entry/index.js
@@ -20,6 +20,7 @@ import OrgFile from '../OrgFile';
 import Settings from '../Settings';
 import KeyboardShortcutsEditor from '../KeyboardShortcutsEditor';
 import CaptureTemplatesEditor from '../CaptureTemplatesEditor';
+import Capture from '../Capture';
 import FileSettingsEditor from '../FileSettingsEditor';
 import SyncServiceSignIn from '../SyncServiceSignIn';
 
@@ -194,6 +195,7 @@ class Entry extends PureComponent {
                 <Route path="/settings" exact={true}>
                   <Settings />
                 </Route>
+                <Route path="/capture/:template?" exact component={Capture} />
                 <Redirect to="/files" />
               </Switch>
             )


### PR DESCRIPTION
Hi,

this WIP pull request aims to make organice show up as a share target on android, as described in #52

First of all, I cannot get *any* PWA to show up as share target on my phone, not even the sample PWAs like https://github.com/GoogleChrome/samples/blob/gh-pages/web-share/README.md#web-share-demo
That being said, I won't be able to finish this PR since I can neither use nor test it properly.
Maybe someelse wants to finish the PR though (there is not much left to do imo). Or maybe the new `/capture` page is useful on its own already.

Implemented so far:
- a new route `/capture` is implemented, which lets the user select capture template & target file (capture template settings are used here, e.g. which capture template is available in which files). Either one or both parameters can also be passed as URL parameters, the form is then populated with these values
- on submitting the form, the user is forwarded to the selected file & the capture process is triggered
- any `captureVariable_` url parameters are forwarded through the process, so you can open the initial page `/caputre?captureVariable_foo=bar`, select file & template interactively, and the capture variables are still used in the following capture process
- "Share targets" on android receive three parameters: `title`, `text`, `url`: these will be mapped into the capture variables `v_title`, `v_text`, `v_url` (see below for the strange variable names)

TODOs
- The url `/capture` should be used as the share target, with the `captureVaraible_*` parameters filled. I have added this already to the manifest, so it *should* work already. No idea why this does not work on my phone, but maybe someone else can test it.
- probably the capture page can be styled a bit nicer

Some open questions / further ideas:
- the replacement of capture variables seems odd to me (or maybe I was doing something wrong?): the single letter placeholders like `%u` or `%t` get replaced *before* any custom variables (like `captureVariable_url` / `%url`), so there can be no capture variables starting with certain letter (for example `%title` woiuld be replaced to `[1970-01-01]itle`). Is that behaviour intended? Or am I doing something wrong? I have prefixed the capture variables with `v_` meanwhile
- this PR makes organice show up as a *single* share target. It might also be possible to make certain capture templates show up as share targets on their own (mabye with a template setting). This should be a separate issue imo
- when the user submits the form on the `/capture` route, the capture process is directly triggered and the captured content saved to the file. Under some circumstances it could be preferable to show the capture popup and let the user change the captured content interactively
