### PR TITLE
feat: Add long-press to duplicate header and enhance visual feedback

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -8,6 +8,19 @@ All user visible changes to organice will be documented in this file.
 When there are updates to the changelog, you will be notified and see a 'gift' icon appear on the top right corner.
 
 * [2025-05-24 Sat]
+
+** Added
+*** Duplicate header via long-press on '+' icon
+
+- Long-pressing the '+' icon in the header action drawer now
+  duplicates the current header and its entire subtree.
+- Visual feedback for the long-press interaction has been
+  significantly enhanced with larger surrounding shadows for better
+  visibility, especially on touch devices.
+- Short-press on the '+' icon continues to add a new, empty header.
+
+PR: https://github.com/200ok-ch/organice/pull/1025
+
 ** Fixed
 *** Table add/remove button inverted
 

--- a/sample.org
+++ b/sample.org
@@ -23,7 +23,7 @@ If you want the "header action drawer" to disappear or to deselect the current h
 3. Tags: [[https://orgmode.org/manual/Tags.html][Modify tags]]
 4. Properties: [[https://orgmode.org/manual/Properties-and-columns.html][Modify properties]]
 5. Expand: [[https://orgmode.org/manual/Structure-editing.html][Narrow to subtree]] (/Narrowing/ means focusing on this header, making the rest temporarily inaccessible.)
-6. Plus: Create new header below
+6. Plus: Create new header below. Long-pressing this icon duplicates the current header and its entire subtree, providing enhanced visual feedback with larger surrounding shadows. 
 7. Mail: Share this header via email
 8. Calendar 1: [[https://orgmode.org/manual/Deadlines-and-scheduling.html][Set deadline datetime]]
 9. Calendar 2: [[https://orgmode.org/manual/Deadlines-and-scheduling.html][Set scheduled datetime]]

--- a/src/actions/org.js
+++ b/src/actions/org.js
@@ -314,6 +314,12 @@ export const addHeader = (headerId) => ({
   dirtying: false,
 });
 
+export const duplicateHeader = (headerId) => ({
+  type: 'DUPLICATE_HEADER',
+  headerId,
+  dirtying: true,
+});
+
 export const createFirstHeader = () => ({
   type: 'CREATE_FIRST_HEADER',
   dirtying: true,

--- a/src/components/OrgFile/components/Header/components/HeaderActionDrawer/index.js
+++ b/src/components/OrgFile/components/Header/components/HeaderActionDrawer/index.js
@@ -12,47 +12,55 @@ export default class HeaderActionDrawer extends PureComponent {
   // A nasty hack required to get click handling to work properly in Firefox. No idea why its
   // broken in the first place or why this fixes it.
   iconWithFFClickCatcher({ className, onClick, onLongPress, title, testId = '' }) {
-    const handleMouseDown = onLongPress ? (e) => {
-      this.isLongPressing = false;
-      // Store reference to the target element to avoid React event pooling issues
-      const targetElement = e.currentTarget;
-      // Add visual feedback class immediately for better UX
-      targetElement.classList.add('header-action-drawer__long-press-feedback');
-      this.longPressTimer = setTimeout(() => {
-        this.isLongPressing = true;
-        onLongPress(e);
-        // Add success feedback class
-        targetElement.classList.add('header-action-drawer__long-press-success');
-      }, 600);
-    } : undefined;
+    const handleMouseDown = onLongPress
+      ? (e) => {
+          this.isLongPressing = false;
+          // Store reference to the target element to avoid React event pooling issues
+          const targetElement = e.currentTarget;
+          // Add visual feedback class immediately for better UX
+          targetElement.classList.add('header-action-drawer__long-press-feedback');
+          this.longPressTimer = setTimeout(() => {
+            this.isLongPressing = true;
+            onLongPress(e);
+            // Add success feedback class
+            targetElement.classList.add('header-action-drawer__long-press-success');
+          }, 600);
+        }
+      : undefined;
 
-    const handleMouseUp = onLongPress ? (e) => {
-      if (this.longPressTimer) {
-        clearTimeout(this.longPressTimer);
-        this.longPressTimer = null;
-      }
-      // Remove visual feedback classes
-      e.currentTarget.classList.remove('header-action-drawer__long-press-feedback');
-      e.currentTarget.classList.remove('header-action-drawer__long-press-success');
-    } : undefined;
+    const handleMouseUp = onLongPress
+      ? (e) => {
+          if (this.longPressTimer) {
+            clearTimeout(this.longPressTimer);
+            this.longPressTimer = null;
+          }
+          // Remove visual feedback classes
+          e.currentTarget.classList.remove('header-action-drawer__long-press-feedback');
+          e.currentTarget.classList.remove('header-action-drawer__long-press-success');
+        }
+      : undefined;
 
-    const handleMouseLeave = onLongPress ? (e) => {
-      if (this.longPressTimer) {
-        clearTimeout(this.longPressTimer);
-        this.longPressTimer = null;
-      }
-      // Remove visual feedback classes
-      e.currentTarget.classList.remove('header-action-drawer__long-press-feedback');
-      e.currentTarget.classList.remove('header-action-drawer__long-press-success');
-    } : undefined;
+    const handleMouseLeave = onLongPress
+      ? (e) => {
+          if (this.longPressTimer) {
+            clearTimeout(this.longPressTimer);
+            this.longPressTimer = null;
+          }
+          // Remove visual feedback classes
+          e.currentTarget.classList.remove('header-action-drawer__long-press-feedback');
+          e.currentTarget.classList.remove('header-action-drawer__long-press-success');
+        }
+      : undefined;
 
-    const handleClick = onClick ? (e) => {
-      // Only trigger regular click if it wasn't a long press
-      if (!this.isLongPressing) {
-        onClick(e);
-      }
-      this.isLongPressing = false;
-    } : undefined;
+    const handleClick = onClick
+      ? (e) => {
+          // Only trigger regular click if it wasn't a long press
+          if (!this.isLongPressing) {
+            onClick(e);
+          }
+          this.isLongPressing = false;
+        }
+      : undefined;
 
     return (
       <div
@@ -93,12 +101,14 @@ export default class HeaderActionDrawer extends PureComponent {
     } = this.props;
 
     // Create a fallback function for onDuplicateHeader if not provided
-    const handleDuplicateHeader = onDuplicateHeader || ((e) => {
-      // As a fallback, just call the regular add new header function
-      if (onAddNewHeader) {
-        onAddNewHeader(e);
-      }
-    });
+    const handleDuplicateHeader =
+      onDuplicateHeader ||
+      ((e) => {
+        // As a fallback, just call the regular add new header function
+        if (onAddNewHeader) {
+          onAddNewHeader(e);
+        }
+      });
 
     return (
       <div className="header-action-drawer-container">

--- a/src/components/OrgFile/components/Header/components/HeaderActionDrawer/index.js
+++ b/src/components/OrgFile/components/Header/components/HeaderActionDrawer/index.js
@@ -3,13 +3,67 @@ import React, { PureComponent } from 'react';
 import './stylesheet.css';
 
 export default class HeaderActionDrawer extends PureComponent {
+  constructor(props) {
+    super(props);
+    this.longPressTimer = null;
+    this.isLongPressing = false;
+  }
+
   // A nasty hack required to get click handling to work properly in Firefox. No idea why its
   // broken in the first place or why this fixes it.
-  iconWithFFClickCatcher({ className, onClick, title, testId = '' }) {
+  iconWithFFClickCatcher({ className, onClick, onLongPress, title, testId = '' }) {
+    const handleMouseDown = onLongPress ? (e) => {
+      this.isLongPressing = false;
+      // Store reference to the target element to avoid React event pooling issues
+      const targetElement = e.currentTarget;
+      // Add visual feedback class immediately for better UX
+      targetElement.classList.add('header-action-drawer__long-press-feedback');
+      this.longPressTimer = setTimeout(() => {
+        this.isLongPressing = true;
+        onLongPress(e);
+        // Add success feedback class
+        targetElement.classList.add('header-action-drawer__long-press-success');
+      }, 600);
+    } : undefined;
+
+    const handleMouseUp = onLongPress ? (e) => {
+      if (this.longPressTimer) {
+        clearTimeout(this.longPressTimer);
+        this.longPressTimer = null;
+      }
+      // Remove visual feedback classes
+      e.currentTarget.classList.remove('header-action-drawer__long-press-feedback');
+      e.currentTarget.classList.remove('header-action-drawer__long-press-success');
+    } : undefined;
+
+    const handleMouseLeave = onLongPress ? (e) => {
+      if (this.longPressTimer) {
+        clearTimeout(this.longPressTimer);
+        this.longPressTimer = null;
+      }
+      // Remove visual feedback classes
+      e.currentTarget.classList.remove('header-action-drawer__long-press-feedback');
+      e.currentTarget.classList.remove('header-action-drawer__long-press-success');
+    } : undefined;
+
+    const handleClick = onClick ? (e) => {
+      // Only trigger regular click if it wasn't a long press
+      if (!this.isLongPressing) {
+        onClick(e);
+      }
+      this.isLongPressing = false;
+    } : undefined;
+
     return (
       <div
         title={title}
-        onClick={onClick}
+        onClick={handleClick}
+        onMouseDown={handleMouseDown}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseLeave}
+        onTouchStart={handleMouseDown}
+        onTouchEnd={handleMouseUp}
+        onTouchCancel={handleMouseLeave}
         className="header-action-drawer__ff-click-catcher-container"
       >
         <div className="header-action-drawer__ff-click-catcher" />
@@ -35,7 +89,16 @@ export default class HeaderActionDrawer extends PureComponent {
       onShareHeader,
       onRefileHeader,
       onAddNote,
+      onDuplicateHeader,
     } = this.props;
+
+    // Create a fallback function for onDuplicateHeader if not provided
+    const handleDuplicateHeader = onDuplicateHeader || ((e) => {
+      // As a fallback, just call the regular add new header function
+      if (onAddNewHeader) {
+        onAddNewHeader(e);
+      }
+    });
 
     return (
       <div className="header-action-drawer-container">
@@ -82,8 +145,9 @@ export default class HeaderActionDrawer extends PureComponent {
           {this.iconWithFFClickCatcher({
             className: 'fas fa-plus fa-lg',
             onClick: onAddNewHeader,
+            onLongPress: handleDuplicateHeader,
             testId: 'header-action-plus',
-            title: 'Create new header below',
+            title: 'Create new header below (long-press to duplicate current header)',
           })}
         </div>
 

--- a/src/components/OrgFile/components/Header/components/HeaderActionDrawer/stylesheet.css
+++ b/src/components/OrgFile/components/Header/components/HeaderActionDrawer/stylesheet.css
@@ -2,32 +2,48 @@
 
 .header-action-drawer-container {
   color: var(--base01);
-
   padding-bottom: 10px;
-
   padding-right: 20px;
 }
 
 .header-action-drawer__row {
   display: flex;
   justify-content: space-between;
-
   padding-top: 10px;
 }
 
 .header-action-drawer__ff-click-catcher-container {
   position: relative;
   cursor: pointer;
+  /* Base transition for transform, color, and box-shadow */
+  transition: transform 0.1s ease-in-out, color 0.1s ease-in-out, box-shadow 0.15s ease-in-out, background-color 0.1s ease-in-out;
 }
 
 .header-action-drawer__ff-click-catcher-container:hover {
   color: var(--base02);
 }
 
+.header-action-drawer__ff-click-catcher-container.header-action-drawer__long-press-feedback {
+  transform: scale(1.05);
+  color: var(--base02); /* Or a specific feedback color if preferred */
+  background-color: rgba(0, 0, 0, 0.05); /* Subtle background change */
+  border-radius: 4px;
+  /* Assuming var(--base02) is a greyish color like rgb(131, 148, 150) for the shadow */
+  box-shadow: 0 0 0 18px rgba(131, 148, 150, 0.25); /* Increased visible shadow during press */
+}
+
+.header-action-drawer__ff-click-catcher-container.header-action-drawer__long-press-success {
+  transform: scale(1.15);
+  color: var(--base0B); /* Success color for the icon */
+  background-color: rgba(0, 0, 0, 0.05); /* Can use a success-themed background if available, e.g., var(--base0B-alpha-low) */
+  border-radius: 4px;
+  /* Assuming var(--base0B) is a success/greenish color like rgb(133, 153, 0) for the shadow */
+  box-shadow: 0 0 0 28px rgba(133, 153, 0, 0.3); /* Increased larger, more prominent shadow on success */
+}
+
 .header-action-drawer__ff-click-catcher {
   height: 20px;
   width: 20px;
-
   position: absolute;
   top: 0;
   left: 0;
@@ -35,10 +51,8 @@
 
 .header-action-drawer__separator {
   background-color: var(--base01);
-
   height: 15px;
   width: 1px;
-
   margin-left: 10px;
   margin-right: 10px;
 }

--- a/src/components/OrgFile/components/Header/index.js
+++ b/src/components/OrgFile/components/Header/index.js
@@ -49,6 +49,7 @@ class Header extends PureComponent {
       'handleShareHeaderClick',
       'handleRefileHeaderRequest',
       'handleAddNoteClick',
+      'handleDuplicateHeader',
     ]);
 
     this.state = {
@@ -278,6 +279,10 @@ class Header extends PureComponent {
 
   handleAddNewHeader() {
     this.props.org.addHeaderAndEdit(this.props.header.get('id'));
+  }
+
+  handleDuplicateHeader() {
+    this.props.org.duplicateHeader(this.props.header.get('id'));
   }
 
   handleRest() {
@@ -591,6 +596,7 @@ ${header.get('rawDescription')}`;
                   onShareHeader={this.handleShareHeaderClick}
                   onRefileHeader={this.handleRefileHeaderRequest}
                   onAddNote={this.handleAddNoteClick}
+                  onDuplicateHeader={this.handleDuplicateHeader}
                 />
               </Collapse>
 

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -322,6 +322,30 @@ const addHeader = (state, action) => {
   );
 };
 
+const duplicateHeader = (state, action) => {
+  const headers = state.get('headers');
+  const { header: originalHeader, headerIndex: originalHeaderIndex } = indexAndHeaderWithId(
+    headers,
+    action.headerId
+  );
+
+  if (!originalHeader) {
+    return state;
+  }
+
+  const subheaders = subheadersOfHeaderWithId(headers, action.headerId);
+  const headersToClone = [originalHeader].concat(subheaders.toJS());
+
+  const clonedHeaders = headersToClone.map((header) => {
+    // Deep clone and generate new ID
+    return fromJS(header.toJS()).set('id', generateId());
+  });
+
+  return state.update('headers', (headers) =>
+    headers.splice(originalHeaderIndex + subheaders.size + 1, 0, ...clonedHeaders)
+  );
+};
+
 const createFirstHeader = (state) => {
   let newHeader = newHeaderWithTitle('First header', 1, state.get('todoKeywordSets'));
 
@@ -1766,6 +1790,8 @@ const reducer = (state, action) => {
       return inFile(updateHeaderDescription);
     case 'ADD_HEADER':
       return inFile(addHeader);
+    case 'DUPLICATE_HEADER':
+      return inFile(duplicateHeader);
     case 'CREATE_FIRST_HEADER':
       return inFile(createFirstHeader);
     case 'SELECT_NEXT_SIBLING_HEADER':

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -338,7 +338,7 @@ const duplicateHeader = (state, action) => {
 
   const clonedHeaders = headersToClone.map((header) => {
     // Deep clone and generate new ID
-    return fromJS(header.toJS()).set('id', generateId());
+    return fromJS(header).set('id', generateId());
   });
 
   return state.update('headers', (headers) =>


### PR DESCRIPTION
Closes #894 

Implements a long-press gesture on the plus icon within the
HeaderActionDrawer to duplicate the current header and its entire
subtree. This provides a quick alternative to manually recreating
similar header structures.

There's visual feedback for long-press interactions, too.

@schoettl It's taken a *loong* time, but I finally got around to your feature request. What do you say, can we use it like this?

NB: I would have liked to go with vibration feedback on mobile, but it never worked on my phone, so I went with a bit of clumsy visual feedback(;