### PR TITLE
fix: Automatically sign out when Dropbox has expired access token

### DIFF
--- a/src/actions/sync_backend.js
+++ b/src/actions/sync_backend.js
@@ -7,6 +7,8 @@ import { createGitlabOAuth } from '../sync_backend_clients/gitlab_sync_backend_c
 
 import { addSeconds } from 'date-fns';
 
+import _ from 'lodash';
+
 import pathParse from 'path-parse';
 
 export const signOut = () => (dispatch, getState) => {
@@ -68,9 +70,16 @@ export const getDirectoryListing = (path) => (dispatch, getState) => {
       dispatch(hideLoadingMessage());
     })
     .catch((error) => {
-      alert('There was an error retrieving files!');
-      console.error(error);
       dispatch(hideLoadingMessage());
+      if (
+        error.status === 401 ||
+        _.get(error, 'error.error_summary').includes('expired_access_token')
+      ) {
+        dispatch(signOut());
+      } else {
+        alert('There was an error retrieving files!');
+        console.error(error);
+      }
     });
 };
 


### PR DESCRIPTION
NOTE: This is a bad (non-)solution to https://github.com/200ok-ch/organice/issues/848 However, it is a safeguard in case authentication for sync back-ends expires. It's better than to show a 401 and require the user to sign off manually.

Background why this can happen right now: Dropbox is in the process of switching to only issuing short-lived access tokens. They started migrating apps on September 30th 2021. They are releasing it gradually, so some apps may not have been affected until now.

https://www.dropboxforum.com/t5/Dropbox-API-Support-Feedback/dropbox-exceptions-AuthError-expired-access-token/td-p/580407

Followup: We should be looking into Dropbox refresh tokens. More info in #848.

Leaving this PR for reference until then.