### PR TITLE
fix: Prevent app crash when deleting a list item immediately after exiting edit mode

### DIFF
--- a/src/components/OrgFile/components/AttributedString/components/ListPart/index.js
+++ b/src/components/OrgFile/components/AttributedString/components/ListPart/index.js
@@ -6,6 +6,8 @@ import './stylesheet.css';
 import AttributedString from '../../../AttributedString/';
 import Checkbox from '../../../../../UI/Checkbox/';
 import ListActionDrawer from './ListActionDrawer';
+import { listPartContainsItemId } from '../../../../../../lib/org_utils';
+
 import { attributedStringToRawText } from '../../../../../../lib/export_org';
 
 import { getCurrentTimestampAsText } from '../../../../../../lib/timestamps';
@@ -60,7 +62,7 @@ export default class ListPart extends PureComponent {
       inListTitleEditMode &&
       prevProps.subPartDataAndHandlers.inListTitleEditMode
     ) {
-      if (listTitleValues.has(prevSelectedListItemId)) {
+      if (listTitleValues.has(prevSelectedListItemId) && listPartContainsItemId(this.props.part, prevSelectedListItemId)) {
         onListTitleValueUpdate(prevSelectedListItemId, listTitleValues.get(prevSelectedListItemId));
       }
     }
@@ -76,7 +78,7 @@ export default class ListPart extends PureComponent {
       inListContentsEditMode &&
       prevProps.subPartDataAndHandlers.inListContentsEditMode
     ) {
-      if (listContentsValues.has(prevSelectedListItemId)) {
+      if (listContentsValues.has(prevSelectedListItemId) && listPartContainsItemId(this.props.part, prevSelectedListItemId)) {
         onListContentsValueUpdate(
           prevSelectedListItemId,
           listContentsValues.get(prevSelectedListItemId)

--- a/src/components/OrgFile/components/AttributedString/components/ListPart/index.js
+++ b/src/components/OrgFile/components/AttributedString/components/ListPart/index.js
@@ -62,7 +62,10 @@ export default class ListPart extends PureComponent {
       inListTitleEditMode &&
       prevProps.subPartDataAndHandlers.inListTitleEditMode
     ) {
-      if (listTitleValues.has(prevSelectedListItemId) && listPartContainsItemId(this.props.part, prevSelectedListItemId)) {
+      if (
+        listTitleValues.has(prevSelectedListItemId) &&
+        listPartContainsItemId(this.props.part, prevSelectedListItemId)
+      ) {
         onListTitleValueUpdate(prevSelectedListItemId, listTitleValues.get(prevSelectedListItemId));
       }
     }
@@ -78,7 +81,10 @@ export default class ListPart extends PureComponent {
       inListContentsEditMode &&
       prevProps.subPartDataAndHandlers.inListContentsEditMode
     ) {
-      if (listContentsValues.has(prevSelectedListItemId) && listPartContainsItemId(this.props.part, prevSelectedListItemId)) {
+      if (
+        listContentsValues.has(prevSelectedListItemId) &&
+        listPartContainsItemId(this.props.part, prevSelectedListItemId)
+      ) {
         onListContentsValueUpdate(
           prevSelectedListItemId,
           listContentsValues.get(prevSelectedListItemId)

--- a/src/lib/org_utils.js
+++ b/src/lib/org_utils.js
@@ -389,7 +389,7 @@ export const pathAndPartOfTimestampItemWithIdInAttributedString = (parts, timest
     .filter((result) => result)
     .first();
 
-const listPartContainsItemId = (listPart, itemId) =>
+export const listPartContainsItemId = (listPart, itemId) =>
   listPart.get('items').some((item) => item.get('id') === itemId);
 
 export const headerThatContainsListItemId = (headers, listItemId) => {


### PR DESCRIPTION
Fix #988 where the application would crash if a list was deleted immediately after exiting edit mode for the list title (or content).