### PR TITLE
Specify default webDAV URL in .env file

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,4 @@
 REACT_APP_DROPBOX_CLIENT_ID=your_dropbox_client_id
 REACT_APP_GITLAB_CLIENT_ID=your_gitlab_client_id
 REACT_APP_GITLAB_SECRET=your_gitlab_secret
+REACT_APP_WEBDAV_URL=your_default_webdav_server_if_desired

--- a/src/components/SyncServiceSignIn/index.js
+++ b/src/components/SyncServiceSignIn/index.js
@@ -19,7 +19,7 @@ import _ from 'lodash';
 function WebDAVForm() {
   const [isVisible, setIsVisible] = useState(false);
   const toggleVisible = () => setIsVisible(!isVisible);
-  const [url, setUrl] = useState('');
+  const [url, setUrl] = useState(process.env.REACT_APP_WEBDAV_URL);
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
 


### PR DESCRIPTION
Added the feature to specify the REACT_APP_WEBDAV_URL in the .env file and have the sign-in page pre-fill in that field based on your default preference.  This variable is optional in the .env file