### PR TITLE
fix: Rename sample demo file in bundled WebDAV image

### DIFF
--- a/doc/webdav/Dockerfile
+++ b/doc/webdav/Dockerfile
@@ -18,7 +18,7 @@ RUN mkdir /srv/dav
 RUN chmod 770 /srv/dav
 RUN chown www-data. /srv/dav
 
-COPY sample.org /srv/dav
+COPY sample.org /srv/dav/demo.org
 
 CMD apachectl -D FOREGROUND
 EXPOSE 80


### PR DESCRIPTION
Otherwise there's a routing conflict between the actual sample.org file and the demo file.

That means, that anyone who has a `sample.org` file might still run
into the problem. The better fix would be, of course, to treat the
sample.org file differently. However, that would be a bigger refactor which could be done by the person requiring to have a file in her root directory to be called `sample.org`.