### PR TITLE
fix: Conflated Routing

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -29,7 +29,7 @@ import createGitLabSyncBackendClient, {
 
 import './base.css';
 
-import SwitchComponent from './components/SwitchComponent';
+import Turnout from './components/Turnout';
 
 import {
   listenToBrowserButtons,
@@ -210,7 +210,7 @@ export default class App extends PureComponent {
       <DragDropContext onDragEnd={this.handleDragEnd}>
         <BrowserRouter>
           <Provider store={this.store}>
-            <SwitchComponent />
+            <Turnout />
           </Provider>
         </BrowserRouter>
       </DragDropContext>

--- a/src/App.js
+++ b/src/App.js
@@ -29,7 +29,7 @@ import createGitLabSyncBackendClient, {
 
 import './base.css';
 
-import Entry from './components/Entry';
+import SwitchComponent from './components/SwitchComponent';
 
 import {
   listenToBrowserButtons,
@@ -210,7 +210,7 @@ export default class App extends PureComponent {
       <DragDropContext onDragEnd={this.handleDragEnd}>
         <Router>
           <Provider store={this.store}>
-            <Entry />
+            <SwitchComponent />
           </Provider>
         </Router>
       </DragDropContext>

--- a/src/App.js
+++ b/src/App.js
@@ -12,7 +12,7 @@ import {
 
 import runAllMigrations from './migrations';
 import parseQueryString from './util/parse_query_string';
-import { BrowserRouter as Router } from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 
 import { DragDropContext } from 'react-beautiful-dnd';
 
@@ -208,11 +208,11 @@ export default class App extends PureComponent {
   render() {
     return (
       <DragDropContext onDragEnd={this.handleDragEnd}>
-        <Router>
+        <BrowserRouter>
           <Provider store={this.store}>
             <SwitchComponent />
           </Provider>
-        </Router>
+        </BrowserRouter>
       </DragDropContext>
     );
   }

--- a/src/components/Entry/index.js
+++ b/src/components/Entry/index.js
@@ -43,9 +43,11 @@ class Entry extends PureComponent {
   }
 
   componentDidMount() {
-    this.setChangelogUnseenChanges();
-    this.props.filesToLoad.forEach((path) => this.props.syncBackend.downloadFile(path));
-    this.props.filesToSync.forEach((path) => this.props.org.sync({ path }));
+    if (!isLandingPage()) {
+      this.setChangelogUnseenChanges();
+      this.props.filesToLoad.forEach((path) => this.props.syncBackend.downloadFile(path));
+      this.props.filesToSync.forEach((path) => this.props.org.sync({ path }));
+    }
   }
 
   // TODO: Should this maybe done on init of the application and not in the component?

--- a/src/components/Settings/index.js
+++ b/src/components/Settings/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
-import { withRouter, Link } from 'react-router-dom';
+import { withRouter, Link, useHistory } from 'react-router-dom';
 
 import * as syncBackendActions from '../../actions/sync_backend';
 import * as baseActions from '../../actions/base';
@@ -37,6 +37,8 @@ const Settings = ({
   base,
   org,
 }) => {
+  const history = useHistory();
+
   // This looks like hardcoding where it would be possible to dispatch
   // on the `location.origin`, but here we assure that every instance
   // of organice has a valid link to documentation. Self-building does
@@ -46,8 +48,14 @@ const Settings = ({
     ? 'https://staging.organice.200ok.ch'
     : 'https://organice.200ok.ch';
 
-  const handleSignOutClick = () =>
-    window.confirm('Are you sure you want to sign out?') ? syncBackend.signOut() : void 0;
+  const handleSignOutClick = () => {
+    if (window.confirm('Are you sure you want to sign out?')) {
+      syncBackend.signOut();
+      history.push('/');
+    } else {
+      return void 0;
+    }
+  };
 
   const handleKeyboardShortcutsClick = () => base.pushModalPage('keyboard_shortcuts_editor');
 

--- a/src/components/Settings/index.js
+++ b/src/components/Settings/index.js
@@ -52,8 +52,6 @@ const Settings = ({
     if (window.confirm('Are you sure you want to sign out?')) {
       syncBackend.signOut();
       history.push('/');
-    } else {
-      return void 0;
     }
   };
 

--- a/src/components/SwitchComponent/index.js
+++ b/src/components/SwitchComponent/index.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import Landing from '../Landing';
+import Entry from '../Entry';
+
+import { isLandingPage } from '../../util/misc';
+
+export default () => {
+  if (isLandingPage()) {
+    return (
+      <div className="App landing-page">
+        <Landing />
+      </div>
+    );
+  } else {
+    return <Entry />;
+  }
+};

--- a/src/components/SwitchComponent/index.js
+++ b/src/components/SwitchComponent/index.js
@@ -67,8 +67,4 @@ const mapStateToProps = (state) => {
   };
 };
 
-const mapDispatchToProps = (dispatch) => {
-  return {};
-};
-
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(SwitchComponent));
+export default withRouter(connect(mapStateToProps)(SwitchComponent));

--- a/src/components/SwitchComponent/index.js
+++ b/src/components/SwitchComponent/index.js
@@ -1,18 +1,76 @@
+// organice renders different kinds of components:
+//  - Static pages like the landing page
+//  - The actual application
+// These components do not have many things in common. See adr-002 for
+// details Neither CSS, nor structure. <SwitchComponent /> ensures
+// rendering either a static page or a dynamic application component.
+
 import React from 'react';
+import { connect } from 'react-redux';
+
+import { Route, Switch, Redirect, withRouter } from 'react-router-dom';
 
 import Landing from '../Landing';
 import Entry from '../Entry';
+import PrivacyPolicy from '../PrivacyPolicy';
+import SyncServiceSignIn from '../SyncServiceSignIn';
+import OrgFile from '../OrgFile';
+import HeaderBar from '../HeaderBar';
 
-import { isLandingPage } from '../../util/misc';
+const SwitchComponent = ({ isAuthenticated }) => {
+  console.log(isAuthenticated);
+  if (isAuthenticated) return <Entry />;
 
-export default () => {
-  if (isLandingPage()) {
+  if (!isAuthenticated)
     return (
-      <div className="App landing-page">
-        <Landing />
+      <div>
+        <Switch>
+          <Route path="/privacy-policy" exact>
+            <div className="App">
+              <HeaderBar />
+              <PrivacyPolicy />
+            </div>
+          </Route>
+          <Route path="/sample" exact={true}>
+            <div className="App">
+              <HeaderBar />
+              <OrgFile
+                staticFile="sample"
+                shouldDisableDirtyIndicator={true}
+                shouldDisableActionDrawer={false}
+                shouldDisableSyncButtons={true}
+                parsingErrorMessage={
+                  "The contents of sample.org couldn't be loaded. You probably forgot to set the environment variable - see the Development section of README.org for details!"
+                }
+              />
+            </div>
+          </Route>
+          <Route path="/sign_in" exact={true}>
+            <div className="App">
+              <HeaderBar />
+              <SyncServiceSignIn />
+            </div>
+          </Route>
+          <Route path="/" exact={true}>
+            <div className="App landing-page">
+              <Landing />
+            </div>
+          </Route>
+          <Route component={Entry} />
+          <Redirect to="/" />
+        </Switch>
       </div>
     );
-  } else {
-    return <Entry />;
-  }
 };
+
+const mapStateToProps = (state) => {
+  return {
+    isAuthenticated: state.syncBackend.get('isAuthenticated'),
+  };
+};
+
+const mapDispatchToProps = (dispatch) => {
+  return {};
+};
+
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(SwitchComponent));

--- a/src/components/SwitchComponent/index.js
+++ b/src/components/SwitchComponent/index.js
@@ -18,7 +18,6 @@ import OrgFile from '../OrgFile';
 import HeaderBar from '../HeaderBar';
 
 const SwitchComponent = ({ isAuthenticated }) => {
-  console.log(isAuthenticated);
   if (isAuthenticated) return <Entry />;
 
   if (!isAuthenticated)
@@ -26,13 +25,13 @@ const SwitchComponent = ({ isAuthenticated }) => {
       <div>
         <Switch>
           <Route path="/privacy-policy" exact>
-            <div className="App">
+            <div className="App entry-container">
               <HeaderBar />
               <PrivacyPolicy />
             </div>
           </Route>
           <Route path="/sample" exact={true}>
-            <div className="App">
+            <div className="App entry-container">
               <HeaderBar />
               <OrgFile
                 staticFile="sample"
@@ -46,7 +45,7 @@ const SwitchComponent = ({ isAuthenticated }) => {
             </div>
           </Route>
           <Route path="/sign_in" exact={true}>
-            <div className="App">
+            <div className="App entry-container">
               <HeaderBar />
               <SyncServiceSignIn />
             </div>
@@ -56,7 +55,6 @@ const SwitchComponent = ({ isAuthenticated }) => {
               <Landing />
             </div>
           </Route>
-          <Route component={Entry} />
           <Redirect to="/" />
         </Switch>
       </div>

--- a/src/components/Turnout/index.js
+++ b/src/components/Turnout/index.js
@@ -1,9 +1,10 @@
 // organice renders different kinds of components:
 //  - Static pages like the landing page
 //  - The actual application
-// These components do not have many things in common. See adr-002 for
-// details Neither CSS, nor structure. <SwitchComponent /> ensures
-// rendering either a static page or a dynamic application component.
+// These components do not have many things in common, neither CSS,
+// nor structure. See adr-002 for details <Turnout />
+// ensures rendering either a static page or a dynamic application
+// component.
 
 import React from 'react';
 import { connect } from 'react-redux';
@@ -17,7 +18,7 @@ import SyncServiceSignIn from '../SyncServiceSignIn';
 import OrgFile from '../OrgFile';
 import HeaderBar from '../HeaderBar';
 
-const SwitchComponent = ({ isAuthenticated }) => {
+const Turnout = ({ isAuthenticated }) => {
   if (isAuthenticated) return <Entry />;
 
   if (!isAuthenticated)
@@ -67,4 +68,4 @@ const mapStateToProps = (state) => {
   };
 };
 
-export default withRouter(connect(mapStateToProps)(SwitchComponent));
+export default withRouter(connect(mapStateToProps)(Turnout));

--- a/src/sync_backend_clients/gitlab_sync_backend_client.js
+++ b/src/sync_backend_clients/gitlab_sync_backend_client.js
@@ -51,6 +51,8 @@ export const createGitlabOAuth = () => {
  * parsing succeeded, otherwise undefined.
  */
 export const gitLabProjectIdFromURL = (projectURL) => {
+  if (!projectURL) return;
+
   if (!projectURL.includes('://')) {
     // URL() class requires protocol.
     projectURL = `https://${projectURL}`;

--- a/src/util/misc.js
+++ b/src/util/misc.js
@@ -11,5 +11,9 @@ export const formatTextWrap = (text, w) => {
 
 export const isLandingPage = () => {
   const history = createBrowserHistory();
-  return !window.testRunner && history.location.pathname === '/';
+  return (
+    !window.testRunner &&
+    history.location.pathname === '/' &&
+    !localStorage.authenticatedSyncService
+  );
 };


### PR DESCRIPTION
We are running different kinds of pages in our SPA (see [ADR-002](https://organice.200ok.ch/documentation.html#adr-002)).

Currently, the `<Entry />` component has conflated logic for rendering the LP and the actual application. This makes the code more complex and can yield unexpected side effects.

Todos:

- [x] Create a new component `<SwitchComponent />` that has the responsibility to render either `<Landing />` or `<Entry />`
- [x] Render the new `<SwitchComponent />` in `<App />`
- [x] Refactor relevant Routing logic from `<Entry />` to `<SwitchComponent />`
- [x] Remove LP boilerplate from `<Entry />` 
- [x] Do extensive manual testing to ensure that all routes still work 
- [x] Come up with better naming than SwitchComponent, it's just a working title
  - [x] @branch14 proposes `Turnout` as in railway lingo 
