### PR TITLE
Disable auto-capitalization for search

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -6,6 +6,20 @@
 All user visible changes to organice will be documented in this file.
 
 When there are updates to the changelog, you will be notified and see a 'gift' icon appear on the top right corner.
+
+* [2023-01-04 Wed]
+
+** Changed
+
+- Disable auto-capitalization for search
+  - Before:
+    - When using the search or task list text inputs the Android/iOS keyboards automatically apply the shift key, meaning that the first character is capitalized.
+    - 99% of the time this is not what we want because:
+      - Having mixed case triggers a case sensitive search. This is quite confusing when I did not intentionally use capitalization, but it was added anyway. For example, I type "and", and it actually inputs and searches for "And", which yields no results.
+      - Many of the keywords in the search grammar are lower case, e.g., =deadline:=, =desc:=.
+  - Now: Auto-capitalization is turned off
+  - PR: https://github.com/200ok-ch/organice/pull/914
+  - Thank you [[https://github.com/neildavidforrest][neildavidforrest]] for the PR🙏
 * [2022-12-03 Sat]
 ** Fixed
 

--- a/src/components/OrgFile/__snapshots__/OrgFile.integration.test.js.snap
+++ b/src/components/OrgFile/__snapshots__/OrgFile.integration.test.js.snap
@@ -46,6 +46,8 @@ exports[`Render all views Org Functionality Renders everything starting from an 
         class="search__input-container"
       >
         <input
+          autocapitalize="none"
+          autocomplete="off"
           class="textfield task-list__filter-input"
           list="task-list__datalist-filter"
           placeholder="e.g. -DONE doc|man :simple|easy :assignee:nobody|none"

--- a/src/components/OrgFile/components/SearchModal/index.js
+++ b/src/components/OrgFile/components/SearchModal/index.js
@@ -95,6 +95,10 @@ function SearchModal(props) {
                 // be a better way: If the drawer wouldn't move, iOS likely
                 // would set the heights correctly automatically.
                 autoFocus={!isIos()}
+                // Disable auto-capitalization for convenience (autoComplete must also be off to
+                // achieve this on Android).
+                autoCapitalize="none"
+                autoComplete="off"
                 className={classNames('textfield', 'task-list__filter-input', {
                   'task-list__filter-input--invalid': !!searchFilter && !searchFilterValid,
                 })}

--- a/src/components/OrgFile/components/TaskListModal/index.js
+++ b/src/components/OrgFile/components/TaskListModal/index.js
@@ -65,6 +65,10 @@ function TaskListModal(props) {
               value={searchFilter}
               // Rationale: See SearchModal: index.js
               autoFocus={!isIos()}
+              // Disable auto-capitalization for convenience (autoComplete must also be off to
+              // achieve this on Android).
+              autoCapitalize="none"
+              autoComplete="off"
               className={classNames('textfield', 'task-list__filter-input', {
                 'task-list__filter-input--invalid': !!searchFilter && !searchFilterValid,
               })}


### PR DESCRIPTION
This disables auto-capitalization for the search fields on Android Chrome as described here: https://github.com/200ok-ch/organice/issues/913

This is tested only on Chrome for Android only. I also checked Firefox for Android, this works fine (no auto-capitalization) with or without this change.

I'm unable to test with iOS, so that should be checked carefully for regressions.