### PR TITLE
fix: Capture template available everywhere, but capturing to one

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -14,6 +14,11 @@ When there are updates to the changelog, you will be notified and see a 'gift' i
 - Capture template variable =%y= expanding to the raw year
   - PR: https://github.com/200ok-ch/organice/pull/964
 
+** Fixed
+
+- Using a capture template that is available from all Org files, but should always capture to just one file (not necessarily the currently open one).
+  - PR: https://github.com/200ok-ch/organice/pull/965
+
 * [2023-04-11 Tue]
 
 ** Changed

--- a/src/components/CaptureTemplatesEditor/components/CaptureTemplate/index.js
+++ b/src/components/CaptureTemplatesEditor/components/CaptureTemplate/index.js
@@ -191,7 +191,7 @@ export default ({
               ? loadedFilePaths
               : [template.get('file'), ...loadedFilePaths]
             ).map((path) => (
-              <option key={path} value={path}>
+              <option key={path} value={path} selected={path === template.get('file')}>
                 {path}
               </option>
             ))}


### PR DESCRIPTION
Fix this use case: Using a capture template that is available from all Org files, but should always capture to just one file (not necessarily the currently open one).

