### PR TITLE
doc: Fix several links for the documentation

### DIFF
--- a/README.org
+++ b/README.org
@@ -442,7 +442,7 @@ In any case, [[https://organice.200ok.ch/documentation.html#faq_webdav][here's h
 **** Dropbox or GitLab
 
 To test against your own Dropbox or GitLab application, you'll need to create a
-~.env~ file by copying [[file:.env.sample][.env.sample]] to just ~.env~.
+~.env~ file by copying [[https://github.com/200ok-ch/organice/blob/master/.env.sample][.env.sample]] to just ~.env~.
 
 #+BEGIN_SRC shell
 cp .env.sample .env
@@ -576,7 +576,7 @@ automatically deployed to stage.
 
 ** Contributions
 
-Please see our [[file:CONTRIBUTING.org][contributor guidelines]] and our [[file:CODE_OF_CONDUCT.md][code of conduct]].
+Please see our [[https://github.com/200ok-ch/organice/blob/master/CONTRIBUTING.org][contributor guidelines]] and our [[https://github.com/200ok-ch/organice/blob/master/CODE_OF_CONDUCT.md][code of conduct]].
 
 ** Mockups
    :PROPERTIES:
@@ -1005,8 +1005,8 @@ organice has a shared history with [[https://github.com/DanielDe/org-web][org-we
 fork. organice differs from org-web in that:
 
 - organice is a community driven project. See our
-  - [[file:CODE_OF_CONDUCT.md][Code of conduct]]
-  - [[file:CONTRIBUTING.org][Contributing guidelines]]
+  - [[https://github.com/200ok-ch/organice/blob/master/CODE_OF_CONDUCT.md][Code of conduct]]
+  - [[https://github.com/200ok-ch/organice/blob/master/CONTRIBUTING.org][Contributing guidelines]]
   - Community chat: #organice on IRC [[https://libera.chat/][Libera.Chat]], or [[https://matrix.to/#/!DfVpGxoYxpbfAhuimY:matrix.org?via=matrix.org&via=ungleich.ch][#organice:matrix.org]] on Matrix
     on Matrix
 
@@ -1038,7 +1038,7 @@ fork. organice differs from org-web in that:
 
 *** What's new?
 
-To see how organice differs from org-web, please consult the [[file:changelog.org][changelog]]
+To see how organice differs from org-web, please consult the [[https://github.com/200ok-ch/organice/blob/master/changelog.org][changelog]]
 which contains the user visible changes since forking.
 
 *** Acknowledgment

--- a/WIKI.org
+++ b/WIKI.org
@@ -97,7 +97,7 @@
  configuration, so any user account works (including omitted user
  accounts). It goes without saying that if you wanted to use this for
  production, please enable authentication. Within the test image,
- you'll find the [[file:sample.org][sample.org]] file, so you can get started developing and
+ you'll find the [[https://github.com/200ok-ch/organice/blob/master/sample.org][sample.org]] file, so you can get started developing and
  testing right away.
 
  For testing WebDAV outside of organice, and you're an Emacs user, you


### PR DESCRIPTION
Prior, they worked only in Emacs when the repo was checked out, not in the online documentation.