### PR TITLE
WIP: Links to non-org files go to GitLab

### DIFF
--- a/src/components/SyncServiceSignIn/index.js
+++ b/src/components/SyncServiceSignIn/index.js
@@ -116,6 +116,7 @@ function GitLab() {
     const projectId = gitLabProjectIdFromURL(project);
     if (projectId) {
       persistField('authenticatedSyncService', 'GitLab');
+      persistField('gitLabProjectUrl', project)
       persistField('gitLabProject', projectId);
       createGitlabOAuth().fetchAuthorizationCode();
     } else {

--- a/src/sync_backend_clients/gitlab_sync_backend_client.js
+++ b/src/sync_backend_clients/gitlab_sync_backend_client.js
@@ -343,6 +343,13 @@ export default (oauthClient) => {
     });
   };
 
+  const getExternalFileUrl = (path) => {
+    const baseUrl = getPersistedField('gitLabProjectUrl');
+    const defaultBranch = cachedDefaultBranch;
+
+    return `${baseUrl}/-/blob/${defaultBranch}/${path}`;
+  }
+
   return {
     type: 'GitLab',
     isSignedIn,
@@ -354,5 +361,6 @@ export default (oauthClient) => {
     getFileContentsAndMetadata,
     getFileContents,
     deleteFile,
+    getExternalFileUrl,
   };
 };


### PR DESCRIPTION
This work in progress / proof-of-concept shows a potential solution for
links to files that are not org files or folders (#325). It does this by:

- saving the URL to the GitLab project at login time
- parsing links to files that contain a "." but are not org files
- making a link to the file with the template
  `${gitLablProjectUrl}/-/blob/${defaultBranch}/${path}`

The commit is not production ready and has not added or updated any of
the tests, but it meant to solicit early feedback on this approach.
Notably it _only_ works for GitLab sync backends (though others will
revert to the default behaviour.)

---

A working example can be seen at: https://org.kindrobot.ca