### PR TITLE
doc: Clarify where to find docs (interactive tutorial vs. manual)

### DIFF
--- a/README.org
+++ b/README.org
@@ -12,6 +12,8 @@
   :CUSTOM_ID: general
   :END:
 
+** Code
+
 # REPO_PLACEHOLDER
 
 # INFO: We're using inline =#+HTML= notation in favor of the much more
@@ -23,18 +25,41 @@
 
 #+HTML: <p> <a href="https://app.circleci.com/pipelines/github/200ok-ch/organice"> <img src="https://badgen.net/circleci/github/200ok-ch/organice?label=circleci%20master" /> </a> <a href='#'> <img src="https://badgen.net/uptime-robot/month/m789449277-7986138caa6b43ed68a91563" /> </a> <a href="https://matrix.to/#/#organice:matrix.org"> <img src="https://badgen.net/matrix/members/organice/matrix.org?color=purple" /> </a> </p>
 
-[[https://organice.200ok.ch/documentation.html][Documentation]]
+** Getting started
+:PROPERTIES:
+:CUSTOM_ID: getting_started
+:END:
+
+To get you started, we have two kinds of documentation:
+
+1. [[https://organice.200ok.ch/sample][Interactive Tutorial]]
+2. [[https://organice.200ok.ch/documentation.html][Documentation (User manual and developer guide)]]
+
+The [[https://organice.200ok.ch/sample][interactive tutorial]] allows users to explore and experiment with
+various org-mode functionalities directly within the application. It
+provides hands-on examples of tasks, tables, timestamps, and (most)
+other features.
+
+On the other hand, the [[https://organice.200ok.ch/documentation.html][documentation]] contains more comprehensive and
+formal documentation, including installation instructions, deployment
+guides, contribution guidelines, and technical details about the
+project's architecture and development process. This file is aimed at
+both users seeking in-depth information and developers interested in
+contributing to the project.
+
+** Community chat
 
 Community chat:
 - #organice on IRC [[https://libera.chat/][Libera.Chat]]
 - [[https://matrix.to/#/#organice:matrix.org][#organice:matrix.org]] on Matrix
 
+
+** Sponsors
+
 Creating and maintaining organice is made possible by all the
 volunteering [[https://github.com/200ok-ch/organice/graphs/contributors][contributors]] and [[https://github.com/sponsors/200ok-ch][sponsors]]. If you enjoy using organice,
 and want to sponsor the development of Free and Open Source software,
 you can do so with [[https://github.com/sponsors/200ok-ch][Github Sponsors]] and [[https://www.patreon.com/200ok][Patreon]].🙏
-
-** Sponsors
 
 #+HTML: <p align="center"> <a href="https://github.com/mxparker"> <img src="https://github.com/mxparker.png" width="50px" alt="@mxparker"/> </a> <a href="https://github.com/kristiangronberg"> <img src="https://github.com/kristiangronberg.png" width="50px" alt="@kristiangronberg"/></a> <a href="https://github.com/stefanv"> <img src="https://github.com/stefanv.png" width="50px" alt="@stefanv"/></a> </p>
 

--- a/sample.org
+++ b/sample.org
@@ -4,7 +4,7 @@
 #+TODO: START INPROGRESS STALLED | FINISHED
 
 * This is an actual org file - feel free to play around with it! (Don't worry about messing it up - your changes won't be saved, so just refresh the page to reset it)
-* For starters, tap on the next header to open it
+* Tap on any header to open it
 This header has some description text and a couple subheaders. Look through the next few top level headers to learn more about organice.
 ** This is a subheader
 ** This is a subheader too!
@@ -494,3 +494,7 @@ organice supports a flexible mechanism for capturing using URL parameters. This 
 You can use [[https://www.icloud.com/shortcuts/14f91f8cf8f547a183a0734396240984][this sample Shortcut]] to get started with this right away in iOS 12. Open the link on your iOS device and click "Get Shortcut". Then open up the Shortcuts app and edit the template by following the directions in the comments. Then record a Siri trigger and you're good to go!
 
 Alternatively, you can take advantage of the URL parameters yourself to build your own custom capture mechanism. You can find more details about this in [[https://github.com/200ok-ch/organice/#capture-params-and-siri-support][the README file]].
+
+* Further questions?
+
+If you've finished this interactive tutorial, but have further questions, we have you covered! There is additional [[https://organice.200ok.ch/documentation.html][documentation]] which contains more comprehensive and formal documentation, including installation instructions, deployment guides, contribution guidelines, and technical details about the project's architecture and development process. This file is aimed at both users seeking in-depth information and developers interested in contributing to the project.


### PR DESCRIPTION
New users can struggle to find the right kind of help. The docs did not reference the interactive tutorial and the interactive tutorial did not reference the docs. Now, they do.

![image](https://github.com/user-attachments/assets/21af650b-9545-47d4-9d11-810bac96252d)

![image](https://github.com/user-attachments/assets/385e8f37-8efd-4e57-854e-1488798a3ff6)
