### PR TITLE
fix: repeater state changes will now be filed to the correct header

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -7,6 +7,16 @@ All user visible changes to organice will be documented in this file.
 
 When there are updates to the changelog, you will be notified and see a 'gift' icon appear on the top right corner.
 
+* <2025-06-06 Fri>
+
+** Fixed
+
+*** Repeater state changes will now always be filed to the correct header
+
+- =updatePlanningItemsWithRepeaters= now selects the header it intends to update
+
+PR: [[https://github.com/200ok-ch/organice/pull/1029]]  
+  
 * [2025-05-24 Sat]
 
 ** Added

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -2059,6 +2059,9 @@ function updatePlanningItemsWithRepeaters({
   logIntoDrawer,
   timestamp,
 }) {
+  const headerId = state.getIn(['headers', headerIndex, 'id']);
+  state = selectHeader(state, { headerId });
+
   indexedPlanningItemsWithRepeaters.forEach(([planningItem, planningItemIndex]) => {
     const adjustedTimestamp = applyRepeater(planningItem.get('timestamp'), timestamp);
     state = state.setIn(
@@ -2146,6 +2149,7 @@ function updatePlanningItemsWithRepeaters({
             })
           )
     );
+
     state = addTodoStateChangeLogItem(
       state,
       headerIndex,

--- a/test_helpers/fixtures/various_todos.org
+++ b/test_helpers/fixtures/various_todos.org
@@ -4,3 +4,8 @@
 * TODO Task with active timestamp and repeater <2020-11-15 Sun +1d>
 * TODO Repeating task
   SCHEDULED: <2019-11-27 Wed +1d>
+* TODO Not done
+* TODO Not done with logs 
+:LOGBOOK:
+CLOCK: [2025-06-01 Sun 00:29]--[2025-06-01 Sun 00:38] =>  0:09
+:END:


### PR DESCRIPTION
Fixes: #1011 and #750 

I found this error when I added a headline to the end of `various_todos` fixtures, right after the "Repeating task" header. I was adding new Todos as I am going to rewrite #984. Adding a new header caused the 'should advance repeating task' test to fail. It failed at the line where it asserted the `logNotes` of the entry with a repeater had changed. I was able to trace this error to addNoteGeneric where I noticed `headerId` was undefined as `state.get('selectedHeaderId')` returned undefined. However, this would never cause `addNoteGeneric` to fail since `headerId` is passed to `indexOfHeaderWithId`, which relies on `findIndex`. `findIndex` returns -1 whenever it can find an element that satisfies your testing function. That is the reason `updatePlanningItemsWithRepeaters` appeared to work correctly. That is also why the 'should advance repeating task' test would fail whenever a header was added to `various_todos`.  To fix this, I added two more headers to `various_todos`. Then, I revised 'should advance repeating task' , 'should advance repeating task again' and 'should advance active timestamp with repeater in header'. Finally, I made sure to select the header that was being edited in `updatePlanningItemsWithRepeaters`.

I should add that although I resolved this specific issue, I really think `indexOfHeaderWithId` should be looked at and rewritten. Any function that relies on `indexOfHeaderWithId` could end up modifying the wrong header since `findIndex` returns -1, which is still technically an index, when it fails. There is a good chance `indexOfHeaderWithId` is causing other problems. 