### PR TITLE
fix: Fix ORGANICE_WEBDAV_URL not getting inserted correctly #952

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -2,4 +2,4 @@
 
 bin/transient_env_vars.sh switch build serve
 
-serve -p 5000 -s build
+serve -p 5000 -s serve

--- a/bin/transient_env_vars.sh
+++ b/bin/transient_env_vars.sh
@@ -2,7 +2,12 @@
 
 shopt -s globstar
 
-RVARS=$(cut -d = -f 1 .env.sample)
+# Use .env if it exists, otherwise fall back to .env.sample
+ENV_FILE=".env.sample"
+if [ ! -f "$ENV_FILE" ]; then
+  ENV_FILE=".env"
+fi
+RVARS=$(cut -d = -f 1 $ENV_FILE)
 
 case $1 in
 
@@ -23,7 +28,8 @@ case $1 in
 
     for KEY in $OVARS; do
       VALUE=${!KEY}
-      sed -i "s/$KEY/$VALUE/" "$DST"/**/*.js
+      echo "Replacing $KEY with $VALUE"
+      sed -i "s|$KEY|$VALUE|g" "$DST"/**/*.js
     done
     ;;
 


### PR DESCRIPTION
Fix #952

There are three problems:
1、 No .env.sample in docker image of production.
<img width="484" height="69" alt="Snipaste_2025-07-11_18-36-02" src="https://github.com/user-attachments/assets/f0aa08ea-5a0e-492a-b04d-8936cba241ef" />

2、 Failed beacause $VALUE (enviroment value) contains '/' 
when do `sed -i "s/$KEY/$VALUE/g" "$DST"/**/*.js`
<img width="566" height="77" alt="Snipaste_2025-07-11_23-12-41" src="https://github.com/user-attachments/assets/dc3697fd-e5be-41b4-a35d-13644d7a06b0" />

3、 $DST equals "serve" but `serve -p 5000 -s build` in entrypoint.sh.
`set -x` for entrypoint.sh and transient_env_vars.sh，we would get messages:
```plain
+ sed -i 's|ORGANICE_WEBDAV_URL|https://organice.example.org/dav|g' serve/public.2c69fddf.js serve/public.a9de6ea2.js
+ serve -p 5000 -s build
```
In reality, I think we should `-s serve`.