### PR TITLE
Updates WebDav version and prevents it from trying to add Content-Length

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "redux": "^4.1.0",
     "redux-thunk": "^2.3.0",
     "redux-undo": "1.0.1",
-    "webdav": "^3.3.0"
+    "webdav": "^4.11.3"
   },
   "scripts": {
     "start": "./bin/compile_search_parser.sh && react-scripts start",

--- a/src/sync_backend_clients/webdav_sync_backend_client.js
+++ b/src/sync_backend_clients/webdav_sync_backend_client.js
@@ -75,7 +75,7 @@ export default (url, login, password) => {
   const uploadFile = (path, contents) =>
     new Promise((resolve, reject) =>
       webdavClient
-        .putFileContents(path, contents, { overwrite: true })
+        .putFileContents(path, contents, { overwrite: true, contentLength: false })
         .then(resolve())
         .catch(reject)
     );


### PR DESCRIPTION
It seems the current version of the `webdav` library will add the `Content-Length` header when it can, e.g. when updating `.organice-config.json`. However, this is a [forbidden header name](https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name). This updates the webdav library to a newer version (version 3 is no longer recommended) and uses the new option that prevents this header from being added.