### PR TITLE
fix: Fixed timestamp error in OrgFile.integration.test.js

### DIFF
--- a/src/components/OrgFile/OrgFile.integration.test.js
+++ b/src/components/OrgFile/OrgFile.integration.test.js
@@ -525,8 +525,9 @@ describe('Render all views', () => {
         });
 
         test('Clicking the Timestamp in a TODO within the agenda toggles from the date to the time', () => {
+          const expectedDate = new Date(2019, 8, 19, 12, 0);
           fireEvent.click(getByTitle('Show agenda'));
-          const timeSinceScheduled = formatDistanceToNow(new Date('2019-09-19'));
+          const timeSinceScheduled = formatDistanceToNow(expectedDate);
           expect(queryByText(timeSinceScheduled)).toBeFalsy();
           expect(queryByText('09/19')).toBeTruthy();
           fireEvent.click(queryByText('09/19'));


### PR DESCRIPTION
The `Clicking the Timestamp in a TODO within the agenda toggles from the date to the time` test failed when I ran yarn test this morning. However, the feature itself still worked when I tested it. I was able to trace the test error to `dateForTimestamp`. `dateForTimestamp` sets the start hour of a timestamp to 12:00 if it receives a timestamp without a start time. The expected date in the test did not take this account. Now that I have taken that into account, the test no longer fails.