### PR TITLE
Don't cancel swipe due to vertical movements

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -7,6 +7,14 @@ All user visible changes to organice will be documented in this file.
 
 When there are updates to the changelog, you will be notified and see a 'gift' icon appear on the top right corner.
 
+* [2023-01-28 Sat]
+
+** Fixed
+
+- On a header, don't cancel swipe due to vertical movements
+  - PR: https://github.com/200ok-ch/organice/pull/938
+  - Thank you [[https://github.com/neildavidforrest][neildavidforrest]] for the PR🙏
+
 * [2023-01-09 Mon]
 
 ** Fixed


### PR DESCRIPTION
Contrary to most other examples of swiping interactions, swiping a headline in Organice only works if you keep your finger/thumb/mouse inside the bounds of the item being dragged. This makes it rather difficult to swipe reliably, especially on larger devices (and/or smaller hands) since the hand naturally wants to move in an arc, while the headline bounds are linear.

This change is intended to align the swipe interaction with the behavior shared by the native interactions of both Android and IOS: that after initiating a swipe, no amount of vertical movement should cancel it.

Regarding the implementation: It works reliably in my tests, however I'm not previously familiar with React or web development in general, so please feel free to suggest better alternatives.

**Before**:
![video](https://user-images.githubusercontent.com/106537273/215234030-0b278577-c070-47fb-8b03-f3c4e667e8f8.mp4)

**After**:
![video](https://user-images.githubusercontent.com/106537273/215234063-40e94459-6fb1-40b3-aed0-123af8bf7f77.mp4)



