### PR TITLE
fix: Start from the top

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -6,6 +6,10 @@
 All user visible changes to organice will be documented in this file.
 
 When there are updates to the changelog, you will be notified and see a 'gift' icon appear on the top right corner.
+* [2022-07-08 Fri]
+** Fixed
+- When opening an Org file, show it from the top
+  - PR: https://github.com/200ok-ch/organice/pull/878
 * [2022-07-06 Wed]
 ** Fixed
 - Change log renders above previously opened view component

--- a/src/components/OrgFile/index.js
+++ b/src/components/OrgFile/index.js
@@ -106,7 +106,7 @@ class OrgFile extends PureComponent {
         });
       }
 
-      setTimeout(() => (document.querySelector('html').scrollTop = 0), 0);
+      setTimeout(() => (document.querySelector('.App').scrollTop = 0), 0);
     } else if (!_.isEmpty(path)) {
       if (this.props.fileIsLoaded(path)) {
         this.props.org.sync({ path, shouldSuppressMessages: true });


### PR DESCRIPTION
Reported in https://github.com/200ok-ch/organice/issues/864

The regression was visible, for example, when going first to settings and then to the changelog. The changelog would then show in a 'scrolled down' position.