### PR TITLE
feat: transient env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN yarn install
 
 COPY . /opt/organice
 
-RUN ./bin/transient_env_vars.sh bate >> .env
+RUN bin/transient_env_vars.sh bait >> .env
 
 RUN yarn global add serve \
     && yarn build \
@@ -26,7 +26,9 @@ RUN yarn global add serve \
 # No root privileges are required. Create and switch to non-root user.
 # https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
 RUN addgroup -S organice \
-    && adduser -S organice -G organice
+        && adduser -S organice -G organice \
+        && chown -R organice: .
+
 USER organice
 
 ENV NODE_ENV=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ RUN yarn install
 
 COPY . /opt/organice
 
+RUN ./bin/transient_env_vars.sh bate >> .env
+
 RUN yarn global add serve \
     && yarn build \
     && yarn cache clean \
@@ -29,4 +31,4 @@ USER organice
 
 ENV NODE_ENV=production
 EXPOSE 5000
-ENTRYPOINT ["serve", "-s", "build"]
+ENTRYPOINT ["./bin/entrypoint.sh"]

--- a/README.org
+++ b/README.org
@@ -623,7 +623,7 @@ signin form. See [[https://github.com/200ok-ch/organice/blob/master/docker-compo
 A full list of such environment variables can be found in [[https://github.com/200ok-ch/organice/blob/master/.env.sample][.env.sample]].
 
 The prefix =REACT_APP_= has to be replaced with =ORGANICE_=. The
-naming should be pretty self eplanatory.
+naming should be pretty self explanatory.
 
 *** With =docker-compose=
 

--- a/README.org
+++ b/README.org
@@ -618,9 +618,9 @@ organice is also available as a Docker image.
 
 The docker image recognizes a couple of environment variables. For
 example =ORGANICE_WEBDAV_URL= prefills the URL field in the WebDAV
-signin form. See [[docker-compose.yaml]] for an example how to use it.
+signin form. See [[https://github.com/200ok-ch/organice/blob/master/docker-compose.yaml][docker-compose.yaml]] for an example how to use it.
 
-A full list of such environment variables can be found in [[.env.sample]].
+A full list of such environment variables can be found in [[https://github.com/200ok-ch/organice/blob/master/.env.sample][.env.sample]].
 
 The prefix =REACT_APP_= has to be replaced with =ORGANICE_=. The
 naming should be pretty self eplanatory.

--- a/README.org
+++ b/README.org
@@ -618,7 +618,7 @@ organice is also available as a Docker image.
 
 The docker image recognizes a couple of environment variables. For
 example =ORGANICE_WEBDAV_URL= prefills the URL field in the WebDAV
-signin form. See [[docker-compose.yml]] for an example how to use it.
+signin form. See [[docker-compose.yaml]] for an example how to use it.
 
 A full list of such environment variables can be found in [[.env.sample]].
 

--- a/README.org
+++ b/README.org
@@ -616,6 +616,15 @@ deployed via FTP. The full build script is in
 
 organice is also available as a Docker image.
 
+The docker image recognizes a couple of environment variables. For
+example =ORGANICE_WEBDAV_URL= prefills the URL field in the WebDAV
+signin form. See [[docker-compose.yml]] for an example how to use it.
+
+A full list of such environment variables can be found in [[.env.sample]].
+
+The prefix =REACT_APP_= has to be replaced with =ORGANICE_=. The
+naming should be pretty self eplanatory.
+
 *** With =docker-compose=
 
 If [[https://docs.docker.com/compose/][docker-compose]] is installed, the following command downloads and

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+./bin/transient_env_vars.sh switch build serve
+
+serve -s serve

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-./bin/transient_env_vars.sh switch build serve
+bin/transient_env_vars.sh switch build serve
 
 serve -s serve

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -2,4 +2,4 @@
 
 bin/transient_env_vars.sh switch build serve
 
-serve -s serve
+serve -p 5000 -s serve

--- a/bin/transient_env_vars.sh
+++ b/bin/transient_env_vars.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 shopt -s globstar
 

--- a/bin/transient_env_vars.sh
+++ b/bin/transient_env_vars.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/bash
+
+shopt -s globstar
+
+RVARS=$(cut -d = -f 1 .env.sample)
+
+case $1 in
+
+  "bait")
+    for KEY in $RVARS; do
+      echo "$KEY=${KEY//REACT_APP_/ORGANICE_}"
+    done
+    ;;
+
+  "switch")
+    SRC=$2
+    DST=$3
+
+    rm -rf "$DST"
+    cp -r "$SRC" "$DST"
+
+    OVARS=${RVARS//REACT_APP_/ORGANICE_}
+
+    for KEY in $OVARS; do
+      VALUE=${!KEY}
+      sed -i "s/$KEY/$VALUE/" "$DST"/**/*.js
+    done
+    ;;
+
+  *)
+    echo "Unknown command: $1"
+    ;;
+esac

--- a/changelog.org
+++ b/changelog.org
@@ -13,6 +13,9 @@ When there are updates to the changelog, you will be notified and see a 'gift' i
 - Specify default webDAV URL in .env file
   - PR: https://github.com/200ok-ch/organice/pull/829
   - Thank you [[https://github.com/dmorlitz][dmorlitz]] for the PR🙏
+- Docker image recognizes env vars
+  - PR: https://github.com/200ok-ch/organice/pull/835
+  - see [[https://organice.200ok.ch/documentation.html#docker][doc]] for more information
 
 * [2022-06-03 Fri]
 ** Removed

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,11 +1,14 @@
 version: '3'
 services:
   organice:
-    image: 'twohundredok/organice:latest'
+    build: .
+    # image: 'twohundredok/organice:latest'
     ports:
-      - '5000:5000'
+      - '5000:3000'
     logging:
       driver: json-file
+    environment:
+      ORGANICE_WEBDAV_URL: hello.world
   apache-webdav:
     build:
       context: ./

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,14 +1,13 @@
 version: '3'
 services:
   organice:
-    build: .
-    # image: 'twohundredok/organice:latest'
+    image: 'twohundredok/organice:latest'
     ports:
-      - '5000:3000'
+      - '5000:5000'
     logging:
       driver: json-file
     environment:
-      ORGANICE_WEBDAV_URL: hello.alain
+      ORGANICE_WEBDAV_URL: http://webdav.example.com
   apache-webdav:
     build:
       context: ./

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
     logging:
       driver: json-file
     environment:
-      ORGANICE_WEBDAV_URL: hello.world
+      ORGANICE_WEBDAV_URL: hello.alain
   apache-webdav:
     build:
       context: ./


### PR DESCRIPTION
This uses an 2 step approach (**bait & switch**) to inject the values of environment variables post compilation.

Step 1: Scan `.env.sample` and build a dummy `.env` file (**bait**) that injects dummy strings that can be replaced post compilation.

Step 2: After compilation replace (**switch**) the dummy strings with the value of corresponding env vars. (This is cheap and runs on every start of the docker container.)