### PR TITLE
Fix whitespaces in JS string in README

### DIFF
--- a/README.org
+++ b/README.org
@@ -924,9 +924,7 @@ little bit of JavaScript:
 #+BEGIN_SRC javascript
   javascript:(function() {
     const {title} = document;
-    const url = `https://organice.200ok.ch?captureTemplateName=Media&captureContent=${title}&captureFile=/org/media.org&captureVariable_mediaURL=${
-    window.location.href
-  }`;
+    const url = `https://organice.200ok.ch?captureTemplateName=Media&captureContent=${title}&captureFile=/org/media.org&captureVariable_mediaURL=${window.location.href}`;
     window.open(url, "_blank");
   })()
 #+END_SRC


### PR DESCRIPTION
The indentation level here was wrong, the line breaks didn't make sense to me and I think it's easier to grasp now.