### PR TITLE
Fix: move preventDefault to prevent race with oauth request

### DIFF
--- a/src/components/SyncServiceSignIn/index.js
+++ b/src/components/SyncServiceSignIn/index.js
@@ -113,13 +113,13 @@ function GitLab() {
   const defaultProject = 'https://gitlab.com/your/project';
   const [project, setProject] = useState(defaultProject);
   const handleSubmit = (evt) => {
+    evt.preventDefault();
     const projectId = gitLabProjectIdFromURL(project);
     if (projectId) {
       persistField('authenticatedSyncService', 'GitLab');
       persistField('gitLabProject', projectId);
       createGitlabOAuth().fetchAuthorizationCode();
     } else {
-      evt.preventDefault();
       alert('Project does not appear to be a valid gitlab.com URL');
     }
   };


### PR DESCRIPTION
Fixes #1059 

Addresses a race condition where the default form submission request may preempt the request to the GitLab OAuth endpoint, causing the latter to be cancelled. When this happens, the local storage `oauth2authcodepkce-state` ends up in a corrupt state, resulting in the error observed in #1059.

This moves the call to `preventDefault()` to the beginning of the form submission handler, so it is called also when the project URL is valid. This placement is also consistent with the WebDAV handler.

It's unclear to me what changed in recent versions of Chrome to make the issue manifest, but I think the change is correct regardless.