### PR TITLE
Add filtering by description

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -6,6 +6,11 @@
 All user visible changes to organice will be documented in this file.
 
 When there are updates to the changelog, you will be notified and see a 'gift' icon appear on the top right corner.
+* [2022-12-02 Fri]
+** Added
+- Filtering by description
+  - PR: https://github.com/200ok-ch/organice/pull/907
+  - Thank you [[https://github.com/neildavidforrest][neildavidforrest]] for the PR🙏
 * [2022-07-08 Fri]
 ** Fixed
 - When opening an Org file, show it from the top

--- a/sample.org
+++ b/sample.org
@@ -408,6 +408,14 @@ Some examples on how to use time ranges:
 
 Note that negating time ranges is not implemented.
 
+To search for the description of your headlines, use =desc= or =description=:
+
+- =desc:"search term"=
+
+If you want to search for multiple terms, you can combine them like so:
+
+- =desc:term_1 desc:term_2=
+
 
 ** Auto-completion for filters
 

--- a/src/lib/headline_filter.js
+++ b/src/lib/headline_filter.js
@@ -215,6 +215,13 @@ export const isMatch = (filterExpr) => {
     .filter(filterFilter('property', true))
     .map((x) => [x.property, x.words]);
 
+  const filterDesc = filterField
+    .filter((f) => f.field.type === 'description' && f.field.text.type === 'ignore-case')
+    .map((x) => x.field.text.words.map((y) => y.toLowerCase()));
+  const filterDescCS = filterField
+    .filter((f) => f.field.type === 'description' && f.field.text.type === 'case-sensitive')
+    .map((x) => x.field.text.words);
+
   return (header) => {
     const headLine = header.get('titleLine');
     const tags = headLine.get('tags');
@@ -234,6 +241,13 @@ export const isMatch = (filterExpr) => {
     const deadlines = planningItems
       .filter((p) => p.get('type') === 'DEADLINE')
       .map((p) => p.get('timestamp'));
+
+    var description = '';
+    if (filterDesc.length > 0 || filterDescCS.length > 0) {
+      const stripMarkup = (text) => text.replace(/\*([\w]*)\*/, (match, p1, _, __) => p1);
+      description = stripMarkup(header.get('rawDescription'));
+    }
+
     //const clocks = header
     //  .get('logBookEntries')
     //  .flatMap((l) => [l.get('start'), l.get('end')])
@@ -258,6 +272,8 @@ export const isMatch = (filterExpr) => {
       //filterClock.every(orChainDate(clocks)) &&
       filterSchedule.every(orChainDate(scheduleds)) &&
       filterDeadline.every(orChainDate(deadlines)) &&
+      filterDesc.every(orChain(description.toLowerCase())) &&
+      filterDescCS.every(orChain(description)) &&
       !filterTagsExcl.some(orChain(tags)) &&
       !filterCSExcl.some(orChain(headlineText)) &&
       !filterICExcl.some(orChain(headlineText.toLowerCase())) &&

--- a/src/lib/headline_filter_parser.grammar.pegjs
+++ b/src/lib/headline_filter_parser.grammar.pegjs
@@ -100,10 +100,11 @@ TermProp "property filter term"
         };
 
 TermField "search outside of header"
-  = "date:"                   a:TimeRange { return { type: 'field', field: { type: 'date',      timerange: a } }; }
-  / "clock:"                  a:TimeRange { return { type: 'field', field: { type: 'clock',     timerange: a } }; }
-  / ("sched:" / "scheduled:") a:TimeRange { return { type: 'field', field: { type: 'scheduled', timerange: a } }; }
-  / ("dead:" / "deadline:")   a:TimeRange { return { type: 'field', field: { type: 'deadline',  timerange: a } }; }
+  = "date:"                    a:TimeRange { return { type: 'field', field: { type: 'date',        timerange: a } }; }
+  / "clock:"                   a:TimeRange { return { type: 'field', field: { type: 'clock',       timerange: a } }; }
+  / ("sched:" / "scheduled:")  a:TimeRange { return { type: 'field', field: { type: 'scheduled',   timerange: a } }; }
+  / ("dead:" / "deadline:")    a:TimeRange { return { type: 'field', field: { type: 'deadline',    timerange: a } }; }
+  / ("desc:" / "description:") a:TermText  { return { type: 'field', field: { type: 'description', text: a } }; }
 
 TimeRange "moments and timeranges"
   = a:Moment ".." b:Moment { return { type: 'range', from: a, to: b }; }


### PR DESCRIPTION
As discussed in https://github.com/200ok-ch/organice/issues/511, this PR adds the ability to search any text in the description of a node.

To search the description use the syntax `desc:"search term"`.

New tests will need to be added.