### PR TITLE
Fix logdone by writing CLOSED timestamps on TODO completion

### DIFF
--- a/README.org
+++ b/README.org
@@ -303,12 +303,14 @@ organice implements this customization strategy:
 *** =#+STARTUP:= options
 
 - =nologrepeat=: Do not record when reinstating repeating item
+- =logdone= / =nologdone=: Record a =CLOSED:= timestamp when a TODO is marked done (and remove it when leaving a done state)
 
 *** Drawer properties
     :PROPERTIES:
     :END:
 
 - =logrepeat= and =nologrepeat=: Whether to record when reinstating repeating item
+- =logdone= and =nologdone=: Whether to record a =CLOSED:= timestamp when marking TODO items done
 
 #+BEGIN_EXAMPLE
    :PROPERTIES:

--- a/src/components/OrgFile/OrgFile.unit.test.js
+++ b/src/components/OrgFile/OrgFile.unit.test.js
@@ -9,7 +9,7 @@ import {
 import { exportOrg, createRawDescriptionText } from '../../lib/export_org';
 import { newHeaderWithTitle } from '../../lib/parse_org';
 import readFixture from '../../../test_helpers/index';
-import { noLogRepeatEnabledP } from '../../reducers/org';
+import { noLogRepeatEnabledP, logDoneEnabledP } from '../../reducers/org';
 import { fromJS } from 'immutable';
 
 /**
@@ -468,6 +468,39 @@ ${description}`;
         expect(noLogRepeatEnabledP({ state, headerIndex: 2 })).toBe(true);
         expect(noLogRepeatEnabledP({ state, headerIndex: 5 })).toBe(false);
         expect(noLogRepeatEnabledP({ state, headerIndex: 7 })).toBe(true);
+      });
+    });
+
+    describe('"logdone" configuration', () => {
+      test('Detects "logdone" when set in #+STARTUP as only option', () => {
+        const testOrgFile = readFixture('todo_with_logdone');
+        const state = parseOrg(testOrgFile);
+        expect(logDoneEnabledP({ state, headerIndex: 0 })).toBe(true);
+      });
+      test('Detects "logdone" when set in #+STARTUP with other options', () => {
+        const testOrgFile = readFixture('todo_with_logdone_and_other_options');
+        const state = parseOrg(testOrgFile);
+        expect(logDoneEnabledP({ state, headerIndex: 0 })).toBe(true);
+      });
+      test('Does not detect "logdone" when not set', () => {
+        const testOrgFile = readFixture('various_todos');
+        const state = parseOrg(testOrgFile);
+        expect(logDoneEnabledP({ state, headerIndex: 0 })).toBe(false);
+      });
+      test('Does not treat "nologdone" as "logdone"', () => {
+        const testOrgFile = readFixture('todo_with_nologdone');
+        const state = parseOrg(testOrgFile);
+        expect(logDoneEnabledP({ state, headerIndex: 0 })).toBe(false);
+      });
+      test('Detects "logdone" when set via a property list', () => {
+        const testOrgFile = readFixture('todo_with_logdone_property');
+        const state = parseOrg(testOrgFile);
+        // ** TODO Child should log (under Parent with logging)
+        expect(logDoneEnabledP({ state, headerIndex: 1 })).toBe(true);
+        // ** TODO Child should not log (under Sibling without logging)
+        expect(logDoneEnabledP({ state, headerIndex: 3 })).toBe(false);
+        // ** TODO Child disabled (under Explicitly disabled)
+        expect(logDoneEnabledP({ state, headerIndex: 5 })).toBe(false);
       });
     });
   });

--- a/src/reducers/org.js
+++ b/src/reducers/org.js
@@ -267,6 +267,13 @@ const setTodoState = (state, action) => {
     });
   } else {
     state = state.setIn(['headers', headerIndex, 'titleLine', 'todoKeyword'], newTodoState);
+    state = applyLogDoneClosedTimestamp({
+      state,
+      headerIndex,
+      wasCompleted: currentTodoSet.get('completedKeywords').includes(currentTodoState),
+      isNowCompleted: newTodoSet.get('completedKeywords').includes(newTodoState),
+      timestamp,
+    });
   }
 
   state = updateCookiesOfParentOfHeaderWithId(state, existingHeaderId);
@@ -2106,7 +2113,14 @@ function updateHeadlines({
       timestamp,
     });
   // Update simple headline (without repeaters)
-  return state.setIn(['headers', headerIndex, 'titleLine', 'todoKeyword'], newTodoState);
+  state = state.setIn(['headers', headerIndex, 'titleLine', 'todoKeyword'], newTodoState);
+  return applyLogDoneClosedTimestamp({
+    state,
+    headerIndex,
+    wasCompleted: currentTodoSet.get('completedKeywords').includes(currentTodoState),
+    isNowCompleted: currentTodoSet.get('completedKeywords').includes(newTodoState),
+    timestamp,
+  });
 }
 
 /**
@@ -2276,6 +2290,100 @@ export function noLogRepeatEnabledP({ state, headerIndex }) {
         (v) => v.get('type') === 'text' && v.get('contents').match(/\s*nologrepeat\s*/)
       ))
   );
+}
+
+/**
+ * Does a `#+STARTUP:` line contain the given option as a whole word?
+ * Careful with substrings: `nologdone` must not match `logdone`.
+ */
+function startupHasOption(fileConfigLines, option) {
+  const re = new RegExp(`^#\\+STARTUP:.*(?:^|\\s)${option}(?:\\s|$)`);
+  return fileConfigLines.some((elt) => re.test(elt));
+}
+
+/**
+ * Extract whitespace-delimited tokens from a LOGGING property value.
+ */
+function loggingPropertyTokens(loggingProp) {
+  if (!loggingProp) {
+    return [];
+  }
+  return loggingProp
+    .filter((v) => v.get('type') === 'text')
+    .map((v) => v.get('contents'))
+    .join(' ')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+/**
+ * Is `org-log-done` / `#+STARTUP: logdone` enabled for this header?
+ * More info:
+ * https://www.gnu.org/software/emacs/manual/html_node/org/Tracking-TODO-state-changes.html
+ *
+ * Per-subtree `:LOGGING:` properties override buffer `#+STARTUP:` options.
+ */
+export function logDoneEnabledP({ state, headerIndex }) {
+  const loggingTokens = loggingPropertyTokens(
+    inheritedValueOfProperty(state.get('headers'), headerIndex, 'LOGGING')
+  );
+  if (loggingTokens.includes('nologdone')) {
+    return false;
+  }
+  if (loggingTokens.includes('logdone')) {
+    return true;
+  }
+
+  const configLines = state.get('fileConfigLines');
+  if (startupHasOption(configLines, 'nologdone')) {
+    return false;
+  }
+  return startupHasOption(configLines, 'logdone');
+}
+
+/**
+ * When logdone is enabled, add a CLOSED timestamp on completion and remove it
+ * when leaving a completed state. Matches Emacs `org-log-done` / `time` behavior.
+ */
+function applyLogDoneClosedTimestamp({
+  state,
+  headerIndex,
+  wasCompleted,
+  isNowCompleted,
+  timestamp,
+}) {
+  if (!logDoneEnabledP({ state, headerIndex })) {
+    return state;
+  }
+
+  if (isNowCompleted && !wasCompleted) {
+    const closedTimestamp = timestampForDate(timestamp, {
+      isActive: false,
+      withStartTime: true,
+    });
+    const newClosedItem = fromJS({
+      id: generateId(),
+      type: 'CLOSED',
+      timestamp: closedTimestamp,
+    });
+
+    return state.updateIn(['headers', headerIndex, 'planningItems'], (planningItems) => {
+      const existingIndex = planningItems.findIndex((item) => item.get('type') === 'CLOSED');
+      if (existingIndex >= 0) {
+        return planningItems.set(existingIndex, newClosedItem);
+      }
+      return planningItems.unshift(newClosedItem);
+    });
+  }
+
+  if (!isNowCompleted && wasCompleted) {
+    return state.updateIn(['headers', headerIndex, 'planningItems'], (planningItems) =>
+      planningItems.filter((item) => item.get('type') !== 'CLOSED')
+    );
+  }
+
+  return state;
 }
 
 /**

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -1153,6 +1153,128 @@ describe('org reducer', () => {
       check_is_undoable(state, types.advanceTodoState(todoHeaderId, true));
       check_is_undoable(state, types.advanceTodoState(doneHeaderId, false));
     });
+
+    describe('with #+STARTUP: logdone', () => {
+      const logdonePath = 'logdone-testfile';
+      const fixedTimestamp = new Date(2024, 3, 17, 15, 3);
+
+      const advanceWithTimestamp = (headerId) => ({
+        type: 'ADVANCE_TODO_STATE',
+        headerId,
+        logIntoDrawer: false,
+        dirtying: true,
+        timestamp: fixedTimestamp,
+      });
+
+      const setTodoWithTimestamp = (headerId, newTodoState) => ({
+        type: 'SET_TODO_STATE',
+        headerId,
+        newTodoState,
+        logIntoDrawer: false,
+        dirtying: true,
+        timestamp: fixedTimestamp,
+      });
+
+      it('adds a CLOSED timestamp when completing a TODO', () => {
+        const logdoneState = setUpStateForFile(logdonePath, readFixture('todo_with_logdone'));
+        const todoId = logdoneState.org.present.getIn(['files', logdonePath, 'headers']).get(0).get('id');
+
+        const newHeaders = reducer(logdoneState.org.present, advanceWithTimestamp(todoId)).getIn([
+          'files',
+          logdonePath,
+          'headers',
+        ]);
+        const header = headerWithId(newHeaders, todoId);
+
+        expect(header.getIn(['titleLine', 'todoKeyword'])).toEqual('DONE');
+        const closedItem = header.get('planningItems').find((item) => item.get('type') === 'CLOSED');
+        expect(closedItem).toBeTruthy();
+        expect(closedItem.getIn(['timestamp', 'isActive'])).toBe(false);
+        expect(closedItem.getIn(['timestamp', 'year'])).toEqual('2024');
+        expect(closedItem.getIn(['timestamp', 'month'])).toEqual('04');
+        expect(closedItem.getIn(['timestamp', 'day'])).toEqual('17');
+        expect(closedItem.getIn(['timestamp', 'startHour'])).toEqual('15');
+        expect(closedItem.getIn(['timestamp', 'startMinute'])).toEqual('03');
+      });
+
+      it('preserves existing SCHEDULED items when adding CLOSED', () => {
+        const logdoneState = setUpStateForFile(logdonePath, readFixture('todo_with_logdone'));
+        const scheduledId = logdoneState.org.present
+          .getIn(['files', logdonePath, 'headers'])
+          .get(2)
+          .get('id');
+
+        const newHeaders = reducer(
+          logdoneState.org.present,
+          advanceWithTimestamp(scheduledId)
+        ).getIn(['files', logdonePath, 'headers']);
+        const header = headerWithId(newHeaders, scheduledId);
+
+        expect(header.get('planningItems').map((item) => item.get('type')).toJS()).toEqual([
+          'CLOSED',
+          'SCHEDULED',
+        ]);
+      });
+
+      it('removes CLOSED when leaving a DONE state', () => {
+        const logdoneState = setUpStateForFile(logdonePath, readFixture('todo_with_logdone'));
+        const doneId = logdoneState.org.present.getIn(['files', logdonePath, 'headers']).get(1).get('id');
+
+        expect(
+          headerWithId(logdoneState.org.present.getIn(['files', logdonePath, 'headers']), doneId)
+            .get('planningItems')
+            .some((item) => item.get('type') === 'CLOSED')
+        ).toBe(true);
+
+        const newHeaders = reducer(logdoneState.org.present, advanceWithTimestamp(doneId)).getIn([
+          'files',
+          logdonePath,
+          'headers',
+        ]);
+        const header = headerWithId(newHeaders, doneId);
+
+        expect(header.getIn(['titleLine', 'todoKeyword'])).toEqual('');
+        expect(header.get('planningItems').some((item) => item.get('type') === 'CLOSED')).toBe(
+          false
+        );
+      });
+
+      it('does not add CLOSED when logdone is not enabled', () => {
+        const oldHeaders = state.org.present.getIn(['files', path, 'headers']);
+        const newHeaders = reducer(
+          state.org.present,
+          advanceWithTimestamp(todoHeaderId)
+        ).getIn(['files', path, 'headers']);
+
+        expect(headerWithId(newHeaders, todoHeaderId).getIn(['titleLine', 'todoKeyword'])).toEqual(
+          'DONE'
+        );
+        expect(
+          headerWithId(newHeaders, todoHeaderId)
+            .get('planningItems')
+            .some((item) => item.get('type') === 'CLOSED')
+        ).toBe(false);
+        expect(headerWithId(oldHeaders, todoHeaderId).get('planningItems')).toEqual(
+          headerWithId(newHeaders, todoHeaderId).get('planningItems')
+        );
+      });
+
+      it('adds CLOSED via setTodoState when completing a TODO', () => {
+        const logdoneState = setUpStateForFile(logdonePath, readFixture('todo_with_logdone'));
+        const todoId = logdoneState.org.present.getIn(['files', logdonePath, 'headers']).get(0).get('id');
+
+        const newHeaders = reducer(
+          logdoneState.org.present,
+          setTodoWithTimestamp(todoId, 'DONE')
+        ).getIn(['files', logdonePath, 'headers']);
+        const header = headerWithId(newHeaders, todoId);
+
+        expect(header.getIn(['titleLine', 'todoKeyword'])).toEqual('DONE');
+        expect(header.get('planningItems').some((item) => item.get('type') === 'CLOSED')).toBe(
+          true
+        );
+      });
+    });
   });
 
   describe('UPDATE_LOG_ENTRY_TIME', () => {

--- a/src/reducers/org.unit.test.js
+++ b/src/reducers/org.unit.test.js
@@ -1177,7 +1177,10 @@ describe('org reducer', () => {
 
       it('adds a CLOSED timestamp when completing a TODO', () => {
         const logdoneState = setUpStateForFile(logdonePath, readFixture('todo_with_logdone'));
-        const todoId = logdoneState.org.present.getIn(['files', logdonePath, 'headers']).get(0).get('id');
+        const todoId = logdoneState.org.present
+          .getIn(['files', logdonePath, 'headers'])
+          .get(0)
+          .get('id');
 
         const newHeaders = reducer(logdoneState.org.present, advanceWithTimestamp(todoId)).getIn([
           'files',
@@ -1187,7 +1190,9 @@ describe('org reducer', () => {
         const header = headerWithId(newHeaders, todoId);
 
         expect(header.getIn(['titleLine', 'todoKeyword'])).toEqual('DONE');
-        const closedItem = header.get('planningItems').find((item) => item.get('type') === 'CLOSED');
+        const closedItem = header
+          .get('planningItems')
+          .find((item) => item.get('type') === 'CLOSED');
         expect(closedItem).toBeTruthy();
         expect(closedItem.getIn(['timestamp', 'isActive'])).toBe(false);
         expect(closedItem.getIn(['timestamp', 'year'])).toEqual('2024');
@@ -1210,15 +1215,20 @@ describe('org reducer', () => {
         ).getIn(['files', logdonePath, 'headers']);
         const header = headerWithId(newHeaders, scheduledId);
 
-        expect(header.get('planningItems').map((item) => item.get('type')).toJS()).toEqual([
-          'CLOSED',
-          'SCHEDULED',
-        ]);
+        expect(
+          header
+            .get('planningItems')
+            .map((item) => item.get('type'))
+            .toJS()
+        ).toEqual(['CLOSED', 'SCHEDULED']);
       });
 
       it('removes CLOSED when leaving a DONE state', () => {
         const logdoneState = setUpStateForFile(logdonePath, readFixture('todo_with_logdone'));
-        const doneId = logdoneState.org.present.getIn(['files', logdonePath, 'headers']).get(1).get('id');
+        const doneId = logdoneState.org.present
+          .getIn(['files', logdonePath, 'headers'])
+          .get(1)
+          .get('id');
 
         expect(
           headerWithId(logdoneState.org.present.getIn(['files', logdonePath, 'headers']), doneId)
@@ -1241,10 +1251,11 @@ describe('org reducer', () => {
 
       it('does not add CLOSED when logdone is not enabled', () => {
         const oldHeaders = state.org.present.getIn(['files', path, 'headers']);
-        const newHeaders = reducer(
-          state.org.present,
-          advanceWithTimestamp(todoHeaderId)
-        ).getIn(['files', path, 'headers']);
+        const newHeaders = reducer(state.org.present, advanceWithTimestamp(todoHeaderId)).getIn([
+          'files',
+          path,
+          'headers',
+        ]);
 
         expect(headerWithId(newHeaders, todoHeaderId).getIn(['titleLine', 'todoKeyword'])).toEqual(
           'DONE'
@@ -1261,7 +1272,10 @@ describe('org reducer', () => {
 
       it('adds CLOSED via setTodoState when completing a TODO', () => {
         const logdoneState = setUpStateForFile(logdonePath, readFixture('todo_with_logdone'));
-        const todoId = logdoneState.org.present.getIn(['files', logdonePath, 'headers']).get(0).get('id');
+        const todoId = logdoneState.org.present
+          .getIn(['files', logdonePath, 'headers'])
+          .get(0)
+          .get('id');
 
         const newHeaders = reducer(
           logdoneState.org.present,

--- a/test_helpers/fixtures/todo_with_logdone.org
+++ b/test_helpers/fixtures/todo_with_logdone.org
@@ -1,0 +1,7 @@
+#+STARTUP: logdone
+
+* TODO Incomplete task
+* DONE Already done
+  CLOSED: [2020-01-01 Wed 12:00]
+* TODO Scheduled task
+  SCHEDULED: <2020-01-02 Thu>

--- a/test_helpers/fixtures/todo_with_logdone_and_other_options.org
+++ b/test_helpers/fixtures/todo_with_logdone_and_other_options.org
@@ -1,0 +1,3 @@
+#+STARTUP: overview logdone indent
+
+* TODO Incomplete task

--- a/test_helpers/fixtures/todo_with_logdone_property.org
+++ b/test_helpers/fixtures/todo_with_logdone_property.org
@@ -1,0 +1,12 @@
+* Parent with logging
+  :PROPERTIES:
+  :LOGGING:  logdone
+  :END:
+** TODO Child should log
+* Sibling without logging
+** TODO Child should not log
+* Explicitly disabled
+  :PROPERTIES:
+  :LOGGING:  nologdone
+  :END:
+** TODO Child disabled

--- a/test_helpers/fixtures/todo_with_nologdone.org
+++ b/test_helpers/fixtures/todo_with_nologdone.org
@@ -1,0 +1,3 @@
+#+STARTUP: nologdone
+
+* TODO Incomplete task


### PR DESCRIPTION
## Summary
- Honor `#+STARTUP: logdone` / `:LOGGING: logdone` when completing TODOs by writing a `CLOSED:` planning timestamp (and remove it when leaving a done state)
- Fixes #980 by matching Emacs `org-log-done` / `time` behavior for non-repeating tasks
- Document the new in-buffer options in `README.org`

## Verification
Reproduced the reporter's exact fixture from #980:

```org
#+STARTUP: logdone
* TODO clean up here in prep for going to alno
```

After advancing TODO → DONE, export contains:

```org
* DONE clean up here in prep for going to alno
  CLOSED: [2024-04-17 Wed 15:03]
```

Unit tests cover STARTUP/property detection, CLOSED add/remove, SCHEDULED preservation, and the no-logdone default.

## Test plan
- [x] `yarn test --testPathPattern='(org\.unit\.test|OrgFile\.unit\.test)'`
- [x] Reproduce #980 fixture and confirm `CLOSED:` is written on completion
- [ ] Manually toggle TODO → DONE in the UI with `#+STARTUP: logdone`
- [ ] Confirm `nologdone` and missing `logdone` do not write `CLOSED:`
- [ ] Confirm un-completing a DONE header removes `CLOSED:`