### PR TITLE
376 - fixed text discards while check/uncheck box when text has inline-markup

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -7,6 +7,14 @@ All user visible changes to organice will be documented in this file.
 
 When there are updates to the changelog, you will be notified and see a 'gift' icon appear on the top right corner.
 
+* [2023-01-09 Mon]
+
+** Fixed
+
+- Checking or unchecking a checkbox discards text with markup
+  - PR: https://github.com/200ok-ch/organice/pull/928
+  - Thank you [[https://github.com/saikiransathpadi][saikiransathpadi]] for the PR🙏
+
 * [2023-01-05 Thu]
 
 ** Fixed
@@ -39,6 +47,7 @@ When there are updates to the changelog, you will be notified and see a 'gift' i
   - If the user starts any line with a =*=, wanting to start a new list, it is immediately converted to a =-=.
   - PR: https://github.com/200ok-ch/organice/pull/920
   - Thank you [[https://github.com/saikiransathpadi][saikiransathpadi]] for the PR🙏
+   
 
 ** Changed
 

--- a/src/lib/export_org.js
+++ b/src/lib/export_org.js
@@ -184,13 +184,14 @@ const inlineMarkUpToRawText = (part) => {
     underline: '_',
     verbatim: '=',
   };
-  if (part.get('type') !== 'inline-markup' || !markupTypeToRaw[part.get('markupType')]) return part.get('content');
+  if (part.get('type') !== 'inline-markup' || !markupTypeToRaw[part.get('markupType')])
+    return part.get('content');
   return (
     markupTypeToRaw[part.get('markupType')] +
     part.get('content') +
     markupTypeToRaw[part.get('markupType')]
   );
-}
+};
 
 export const attributedStringToRawText = (parts) => {
   if (!parts) {

--- a/src/lib/export_org.js
+++ b/src/lib/export_org.js
@@ -175,6 +175,23 @@ const timestampPartToRawText = (part) => {
   return text;
 };
 
+const inlineMarkUpToRawText = (part) => {
+  const markupTypeToRaw = {
+    'inline-code': '~',
+    bold: '*',
+    italic: '/',
+    strikethrough: '+',
+    underline: '_',
+    verbatim: '=',
+  };
+  if (part.get('type') !== 'inline-markup' || !markupTypeToRaw[part.get('markupType')]) return part.get('content');
+  return (
+    markupTypeToRaw[part.get('markupType')] +
+    part.get('content') +
+    markupTypeToRaw[part.get('markupType')]
+  );
+}
+
 export const attributedStringToRawText = (parts) => {
   if (!parts) {
     return '';
@@ -189,6 +206,9 @@ export const attributedStringToRawText = (parts) => {
       switch (part.get('type')) {
         case 'text':
           text = part.get('contents');
+          break;
+        case 'inline-markup':
+          text = inlineMarkUpToRawText(part);
           break;
         case 'link':
           text = linkPartToRawText(part);


### PR DESCRIPTION
This is related to the issue https://github.com/200ok-ch/organice/issues/376. When we have a check box and whenever we check or uncheck it if we have an inline markup in the description it is getting disappeared. 

There is a switch case for each type to convert to raw text and here the "inline-markup" case is missing. I have written a separate function to handle this text and added the case there.