### PR TITLE
docs: fix pronoun consistency in README

### DIFF
--- a/README.org
+++ b/README.org
@@ -1039,7 +1039,7 @@ and you're good to go!
 
 Before starting work on organice, [[https://github.com/munen/][@munen]] (the original maintainer)
 used Beorg and donated to it multiple times, because he was very happy
-to have a good option to access Org files on my phone with it.
+to have a good option to access Org files on his phone with it.
 
 The important differences to him were:
 


### PR DESCRIPTION
### User Story
As a reader of the documentation, I want consistent pronouns in the project background section, so that the text is clear and grammatically natural.

### Summary
Fixes a small pronoun mismatch in `README.org`. The sentence was written in the third person (*"because he was very happy..."*), but still contained *"my phone"*. Changed *"my phone"* to *"his phone"*.