### PR TITLE
feat: Implement 'deep export' and 'share' with 'mailto' fallback

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -7,6 +7,18 @@ All user visible changes to organice will be documented in this file.
 
 When there are updates to the changelog, you will be notified and see a 'gift' icon appear on the top right corner.
 
+* [2025-06-22 Sun]
+
+** Fixed
+
+*** When exporting to email, don't just export the selected headline, but sub-headlines
+
+** Added
+
+*** Users can now share their headlines (including sub-headlines) to any app - with a fallback to mail.
+
+- PR: https://github.com/200ok-ch/organice/pull/1036
+
 * [2025-06-18 Wed]
 
 ** Fixed

--- a/src/components/OrgFile/OrgFile.integration.test.js
+++ b/src/components/OrgFile/OrgFile.integration.test.js
@@ -382,7 +382,9 @@ describe('Render all views', () => {
           expect(global.open).toBeCalledWith(
             `mailto:?subject=${encodeURIComponent(
               'Another top level header'
-            )}&body=${encodeURIComponent('\n\nSome description content\n')}`
+            )}&body=${encodeURIComponent(
+              '* Another top level header\nSome description content\n\n** TODO A repeating todo\n   SCHEDULED: <2020-04-05 Sun +1d>\n\n'
+            )}`
           );
         });
       });

--- a/src/components/OrgFile/components/Header/components/HeaderActionDrawer/index.js
+++ b/src/components/OrgFile/components/Header/components/HeaderActionDrawer/index.js
@@ -163,7 +163,7 @@ export default class HeaderActionDrawer extends PureComponent {
 
         <div className="header-action-drawer__row">
           {this.iconWithFFClickCatcher({
-            className: 'fas fa-envelope fa-lg',
+            className: 'fas fa-share fa-lg',
             onClick: onShareHeader,
             testId: 'share',
             title: 'Share this header via email',

--- a/src/lib/share_utils.js
+++ b/src/lib/share_utils.js
@@ -1,0 +1,79 @@
+/**
+ * Check if Web Share API is available
+ * @returns {boolean} True if Web Share API is supported
+ */
+export const isWebShareSupported = () => {
+  return navigator.share && typeof navigator.share === 'function';
+};
+
+/**
+ * Share content using Web Share API with fallback
+ * @param {Object} options - Share options
+ * @param {string} options.title - Title for the share
+ * @param {string} options.text - Text content to share
+ * @param {string} options.url - URL to share (optional)
+ * @param {Array} options.files - Files to share (optional)
+ * @returns {Promise<Object>} Result object with success status and method used
+ */
+export const shareContent = async (options) => {
+  const { title, text, url, files } = options;
+
+  if (isWebShareSupported()) {
+    try {
+      const shareData = {};
+      if (title) shareData.title = title;
+      if (text) shareData.text = text;
+      if (url) shareData.url = url;
+      if (files) shareData.files = files;
+
+      await navigator.share(shareData);
+      return { success: true, method: 'web-share' };
+    } catch (error) {
+      if (error.name === 'AbortError') {
+        return { success: false, method: 'web-share', error: 'user-cancelled' };
+      }
+      // Fall through to fallback
+    }
+  }
+
+  // Fallback to email
+  return fallbackToEmail(options);
+};
+
+/**
+ * Fallback to email sharing
+ * @param {Object} options - Share options
+ * @param {string} options.title - Title for the email subject
+ * @param {string} options.text - Text content for the email body
+ * @returns {Object} Result object
+ */
+const fallbackToEmail = ({ title, text }) => {
+  const subject = title || 'Shared from organice';
+  const body = text || '';
+  const mailtoURI = `mailto:?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(
+    body
+  )}`;
+
+  window.open(mailtoURI);
+  return { success: true, method: 'email' };
+};
+
+/**
+ * Create downloadable file
+ * @param {string} content - File content
+ * @param {string} filename - Name of the file
+ * @param {string} mimeType - MIME type of the file (default: 'text/plain')
+ */
+export const createDownloadableFile = (content, filename, mimeType = 'text/plain') => {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+
+  URL.revokeObjectURL(url);
+};


### PR DESCRIPTION
Closing: https://github.com/200ok-ch/organice/issues/935
Closing: https://github.com/200ok-ch/organice/issues/142
Closing: https://github.com/200ok-ch/organice/issues/142

Users can now share their headlines (including sub-headlines) to any app - with a fallback to mail. 