### PR TITLE
feat: auto-continue lists in description editor

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -7,6 +7,16 @@ All user visible changes to organice will be documented in this file.
 
 When there are updates to the changelog, you will be notified and see a 'gift' icon appear on the top right corner.
 
+* [2026-02-12 Thu]
+
+** Added
+
+*** Auto-continue lists in description editor
+    - When editing a header description, pressing Enter after a list item (=- item= or =1. item=) automatically starts the next list item
+    - Ordered lists increment the number (=1.= → =2.= → =3.=)
+    - Pressing Enter on an empty list prefix removes it, exiting the list
+    - Works with both dash (=-=) and plus (=+=) unordered lists, and dot (=1.=) and paren (=1)=) ordered lists
+
 * [2026-02-11 Wed]
 
 ** Added

--- a/sample.org
+++ b/sample.org
@@ -182,6 +182,15 @@ Checkboxes:
   - [X] 1. 2
 - [X] 2
 
+** Auto-continuation
+
+When editing a description, lists are automatically continued when you press Enter:
+
+- Type =- item= and press Enter → the next line starts with =- =
+- Type =1. item= and press Enter → the next line starts with =2. =
+
+To stop the list, press Enter on an empty list prefix (the auto-generated =- = or =2. = is removed).
+
 ** Editing workflow
 
 First, create the first list item by editing the description of a header. When you close the "edit description" modal, you can manipulate the list item with native list manipulation functions. The UX is analogous to manipulating a header. Here's what you can do:


### PR DESCRIPTION
## Summary

- When editing a header description, pressing Enter after a list item (`- item` or `1. item`) automatically starts the next list item
- Ordered lists increment the number (`1.` → `2.` → `3.`)
- Pressing Enter on an empty list prefix removes it, exiting the list
- Works with dash (`-`), plus (`+`) unordered lists and dot (`1.`) / paren (`1)`) ordered lists
- Preserves indentation for nested lists

## Test plan

- [x] All 471 unit tests pass
- [x] All 70 Playwright E2E tests pass (Chromium, Firefox, WebKit, Mobile Chrome, Mobile Safari)
- [x] 4 new E2E tests for list auto-continuation added
- [x] Feature documented in `sample.org` under "Lists and checkboxes > Auto-continuation"
- [x] Changelog entry added