### PR TITLE
fix(1006): Creating a static /manifest.json

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -37,42 +37,5 @@
       </div>
     </noscript>
     <div id="root"></div>
-    <script>
-     var {pathname} = window.location;
-
-     const absoluteUrl = function(path) {
-        return new URL(path, document.baseURI).href;
-     };
-
-     var manifest = {
-         "short_name": "organice",
-         "name": "organice",
-         "icons": [
-             {
-                 "src": absoluteUrl("organice-512x512.png"),
-                 "sizes": "512x512",
-                 "type": "image/png"
-             },
-             {
-                 "src": absoluteUrl("organice-192x192.png"),
-                 "sizes": "192x192",
-                 "type": "image/png"
-             },
-             {
-                 "src": absoluteUrl("favicon.ico"),
-                 "sizes": "64x64 32x32 24x24 16x16",
-                 "type": "image/x-icon"
-             }
-         ],
-         "start_url": absoluteUrl(pathname || "/index.html"),
-         "display": "standalone",
-         "theme_color": "#000000",
-         "background_color": "#ffffff"
-     }
-
-     const manifestBlob = new Blob([JSON.stringify(manifest)], {type: 'application/json'});
-     const manifestURL = URL.createObjectURL(manifestBlob);
-     document.querySelector("link[rel='manifest']").setAttribute('href', manifestURL);
-    </script>
   </body>
 </html>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,25 @@
+{
+  "short_name": "organice",
+  "name": "organice",
+  "icons": [
+    {
+      "src": "./organice-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    },
+    {
+      "src": "./organice-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "./favicon.ico",
+      "sizes": "64x64 32x32 24x24 16x16",
+      "type": "image/x-icon"
+    }
+  ],
+  "start_url": "/index.html",
+  "display": "standalone",
+  "theme_color": "#000000",
+  "background_color": "#ffffff"
+}


### PR DESCRIPTION
Closes #1006 

Originally, I think we created it dynamically, because we thought the `start_url` has to be dynamic for the self hosting. However, according to current [MDN](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest/Reference/start_url#start_url) this is not the case (anymore). So I think, we can go the easy route and just use a static file for every host.

For reference, here's the original implementation: https://github.com/200ok-ch/organice/pull/781

I tested this on Staging and it also looks OK to me in the dev tools:

![image](https://github.com/user-attachments/assets/82c447f6-562c-445f-950c-bdd2d8f926f0)

@tbruckmaier As the original author, is it OK for you if we change the implementation as proposed in this PR?
