### PR TITLE
Fix(Components/OrgFile/TimestampEditor): Incorrect Timestamp Format

### DIFF
--- a/src/components/OrgFile/components/TimestampEditorModal/components/TimestampEditor/index.js
+++ b/src/components/OrgFile/components/TimestampEditorModal/components/TimestampEditor/index.js
@@ -103,8 +103,8 @@ class TimestampEditor extends PureComponent {
 
       const [hourKey, minuteKey] =
         startOrEnd === 'start' ? ['startHour', 'startMinute'] : ['endHour', 'endMinute'];
-      let [hour, minute] = event.target.value.split(':');
-      hour = hour.startsWith('0') ? hour.substring(1) : hour;
+      const [hour, minute] = event.target.value.split(':');
+
       onChange(timestamp.set(hourKey, hour).set(minuteKey, minute));
     };
   }


### PR DESCRIPTION
The org timestamp format is YYYY-MM-DD HH:mm. The line I removed stripped the leading zero from the hour part of the date. So [2018-09-17 Sun 06:00-11:30] was incorrectly saved as [2018-09-17 Sun 6:00-11:30]. All tests still pass. This changes doesn't effect the timestamp backend at all since it already expects the time part of timestamps to be in HH:mm format.