### PR TITLE
feat: Added confirm button on a swipe to remove a header

### DIFF
--- a/src/components/OrgFile/components/Header/index.js
+++ b/src/components/OrgFile/components/Header/index.js
@@ -150,10 +150,11 @@ class Header extends PureComponent {
       }
 
       if (-1 * swipeDistance >= this.SWIPE_ACTION_ACTIVATION_DISTANCE) {
-        this.setState({
-          isPlayingRemoveAnimation: true,
-          heightBeforeRemove: this.containerDiv.offsetHeight,
-        });
+        window.confirm('Please confirm your request to delete this header') &&
+          this.setState({
+            isPlayingRemoveAnimation: true,
+            heightBeforeRemove: this.containerDiv.offsetHeight,
+          });
       }
     }
 


### PR DESCRIPTION
Related: #586 
Accidental deletes have been a major annoyance. They seem to happen constantly whenever I use Organice on my phone. This very small change will simply create a popup that will ask a user to confirm they want to delete a header. This prompt will only appear on left swipes.