### PR TITLE
Added capture template variables to enable advanced dates

### DIFF
--- a/src/components/CaptureTemplatesEditor/components/CaptureTemplate/index.js
+++ b/src/components/CaptureTemplatesEditor/components/CaptureTemplate/index.js
@@ -292,6 +292,12 @@ export default ({
             <code>%U</code> - Inactive timestamp, with date and time.
           </li>
           <li>
+            <code>%r</code> - Timestamp, date only, no surrounding punctation - for dates with modifiers.
+          </li>
+          <li>
+            <code>%R</code> - Timestamp, with date and time, no surrounding punctuation - for dates with modifiers.
+          </li>
+          <li>
             <code>%{'<custom variable>'}</code> - A custom variable from a URL param capture. See{' '}
             <ExternalLink href="https://organice.200ok.ch/documentation.html#capture_templates">
               the README file

--- a/src/components/CaptureTemplatesEditor/components/CaptureTemplate/index.js
+++ b/src/components/CaptureTemplatesEditor/components/CaptureTemplate/index.js
@@ -292,10 +292,10 @@ export default ({
             <code>%U</code> - Inactive timestamp, with date and time.
           </li>
           <li>
-            <code>%r</code> - Timestamp, date only, no surrounding punctation - for dates with modifiers.
+            <code>%r</code> - Timestamp, date only, no surrounding punctation.
           </li>
           <li>
-            <code>%R</code> - Timestamp, with date and time, no surrounding punctuation - for dates with modifiers.
+            <code>%R</code> - Timestamp, with date and time, no surrounding punctuation.
           </li>
           <li>
             <code>%{'<custom variable>'}</code> - A custom variable from a URL param capture. See{' '}

--- a/src/lib/capture_template_substitution.js
+++ b/src/lib/capture_template_substitution.js
@@ -12,6 +12,8 @@ export default (templateString, customVariables = Map()) => {
     '%T': `<${format(new Date(), 'yyyy-MM-dd eee HH:mm')}>`,
     '%u': `[${format(new Date(), 'yyyy-MM-dd eee')}]`,
     '%U': `[${format(new Date(), 'yyyy-MM-dd eee HH:mm')}]`,
+    '%r': `${format(new Date(), 'yyyy-MM-dd eee')}`,
+    '%R': `${format(new Date(), 'yyyy-MM-dd eee HH:mm')}`,
   };
 
   customVariables.entrySeq().forEach(([key, value]) => {


### PR DESCRIPTION
Added %r and %R to the capture template input form and substitution code, so you can specify dates with modifiers in capture templates, such as <%r ++60d>

Currently if you use %t you would get (as an example) <<2022-06-13> ++60d> (which is invalid) - and the same is true for %u but with brackets