### PR TITLE
fix: ensure PWA updates apply immediately on iOS Safari

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,22 @@
+RewriteEngine On
+RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} -f [OR]
+RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} -d
+RewriteRule ^ - [L]
+
+RewriteRule ^ /index.html [L]
+
+# Prevent caching of service worker file
+<FilesMatch "sw\.js$">
+  <IfModule mod_headers.c>
+    Header set Cache-Control "no-store, no-cache, must-revalidate, max-age=0"
+    Header set Pragma "no-cache"
+    Header set Expires "Wed, 11 Jan 1984 05:00:00 GMT"
+  </IfModule>
+</FilesMatch>
+
+# Cache index.html with short expiration to allow updates
+<FilesMatch "index\.html$">
+  <IfModule mod_headers.c>
+    Header set Cache-Control "public, max-age=300, must-revalidate"
+  </IfModule>
+</FilesMatch>

--- a/changelog.org
+++ b/changelog.org
@@ -37,6 +37,16 @@ Base settings (including Org habits settings) were being overwritten with =undef
 
 Settings now correctly persist from localStorage even when the config file is missing specific fields.
 
+*** PWA updates not applying on iOS Safari
+
+When deploying new versions of organice, iOS Safari users often didn't receive updates and had to remove/reinstall the PWA from their home screen.
+
+Fixed by:
+- Adding =skipWaiting()= to force immediate service worker activation
+- Adding =clients.claim()= to ensure new service worker controls all clients immediately
+- Adding proper fetch event handler for cache-first strategy
+- Adding cache headers in =.htaccess= to prevent service worker file from being cached
+
 * [2025-12-01 Mon]
 
 ** Added


### PR DESCRIPTION
- Add skipWaiting() to force immediate service worker activation
- Add clients.claim() to ensure new SW controls all clients immediately
- Add proper fetch event handler for cache-first strategy
- Add cache headers in .htaccess to prevent service worker file caching