### PR TITLE
feat: Handle empty files

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -7,6 +7,12 @@ All user visible changes to organice will be documented in this file.
 
 When there are updates to the changelog, you will be notified and see a 'gift' icon appear on the top right corner.
 
+* [2022-06-22 Wed]
+** Added
+- Ability to handle empty files
+  - This takes care of a big UX problem for users who solely rely on organice. So far, we've shown a parser error if the file is empty *or* if the file did not contain a headline.
+  - Now, if the user opens a file that is empty, or has no headlines, she will see the call to action to create a new headline.
+  - PR: https://github.com/200ok-ch/organice/pull/853
 * [2022-06-16 Thu]
 ** Added
 - Capture template variables =%r= and =%R= expanding to raw timestamps

--- a/src/actions/org.js
+++ b/src/actions/org.js
@@ -315,6 +315,11 @@ export const addHeader = (headerId) => ({
   dirtying: false,
 });
 
+export const createFirstHeader = () => ({
+  type: 'CREATE_FIRST_HEADER',
+  dirtying: true,
+});
+
 export const selectNextSiblingHeader = (headerId) => ({
   type: 'SELECT_NEXT_SIBLING_HEADER',
   headerId,

--- a/src/components/OrgFile/OrgFile.integration.test.js
+++ b/src/components/OrgFile/OrgFile.integration.test.js
@@ -113,6 +113,18 @@ describe('Render all views', () => {
       getByPlaceholderText = res.getByPlaceholderText;
     });
 
+    describe('Works with Org files without headlines', () => {
+      test('Works with a completely empty files', () => {
+        store.dispatch(
+          parseFile(STATIC_FILE_PREFIX + 'fixtureTestFile.org', readFixture('empty_file'))
+        );
+        expect(queryByText('This file has no headlines')).toBeTruthy();
+        expect(queryAllByText('Yes, your file has content.').length).toEqual(0);
+        // Sanity check, ensure that not the regular test file is loaded.
+        expect(queryByText('Top level header')).toBeFalsy();
+      });
+    });
+
     describe('Actions within an Org file', () => {
       test('Can select a header in an org file', () => {
         expect(container.querySelector("[data-testid='org-clock-in']")).toBeFalsy();

--- a/src/components/OrgFile/index.js
+++ b/src/components/OrgFile/index.js
@@ -660,9 +660,13 @@ class OrgFile extends PureComponent {
                 <Fragment>{parsingErrorMessage}</Fragment>
               ) : (
                 <Fragment>
-                  The interaction with your file happens on headlines.{' '}
-                  <button onClick={this.handleCreateFirstHeader}>Click here</button> to create your
-                  first headline in this file.
+                  <p>The interaction with your file happens on headlines.</p>
+                  <p>
+                    <button className="btn" onClick={this.handleCreateFirstHeader}>
+                      Click here
+                    </button>{' '}
+                    to create your first headline in this file.
+                  </p>
                 </Fragment>
               )}
             </div>

--- a/src/components/OrgFile/index.js
+++ b/src/components/OrgFile/index.js
@@ -60,6 +60,7 @@ class OrgFile extends PureComponent {
       'handleEditDescriptionHotKey',
       'handleExitEditModeHotKey',
       'handleAddHeaderHotKey',
+      'handleCreateFirstHeader',
       'handleRemoveHeaderHotKey',
       'handleMoveHeaderUpHotKey',
       'handleMoveHeaderDownHotKey',
@@ -196,6 +197,10 @@ class OrgFile extends PureComponent {
 
   handleAddHeaderHotKey() {
     this.props.org.addHeaderAndEdit(this.props.selectedHeaderId);
+  }
+
+  handleCreateFirstHeader() {
+    this.props.org.createFirstHeader();
   }
 
   handleRemoveHeaderHotKey() {
@@ -649,17 +654,15 @@ class OrgFile extends PureComponent {
         <div className="org-file-container" tabIndex="-1" ref={this.handleContainerRef}>
           {headers.size === 0 ? (
             <div className="org-file__parsing-error-message">
-              <h3>Couldn't parse file</h3>
+              <h3>This file has no headlines</h3>
 
               {!!parsingErrorMessage ? (
                 <Fragment>{parsingErrorMessage}</Fragment>
               ) : (
                 <Fragment>
-                  If you think this is a bug, please{' '}
-                  <ExternalLink href="https://github.com/200ok-ch/organice/issues/new">
-                    create an issue
-                  </ExternalLink>{' '}
-                  and include the org file if possible!
+                  The interaction with your file happens on headlines.{' '}
+                  <button onClick={this.handleCreateFirstHeader}>Click here</button> to create your
+                  first headline in this file.
                 </Fragment>
               )}
             </div>

--- a/src/components/OrgFile/index.js
+++ b/src/components/OrgFile/index.js
@@ -573,6 +573,7 @@ class OrgFile extends PureComponent {
   render() {
     const {
       headers,
+      linesBeforeHeadings,
       shouldDisableDirtyIndicator,
       shouldDisableSyncButtons,
       shouldDisableActions,
@@ -649,6 +650,11 @@ class OrgFile extends PureComponent {
       this.setState({ popupCloseActionValuesAccessor: v });
     };
 
+    // Check if this a legit Org file with content, just no headers
+    const noHeadlineButContent = () => {
+      return headers.size === 0 && linesBeforeHeadings.size > 0;
+    };
+
     return (
       <GlobalHotKeys keyMap={keyMap} handlers={handlers}>
         <div className="org-file-container" tabIndex="-1" ref={this.handleContainerRef}>
@@ -660,12 +666,24 @@ class OrgFile extends PureComponent {
                 <Fragment>{parsingErrorMessage}</Fragment>
               ) : (
                 <Fragment>
-                  <p>The interaction with your file happens on headlines.</p>
+                  {noHeadlineButContent() ? (
+                    <>
+                      <p>Yes, your file has content. Do not worry, it is still there! </p>
+                      <p>
+                        However, interacting with Org files in organice happens on a per headline
+                        basis. To use organice with this file, please create a new headline with the
+                        button below. The existing content is then put into the description of this
+                        new header.
+                      </p>
+                    </>
+                  ) : (
+                    <p></p>
+                  )}
+                  <p>Interact with your file by creating the first headline.</p>
                   <p>
                     <button className="btn" onClick={this.handleCreateFirstHeader}>
-                      Click here
-                    </button>{' '}
-                    to create your first headline in this file.
+                      Create headline
+                    </button>
                   </p>
                 </Fragment>
               )}
@@ -737,6 +755,7 @@ const mapStateToProps = (state) => {
   const fileIsLoaded = (path) => loadedFiles.includes(path);
   const file = state.org.present.getIn(['files', path], Map());
   const headers = file.get('headers');
+  const linesBeforeHeadings = file.get('linesBeforeHeadings');
   const selectedHeaderId = file.get('selectedHeaderId', null);
   const activePopup = state.base.get('activePopup', Map());
 
@@ -744,6 +763,7 @@ const mapStateToProps = (state) => {
     loadedPath: path,
     files,
     headers,
+    linesBeforeHeadings,
     selectedHeaderId,
     isDirty: file.get('isDirty'),
     fileIsLoaded,

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -319,7 +319,15 @@ const addHeader = (state, action) => {
 
 const createFirstHeader = (state) => {
   let newHeader = newHeaderWithTitle('First header', 1, state.get('todoKeywordSets'));
-  newHeader = _updateHeaderFromDescription(newHeader, 'Extend the file from here');
+
+  let description = 'Extend the file from here';
+  if (state.get('linesBeforeHeadings').size > 0) {
+    description = state.get('linesBeforeHeadings').toJS().join('\n');
+
+    state = state.set('linesBeforeHeadings', List());
+  }
+
+  newHeader = _updateHeaderFromDescription(newHeader, description);
 
   return state.update('headers', (headers) => headers.insert(0, newHeader));
 };

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -317,6 +317,13 @@ const addHeader = (state, action) => {
   );
 };
 
+const createFirstHeader = (state) => {
+  let newHeader = newHeaderWithTitle('First header', 1, state.get('todoKeywordSets'));
+  newHeader = _updateHeaderFromDescription(newHeader, 'Extend the file from here');
+
+  return state.update('headers', (headers) => headers.insert(0, newHeader));
+};
+
 const selectNextSiblingHeader = (state, action) => {
   const headers = state.get('headers');
   const { header, headerIndex } = indexAndHeaderWithId(headers, action.headerId);
@@ -1441,6 +1448,8 @@ const reducer = (state, action) => {
       return inFile(updateHeaderDescription);
     case 'ADD_HEADER':
       return inFile(addHeader);
+    case 'CREATE_FIRST_HEADER':
+      return inFile(createFirstHeader);
     case 'SELECT_NEXT_SIBLING_HEADER':
       return inFile(selectNextSiblingHeader);
     case 'SELECT_NEXT_VISIBLE_HEADER':

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -2164,5 +2164,31 @@ describe('org reducer', () => {
         newState.getIn(['files', path, 'headers']).get(0).getIn(['titleLine', 'rawTitle'])
       ).toEqual('First header');
     });
+
+    it('embedds linesBeforeHeadings into the first headline', () => {
+      let path = 'testfile';
+      const emptyOrgFile = readFixture('content_but_no_headline');
+      const state = setUpStateForFile(path, emptyOrgFile);
+
+      expect(state.org.present.getIn(['files', path, 'linesBeforeHeadings']).toJS()).toEqual([
+        'This is a legit Org mode file, yet it has not a single headline.',
+      ]);
+
+      const newState = reducer(state.org.present, types.createFirstHeader());
+      // Create new header
+      expect(
+        newState.getIn(['files', path, 'headers']).get(0).getIn(['titleLine', 'rawTitle'])
+      ).toEqual('First header');
+
+      // Move all linesBeforeHeadings under said header
+      expect(newState.getIn(['files', path, 'headers']).get(0).getIn(['rawDescription'])).toEqual(
+        'This is a legit Org mode file, yet it has not a single headline.'
+      );
+
+      // Old linesBeforeHeadings are gone
+      expect(state.org.present.getIn(['files', path, 'linesBeforeHeadings']).toJS()).toEqual([
+        'This is a legit Org mode file, yet it has not a single headline.',
+      ]);
+    });
   });
 });

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -2186,9 +2186,7 @@ describe('org reducer', () => {
       );
 
       // Old linesBeforeHeadings are gone
-      expect(state.org.present.getIn(['files', path, 'linesBeforeHeadings']).toJS()).toEqual([
-        'This is a legit Org mode file, yet it has not a single headline.',
-      ]);
+      expect(newState.getIn(['files', path, 'linesBeforeHeadings']).toJS()).toEqual([]);
     });
   });
 });

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -2149,4 +2149,20 @@ describe('org reducer', () => {
       expect(header.get('totalTimeLogged')).toEqual(25200000);
     });
   });
+
+  describe('handle empty files', () => {
+    it('creates a new first header in an empty file', () => {
+      let path = 'testfile';
+      const emptyOrgFile = readFixture('empty_file');
+      const state = setUpStateForFile(path, emptyOrgFile);
+
+      // Empty file has no headers
+      expect(state.org.present.getIn(['files', path, 'headers']).toJS()).toEqual([]);
+
+      const newState = reducer(state.org.present, types.createFirstHeader());
+      expect(
+        newState.getIn(['files', path, 'headers']).get(0).getIn(['titleLine', 'rawTitle'])
+      ).toEqual('First header');
+    });
+  });
 });

--- a/test_helpers/fixtures/content_but_no_headline.org
+++ b/test_helpers/fixtures/content_but_no_headline.org
@@ -1,0 +1,1 @@
+This is a legit Org mode file, yet it has not a single headline.


### PR DESCRIPTION
Original issue: https://github.com/200ok-ch/organice/issues/583

This takes care of a big UX problem for users who solely rely on organice. So far, we've shown a parser error if the file is empty *or* if the file did not contain a headline.

Now, if the user opens a file that is completely empty, she has this flow:

![Screen Shot 2022-06-21 at 17 13 40](https://user-images.githubusercontent.com/505721/174835249-a0469bc1-2a11-4708-abfe-d060f36bc3eb.png)


On Click:

![Screen Shot 2022-06-21 at 11 29 16](https://user-images.githubusercontent.com/505721/174767353-480b6a4a-4114-48a4-897b-db756ad8df84.png)

If the file already contains content (but not a headline), the user is shown this optimized screen:

![Screen Shot 2022-06-21 at 17 13 21](https://user-images.githubusercontent.com/505721/174835370-5e53c690-7f9c-4cbd-be4d-dd2b994001a2.png)


Of course, this also works when the user deletes the final headline.


