### PR TITLE
Add "#" and "%" as valid characters for tag searches.

### DIFF
--- a/src/lib/headline_filter_parser.grammar.pegjs
+++ b/src/lib/headline_filter_parser.grammar.pegjs
@@ -168,7 +168,7 @@ PropertyName "property name"
 
 // https://orgmode.org/manual/Tags.html
 TagName "tag name"
-  = [a-zA-Z0-9_@]+ { return text() }
+  = [a-zA-Z0-9_@#%]+ { return text() }
 
 _ "whitespace"
   = [ \t]


### PR DESCRIPTION
The official org documentation doesn't currently mention them, but they are explicitly listed as valid in org-set-tags-command.

Based on version control, it seems like these have been supported for a very long time. I'm planning on submitting a request to the org-mode mailing list to update the documentation to match, but I figured I would do that in parallel with this pull request.

If you'd prefer to wait until the documentation is updated, that is fine too.

I noticed this because I use tags beginning with "#" for context, e.g. "#technology".