### PR TITLE
fix: Made it harder to swipe left or right on a header accidentally

### DIFF
--- a/src/components/OrgFile/components/Header/index.js
+++ b/src/components/OrgFile/components/Header/index.js
@@ -140,16 +140,15 @@ class Header extends PureComponent {
     const { dragStartX, currentDragX } = this.state;
 
     if (!!dragStartX && !!currentDragX) {
-      const swipeDistance = currentDragX - dragStartX;
 
-      if (swipeDistance >= this.SWIPE_ACTION_ACTIVATION_DISTANCE) {
+      if (currentDragX >= (2 * dragStartX)) {
         this.props.org.advanceTodoState(
           this.props.header.get('id'),
           this.props.shouldLogIntoDrawer
         );
       }
 
-      if (-1 * swipeDistance >= this.SWIPE_ACTION_ACTIVATION_DISTANCE) {
+	if (dragStartX >= (2 * currentDragX)) {
         this.setState({
           isPlayingRemoveAnimation: true,
           heightBeforeRemove: this.containerDiv.offsetHeight,


### PR DESCRIPTION
SWIPE_ACTION_ACTIVATION_DISTANCE was the root cause of the accidental deletes. Because of the low value of that variable, you barely had to swipe at all in order to shift the state of a header or delete it. In any case, a hard coded variable should not have been used in this instance. Instead of using that variable, dragStartX and currentDragX are the only variables used to determine whether or not a state shift or delete should be triggered. That means a state shift or delete is only triggered once a user has swiped about halfway across the screen. The swipe animations themselves were not touched.