### PR TITLE
fix: enforce single default startup file

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -7,6 +7,11 @@ All user visible changes to organice will be documented in this file.
 
 When there are updates to the changelog, you will be notified and see a 'gift' icon appear on the top right corner.
 
+* [2026-07-09 Thu]
+** Fixed
+*** Default startup file setting
+    - Selecting a file to open on startup now automatically clears that option from other file settings
+
 * [2026-05-17 Sun]
 ** Fixed
 *** Capture target file sync

--- a/changelog.org
+++ b/changelog.org
@@ -11,6 +11,7 @@ When there are updates to the changelog, you will be notified and see a 'gift' i
 ** Fixed
 *** Default startup file setting
     - Selecting a file to open on startup now automatically clears that option from other file settings
+    - PR: https://github.com/200ok-ch/organice/pull/1122
 
 * [2026-05-17 Sun]
 ** Fixed

--- a/src/components/FileSettingsEditor/components/FileSetting/index.js
+++ b/src/components/FileSettingsEditor/components/FileSetting/index.js
@@ -72,9 +72,8 @@ export default ({ setting, index, onFieldPathUpdate, onDeleteSetting, loadedFile
 
         <div className="file-setting__help-text">
           By default, when you start organice, it will display your root file directory. If you
-          prefer to display a specific Org file instead, enable this option. <br /> Note: There can
-          only be one default file, of course. If you enable this option for multiple files,
-          organice will pick the first one.
+          prefer to display a specific Org file instead, enable this option. Enabling this option
+          disables it for all other file settings.
         </div>
       </div>
       <div className="file-setting__field-container">

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -1768,6 +1768,16 @@ const indexOfFileSettingWithId = (settings, settingId) =>
 const updateFileSettingFieldPathValue = (state, action) => {
   const settingIndex = indexOfFileSettingWithId(state.get('fileSettings'), action.settingId);
 
+  if (
+    settingIndex !== -1 &&
+    action.newValue === true &&
+    _.isEqual(action.fieldPath, ['defaultOnStartup'])
+  ) {
+    return state.update('fileSettings', (settings) =>
+      settings.map((setting, index) => setting.set('defaultOnStartup', index === settingIndex))
+    );
+  }
+
   return state.setIn(['fileSettings', settingIndex].concat(action.fieldPath), action.newValue);
 };
 

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -110,6 +110,35 @@ describe('org reducer', () => {
     'planningItems'
   );
 
+  describe('file settings', () => {
+    it('keeps only one default startup file when enabling a file setting', () => {
+      const state = readInitialState().org.present.set(
+        'fileSettings',
+        fromJS([
+          { id: 'a', path: '/a.org', defaultOnStartup: false },
+          { id: 'b', path: '/b.org', defaultOnStartup: true },
+          { id: 'c', path: '/c.org', defaultOnStartup: true },
+        ])
+      );
+
+      const newState = reducer(
+        state,
+        types.updateFileSettingFieldPathValue('a', ['defaultOnStartup'], true)
+      );
+
+      expect(
+        newState
+          .get('fileSettings')
+          .map((setting) => [setting.get('path'), setting.get('defaultOnStartup')])
+          .toJS()
+      ).toEqual([
+        ['/a.org', true],
+        ['/b.org', false],
+        ['/c.org', false],
+      ]);
+    });
+  });
+
   describe('REFILE_SUBTREE', () => {
     let state;
     const path = 'testfile';


### PR DESCRIPTION
Ensure enabling `defaultOnStartup` on one file setting clears it from all others
